### PR TITLE
fix(search): improve food results and serving unit sync

### DIFF
--- a/backend/src/services/openfoodfacts-api-client.ts
+++ b/backend/src/services/openfoodfacts-api-client.ts
@@ -8,6 +8,7 @@ const USER_AGENT = "MacroTracker/1.0 (contact@example.com)";
 
 // Configuration constants
 const MAX_RESULTS = 10;
+const MAX_CANDIDATE_RESULTS = 50;
 const REQUEST_TIMEOUT = 10000; // 10 seconds
 const MAX_RETRIES = 2;
 const MIN_QUERY_LENGTH = 2;
@@ -58,6 +59,9 @@ export interface QuantityParseResult {
   quantity: number;
   unit: string;
 }
+
+const COUNT_BASED_QUANTITY_PATTERN =
+  /([\d.,]+)\s*(egg|eggs|piece|pieces|pc|pcs|serving|servings|item|items)\b/;
 
 // Custom error classes for better error handling
 export class OpenFoodFactsError extends Error {
@@ -177,12 +181,33 @@ export function parseQuantity(quantityString: string): QuantityParseResult {
 
         const rawUnit = match[2] ?? "";
         const normalizedUnit = unitMap[rawUnit] ?? rawUnit;
+
+        if (normalizedUnit === "fl oz") {
+          return {
+            quantity: Math.round(quantity * 29.5735 * 100) / 100,
+            unit: "ml",
+          };
+        }
+
         return {
           quantity,
           unit: normalizedUnit === "" ? "g" : normalizedUnit,
         };
       }
     }
+  }
+
+  const countBasedMatch = cleanedString.match(COUNT_BASED_QUANTITY_PATTERN);
+  if (countBasedMatch?.[1]) {
+    const quantityStr = countBasedMatch[1].replace(",", ".");
+    const quantity = parseFloat(quantityStr);
+    if (!isNaN(quantity) && quantity > 0) {
+      return { quantity, unit: "unit" };
+    }
+  }
+
+  if (/\b(egg|eggs|piece|pieces|pc|pcs|serving|servings|item|items)\b/.test(cleanedString)) {
+    return { quantity: 1, unit: "unit" };
   }
 
   // Fallback for unrecognized formats
@@ -226,30 +251,180 @@ function getFoodSearchTokens(normalizedQuery: string): string[] {
   return normalizedQuery.split(" ").filter(Boolean);
 }
 
+function isSingleTokenExactFoodNameMatch(
+  normalizedName: string,
+  normalizedQuery: string,
+): boolean {
+  const queryTokens = getFoodSearchTokens(normalizedQuery);
+  if (queryTokens.length !== 1) {
+    return false;
+  }
+
+  const queryToken = queryTokens[0] ?? "";
+  if (!queryToken) {
+    return false;
+  }
+
+  const nameWords = getNormalizedFoodWords(normalizedName);
+  if (nameWords.length !== 1) {
+    return false;
+  }
+
+  const nameWord = nameWords[0] ?? "";
+  return isFoodSearchTokenMatch(queryToken, nameWord);
+}
+
+function getNormalizedFoodWords(value: string): string[] {
+  return normalizeFoodSearchQuery(value).split(/[^a-z0-9]+/).filter(Boolean);
+}
+
+function getFoodSearchTokenStem(token: string): string {
+  if (token.length > 3 && token.endsWith("es")) {
+    return token.slice(0, -2);
+  }
+
+  if (token.length > 3 && token.endsWith("s")) {
+    return token.slice(0, -1);
+  }
+
+  return token;
+}
+
+function getFoodWordStem(word: string): string {
+  if (word.length > 3 && word.endsWith("es")) {
+    return word.slice(0, -2);
+  }
+
+  if (word.length > 3 && word.endsWith("s")) {
+    return word.slice(0, -1);
+  }
+
+  return word;
+}
+
+function isFoodSearchTokenMatch(token: string, word: string): boolean {
+  if (!token || !word) {
+    return false;
+  }
+
+  if (word === token) {
+    return true;
+  }
+
+  const tokenStem = getFoodSearchTokenStem(token);
+  const wordStem = getFoodWordStem(word);
+  if (tokenStem === wordStem) {
+    return true;
+  }
+
+  if (token.length <= 3 && word.startsWith(token)) {
+    return true;
+  }
+
+  if (tokenStem.length <= 3 && word.startsWith(tokenStem)) {
+    return true;
+  }
+
+  return false;
+}
+
+function getNameTokenMatchCount(name: string, tokens: string[]): number {
+  if (tokens.length === 0) {
+    return 0;
+  }
+
+  const normalizedWords = getNormalizedFoodWords(name);
+  return tokens.filter((token) =>
+    normalizedWords.some((word) => isFoodSearchTokenMatch(token, word)),
+  ).length;
+}
+
+function hasStrongFoodNameMatch(
+  hit: FoodSearchHit,
+  normalizedQuery: string,
+): boolean {
+  const tokens = getFoodSearchTokens(normalizedQuery);
+  if (tokens.length === 0) {
+    return false;
+  }
+
+  const normalizedName = normalizeFoodSearchQuery(getFoodProductDisplayName(hit));
+  if (!normalizedName) {
+    return false;
+  }
+
+  if (normalizedName.includes(normalizedQuery)) {
+    return true;
+  }
+
+  const normalizedWords = getNormalizedFoodWords(normalizedName);
+  if (
+    tokens.length === 1 &&
+    normalizedWords.some((word) =>
+      isFoodSearchTokenMatch(tokens[0] ?? "", word),
+    )
+  ) {
+    return true;
+  }
+
+  const matchedTokens = getNameTokenMatchCount(normalizedName, tokens);
+  if (tokens.length === 1) {
+    return matchedTokens === 1;
+  }
+
+  return matchedTokens >= Math.max(1, tokens.length - 1);
+}
+
 function getFoodSearchScore(hit: FoodSearchHit, normalizedQuery: string): number {
   const tokens = getFoodSearchTokens(normalizedQuery);
   const name = normalizeFoodSearchQuery(getFoodProductDisplayName(hit));
+  const nameWords = getNormalizedFoodWords(name);
   const categories = normalizeFoodSearchQuery(hit.categories ?? "");
   const rawQuantity = normalizeFoodSearchQuery(hit.quantity ?? "");
+  const tokenStems = new Set(tokens.map((token) => getFoodSearchTokenStem(token)));
+  const categoryWords = getNormalizedFoodWords(categories);
+  const hasCategorySameAsQuery = categoryWords.some((word) =>
+    tokenStems.has(getFoodWordStem(word)),
+  );
 
   let score = 0;
 
   if (name === normalizedQuery) {
+    score += 180;
+  } else if (name.startsWith(`${normalizedQuery} `) || name.startsWith(normalizedQuery)) {
     score += 120;
-  } else if (name.startsWith(normalizedQuery)) {
-    score += 80;
   } else if (name.includes(normalizedQuery)) {
-    score += 45;
+    score += 80;
   }
 
-  const matchedNameTokens = tokens.filter((token) => name.includes(token)).length;
+  const matchedNameTokens = getNameTokenMatchCount(name, tokens);
   const matchedCategoryTokens = tokens.filter((token) => categories.includes(token)).length;
 
-  score += matchedNameTokens * 14;
-  score += matchedCategoryTokens * 4;
+  score += matchedNameTokens * 28;
+  score += matchedCategoryTokens;
 
   if (tokens.length > 0 && matchedNameTokens === tokens.length) {
-    score += 18;
+    score += 24;
+  }
+
+  if (tokens.length === 1) {
+    if (nameWords.length <= 3) {
+      score += 12;
+    } else if (nameWords.length <= 5) {
+      score += 6;
+    }
+
+    if (nameWords.length > 1) {
+      score -= 8;
+    }
+
+    if (hasCategorySameAsQuery) {
+      score += 12;
+    }
+  }
+
+  if (name.length > 70) {
+    score -= 8;
   }
 
   if (rawQuantity) {
@@ -273,13 +448,26 @@ function getFoodSearchScore(hit: FoodSearchHit, normalizedQuery: string): number
   return score;
 }
 
-function getFoodProductDeduplicationKey(result: FoodProductResult): string {
+function getFoodProductDeduplicationKey(
+  result: FoodProductResult,
+  normalizedQuery: string,
+): string {
+  const normalizedName = normalizeFoodSearchQuery(result.name);
+
+  if (isSingleTokenExactFoodNameMatch(normalizedName, normalizedQuery)) {
+    const normalizedWord = getNormalizedFoodWords(normalizedName)[0] ?? normalizedName;
+    const stemmedWord = getFoodWordStem(normalizedWord);
+
+    return `exact:${stemmedWord}`;
+  }
+
   return [
-    normalizeFoodSearchQuery(result.name),
-    result.rawQuantity ?? "",
+    "detailed",
+    normalizedName,
     result.protein.toFixed(1),
     result.carbs.toFixed(1),
     result.fats.toFixed(1),
+    result.energyKcal.toFixed(1),
   ].join("|");
 }
 
@@ -290,8 +478,13 @@ export function rankAndNormalizeFoodProducts(
   const normalizedQuery = normalizeFoodSearchQuery(query);
   const uniqueResults = new Map<string, FoodProductResult>();
 
-  const rankedHits = hits
-    .filter(isValidFoodProduct)
+  const validHits = hits.filter(isValidFoodProduct);
+  const stronglyMatchedHits = validHits.filter((hit) =>
+    hasStrongFoodNameMatch(hit, normalizedQuery),
+  );
+  const hitsToRank = stronglyMatchedHits.length > 0 ? stronglyMatchedHits : validHits;
+
+  const rankedHits = hitsToRank
     .map((hit) => ({
       hit,
       score: getFoodSearchScore(hit, normalizedQuery),
@@ -304,7 +497,7 @@ export function rankAndNormalizeFoodProducts(
       continue;
     }
 
-    const dedupeKey = getFoodProductDeduplicationKey(mapped);
+    const dedupeKey = getFoodProductDeduplicationKey(mapped, normalizedQuery);
     if (!uniqueResults.has(dedupeKey)) {
       uniqueResults.set(dedupeKey, mapped);
     }
@@ -359,7 +552,7 @@ export class OpenFoodFactsApiClient {
 
     const url = `${API_URL}?q=${encodeURIComponent(
       trimmedQuery
-    )}&lc=en&search_simple=1&fields=product_name,product_name_en,nutriments,categories,quantity`;
+    )}&lc=en&search_simple=1&page_size=${MAX_CANDIDATE_RESULTS}&fields=product_name,product_name_en,nutriments,categories,quantity`;
 
     logger.debug({ url, query: trimmedQuery }, "Requesting URL from search-a-licious API");
 

--- a/backend/tests/lib/openfoodfacts-api-client.test.ts
+++ b/backend/tests/lib/openfoodfacts-api-client.test.ts
@@ -56,6 +56,159 @@ describe("openfoodfacts-api-client", () => {
       expect(typeof parseQuantity).toBe("function");
       expect(parseQuantity("100g").quantity).toBe(100);
     });
+
+    it("parses fl oz quantities to ml", async () => {
+      const { parseQuantity } = await import("../../src/services/openfoodfacts-api-client");
+
+      expect(parseQuantity("12 fl oz")).toEqual({
+        quantity: 354.88,
+        unit: "ml",
+      });
+    });
+
+    it("parses count-based quantities as unit servings", async () => {
+      const { parseQuantity } = await import("../../src/services/openfoodfacts-api-client");
+
+      expect(parseQuantity("6 eggs")).toEqual({
+        quantity: 6,
+        unit: "unit",
+      });
+      expect(parseQuantity("Eggs")).toEqual({
+        quantity: 1,
+        unit: "unit",
+      });
+    });
+
+    it("ranks simple whole-food matches above noisy branded products", async () => {
+      const { rankAndNormalizeFoodProducts } = await import(
+        "../../src/services/openfoodfacts-api-client"
+      );
+
+      const hits = [
+        {
+          product_name: "Chicken curry flavour instant noodles",
+          categories: "Meals, Instant noodles",
+          quantity: "85 g",
+          nutriments: {
+            proteins_100g: 8,
+            carbohydrates_100g: 64,
+            fat_100g: 18,
+            "energy-kcal_100g": 460,
+          },
+        },
+        {
+          product_name: "Chicken",
+          categories: "Meats, Chicken",
+          quantity: "500 g",
+          nutriments: {
+            proteins_100g: 23,
+            carbohydrates_100g: 0,
+            fat_100g: 2,
+            "energy-kcal_100g": 120,
+          },
+        },
+      ];
+
+      const results = rankAndNormalizeFoodProducts(hits, "chicken");
+
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]?.name.toLowerCase()).toBe("chicken");
+    });
+
+    it("deduplicates repeated generic egg entries with the same nutrition", async () => {
+      const { rankAndNormalizeFoodProducts } = await import(
+        "../../src/services/openfoodfacts-api-client"
+      );
+
+      const hits = [
+        {
+          product_name: "Eggs",
+          categories: "Eggs",
+          quantity: "6 eggs",
+          nutriments: {
+            proteins_100g: 12.6,
+            carbohydrates_100g: 0.2,
+            fat_100g: 9,
+            "energy-kcal_100g": 132,
+          },
+        },
+        {
+          product_name: "Eggs",
+          categories: "Eggs",
+          quantity: "12 eggs",
+          nutriments: {
+            proteins_100g: 12.6,
+            carbohydrates_100g: 0.2,
+            fat_100g: 9,
+            "energy-kcal_100g": 132,
+          },
+        },
+        {
+          product_name: "Eggs from caged hens",
+          categories: "Eggs",
+          quantity: "805 g",
+          nutriments: {
+            proteins_100g: 12.6,
+            carbohydrates_100g: 0.1,
+            fat_100g: 9,
+            "energy-kcal_100g": 131,
+          },
+        },
+      ];
+
+      const results = rankAndNormalizeFoodProducts(hits, "eggs");
+      const exactEggs = results.filter((result) => result.name.toLowerCase() === "eggs");
+
+      expect(exactEggs).toHaveLength(1);
+    });
+
+    it("collapses exact singular food names for single-token queries", async () => {
+      const { rankAndNormalizeFoodProducts } = await import(
+        "../../src/services/openfoodfacts-api-client"
+      );
+
+      const hits = [
+        {
+          product_name: "Eggs",
+          categories: "Eggs",
+          quantity: "6 eggs",
+          nutriments: {
+            proteins_100g: 12.6,
+            carbohydrates_100g: 0.2,
+            fat_100g: 9,
+            "energy-kcal_100g": 132,
+          },
+        },
+        {
+          product_name: "Eggs",
+          categories: "Eggs",
+          quantity: "15 eggs",
+          nutriments: {
+            proteins_100g: 13,
+            carbohydrates_100g: 0.5,
+            fat_100g: 9,
+            "energy-kcal_100g": 131,
+          },
+        },
+        {
+          product_name: "Eggs large",
+          categories: "Eggs",
+          quantity: "12 eggs",
+          nutriments: {
+            proteins_100g: 12.5,
+            carbohydrates_100g: 0,
+            fat_100g: 9,
+            "energy-kcal_100g": 130,
+          },
+        },
+      ];
+
+      const results = rankAndNormalizeFoodProducts(hits, "eggs");
+      const exactEggs = results.filter((result) => result.name.toLowerCase() === "eggs");
+
+      expect(exactEggs).toHaveLength(1);
+      expect(results.length).toBe(2);
+    });
   });
 
   describe("error classes", () => {

--- a/frontend/src/features/macroTracking/components/AddEntryForm.test.tsx
+++ b/frontend/src/features/macroTracking/components/AddEntryForm.test.tsx
@@ -1,11 +1,46 @@
-import { render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 
 import AddEntryForm from "./AddEntryForm";
 
+vi.mock("@/features/macroTracking/components/CalorieSearchForm", () => ({
+  default: ({ onResult }: { onResult: (value: unknown) => void }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onResult({
+          protein: "12.6",
+          carbs: "0.2",
+          fats: "9",
+          name: "Eggs",
+          servingQuantity: 100,
+          servingUnit: "g",
+          rawQuantity: "6 eggs",
+        })
+      }
+    >
+      Select mocked food
+    </button>
+  ),
+}));
+
 describe("AddEntryForm", () => {
   it("renders without crashing", () => {
-    const { container } = render(<AddEntryForm />);
+    const { container } = render(
+      <AddEntryForm onSubmit={async () => {}} isSaving={false} />,
+    );
     expect(container).toBeDefined();
+  });
+
+  it("uses parsed serving units from selected food search results", () => {
+    render(<AddEntryForm onSubmit={async () => {}} isSaving={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Select mocked food" }));
+
+    const quantityInput = screen.getByPlaceholderText("100") as HTMLInputElement;
+    const unitSelect = screen.getByDisplayValue("pcs") as HTMLSelectElement;
+
+    expect(quantityInput.value).toBe("6");
+    expect(unitSelect.value).toBe("unit");
   });
 });

--- a/frontend/src/features/macroTracking/components/AddEntryForm.tsx
+++ b/frontend/src/features/macroTracking/components/AddEntryForm.tsx
@@ -133,6 +133,7 @@ function AddEntry({ onSubmit, isSaving: _isSaving }: AddEntryProps) {
       name,
       servingQuantity,
       servingUnit,
+      rawQuantity,
     }: {
       protein: string;
       carbs: string;
@@ -140,6 +141,7 @@ function AddEntry({ onSubmit, isSaving: _isSaving }: AddEntryProps) {
       name: string;
       servingQuantity: number;
       servingUnit: string;
+      rawQuantity?: string;
     }) => {
       const per100g = {
         protein: Number.parseFloat(p),
@@ -150,6 +152,15 @@ function AddEntry({ onSubmit, isSaving: _isSaving }: AddEntryProps) {
       setBaseIngredients(undefined);
       setMealName(name);
       setQuantity(servingQuantity);
+
+      if (rawQuantity) {
+        const parsed = UnitConverter.parseQuantity(rawQuantity);
+        setUnit(parsed.unit);
+        setQuantity(parsed.quantity);
+        setSearchResult(name);
+
+        return;
+      }
 
       let displayUnit = servingUnit as UnitType;
 
@@ -326,6 +337,7 @@ function AddEntry({ onSubmit, isSaving: _isSaving }: AddEntryProps) {
       onSubmit,
       isFormValid,
       handleClearSearch,
+      baseMacros,
       baseIngredients,
       quantity,
       unit,

--- a/frontend/src/features/macroTracking/components/CalorieSearchForm.tsx
+++ b/frontend/src/features/macroTracking/components/CalorieSearchForm.tsx
@@ -25,6 +25,7 @@ interface CalorieSearchProps {
     name: string;
     servingQuantity: number;
     servingUnit: string;
+    rawQuantity?: string;
   }) => void;
   onSelectSavedMeal: (meal: {
     name: string;
@@ -124,85 +125,37 @@ const CalorieSearch = memo(function CalorieSearch({
   }, []);
 
   const processFoodItemSelection = useCallback((item: FoodSearchResult) => {
-    let quantity = item.servingQuantity;
-    let unit = item.servingUnit;
+    const defaultUnit = item.servingUnit as UnitType;
+    const parsedQuantity = item.rawQuantity
+      ? UnitConverter.parseQuantity(item.rawQuantity)
+      : {
+          quantity: item.servingQuantity,
+          unit: defaultUnit,
+          original: "",
+        };
 
-    if (item.rawQuantity) {
-      const raw = item.rawQuantity.toLowerCase().trim();
+    const parsedUnit = parsedQuantity.unit as UnitType;
+    const hasSupportedUnit = [
+      "g",
+      "kg",
+      "oz",
+      "lb",
+      "ml",
+      "L",
+      "cup",
+      "tbsp",
+      "tsp",
+      "pt",
+      "unit",
+    ].includes(parsedUnit);
 
-      const patterns = [
-        /([\d,.]+)\s*(ml|milliliter|milliliters|l|liter|liters|fl\s*oz|cup|cups|tbsp|tablespoon|tablespoons|tsp|teaspoon|teaspoons|pt|pint|pints)/,
-        /([\d,.]+)\s*(g|gram|grams|kg|kilogram|kilograms|oz|ounce|ounces|lb|lbs|pound|pounds)/,
-      ];
+    const quantity = parsedQuantity.quantity;
+    const unit = hasSupportedUnit ? parsedUnit : defaultUnit;
 
-      for (const pattern of patterns) {
-        const match = raw.match(pattern);
-        if (match?.[1] && match[2]) {
-          quantity = Number.parseFloat(match[1].replace(",", "."));
-          const rawUnit = match[2];
-
-          const unitMap: Record<string, UnitType> = {
-            ml: "ml",
-            milliliter: "ml",
-            milliliters: "ml",
-            l: "L",
-            liter: "L",
-            liters: "L",
-            fl: "ml", // fl oz will be handled separately
-            oz: "ml", // fl oz will be handled separately
-            cup: "cup",
-            cups: "cup",
-            tbsp: "tbsp",
-            tablespoon: "tbsp",
-            tablespoons: "tbsp",
-            tsp: "tsp",
-            teaspoon: "tsp",
-            teaspoons: "tsp",
-            pt: "pt",
-            pint: "pt",
-            pints: "pt",
-            g: "g",
-            gram: "g",
-            grams: "g",
-            kg: "kg",
-            kilogram: "kg",
-            kilograms: "kg",
-            lb: "lb",
-            lbs: "lb",
-            pound: "lb",
-            pounds: "lb",
-          };
-
-          if (raw.includes("fl") && raw.includes("oz")) {
-            unit = "ml";
-            quantity = quantity * 29.5735;
-          } else {
-            unit = unitMap[rawUnit] || "g";
-          }
-
-          break;
-        }
-      }
-    }
-
-    if (unit === "g" && item.rawQuantity) {
-      const raw = item.rawQuantity.toLowerCase();
-      if (raw.includes("ml") || raw.includes("milliliter")) {
-        unit = "ml";
-      } else if (raw.includes("l") || raw.includes("liter")) {
-        unit = "L";
-      } else if (raw.includes("cup")) {
-        unit = "cup";
-      } else if (raw.includes("tbsp") || raw.includes("tablespoon")) {
-        unit = "tbsp";
-      } else if (raw.includes("tsp") || raw.includes("teaspoon")) {
-        unit = "tsp";
-      } else if (raw.includes("pt") || raw.includes("pint")) {
-        unit = "pt";
-      }
-    }
-
-    const metric = UnitConverter.toMetric(quantity, unit as UnitType);
+    const metric =
+      unit === "unit"
+        ? { quantity, unit }
+        : UnitConverter.toMetric(quantity, unit);
 
     return {
       protein: item.protein.toFixed(1),
@@ -211,6 +164,7 @@ const CalorieSearch = memo(function CalorieSearch({
       name: item.name,
       servingQuantity: metric.quantity,
       servingUnit: unit,
+      rawQuantity: item.rawQuantity,
     };
   }, []);
 

--- a/frontend/src/features/macroTracking/utils/units.test.ts
+++ b/frontend/src/features/macroTracking/utils/units.test.ts
@@ -114,6 +114,34 @@ describe("units", () => {
           original: "totally unknown input",
         });
       });
+
+      it("parses food counts as unit servings", () => {
+        expect(UnitConverter.parseQuantity("6 eggs")).toEqual({
+          quantity: 6,
+          unit: "unit",
+          original: "6 eggs",
+        });
+
+        expect(UnitConverter.parseQuantity("Eggs")).toEqual({
+          quantity: 1,
+          unit: "unit",
+          original: "Eggs",
+        });
+
+        expect(UnitConverter.parseQuantity("3 pieces")).toEqual({
+          quantity: 3,
+          unit: "unit",
+          original: "3 pieces",
+        });
+      });
+
+      it("parses fl oz volumes into metric milliliters", () => {
+        expect(UnitConverter.parseQuantity("12 fl oz")).toEqual({
+          quantity: 354.88,
+          unit: "ml",
+          original: "12 fl oz",
+        });
+      });
     });
 
     describe("convert", () => {

--- a/frontend/src/features/macroTracking/utils/units.ts
+++ b/frontend/src/features/macroTracking/utils/units.ts
@@ -45,6 +45,16 @@ const US_CUP_WEIGHTS: Record<string, number> = {
   fruits: 160,
 };
 
+const COUNT_BASED_QUANTITY_PATTERN =
+  /^([\d,.]+)\s*(egg|eggs|piece|pieces|pc|pcs|serving|servings|item|items)\b/;
+const COUNT_ONLY_WORD_PATTERN =
+  /\b(egg|eggs|piece|pieces|pc|pcs|serving|servings|item|items)\b/;
+
+const MEASUREMENT_PATTERN =
+  /([\d,.]+)\s*(fl\s*oz|g|gram|grams|kg|kilogram|kilograms|oz|ounce|ounces|lb|lbs|pound|pounds|ml|milliliter|milliliters|l|liter|liters|cup|cups|tbsp|tablespoon|tablespoons|tsp|teaspoon|teaspoons|pt|pint|pints)\b/;
+const CUP_WITH_INGREDIENT_PATTERN =
+  /([\d,.]+)\s*(cup|cups)\s+([a-z]+)/;
+
 export const UnitConverter = {
   parseQuantity(input: string): ParsedQuantity {
     if (!input || typeof input !== "string") {
@@ -60,71 +70,82 @@ export const UnitConverter = {
       return { quantity: 1, unit: "unit", original: input };
     }
 
-    const patterns = [
-      /^([\d,.]+)\s*(g|gram|grams|kg|kilogram|kilograms|oz|ounce|ounces|lb|lbs|pound|pounds|ml|milliliter|milliliters|l|liter|liters|cup|cups|tbsp|tablespoon|tablespoons|tsp|teaspoon|teaspoons|pt|pint|pints)?(?:\s+(.+))?$/,
-      /^([\d,.]+)\s*(cup|cups|tbsp|tablespoon|tablespoons|tsp|teaspoon|teaspoons|pt|pint|pints)(?:\s+(.+))?$/,
-    ];
+    const countBasedMatch = trimmed.match(COUNT_BASED_QUANTITY_PATTERN);
+    if (countBasedMatch?.[1]) {
+      const count = Number.parseFloat(countBasedMatch[1].replace(",", "."));
+      if (!Number.isNaN(count) && count > 0) {
+        return { quantity: count, unit: "unit", original: input };
+      }
+    }
 
-    for (const pattern of patterns) {
-      const match = trimmed.match(pattern);
-      if (match && match[1]) {
-        const quantityString = match[1].replace(",", ".");
-        const quantity = Number.parseFloat(quantityString);
+    if (COUNT_ONLY_WORD_PATTERN.test(trimmed)) {
+      return { quantity: 1, unit: "unit", original: input };
+    }
 
-        if (Number.isNaN(quantity) || quantity <= 0) {
-          continue;
-        }
+    const cupIngredientMatch = trimmed.match(CUP_WITH_INGREDIENT_PATTERN);
+    if (cupIngredientMatch?.[1] && cupIngredientMatch[3]) {
+      const quantity = Number.parseFloat(cupIngredientMatch[1].replace(",", "."));
+      const ingredient = cupIngredientMatch[3].toLowerCase().trim();
 
-        let unit: UnitType = "g";
-        const unitMatch = match[2];
+      if (!Number.isNaN(quantity) && quantity > 0 && US_CUP_WEIGHTS[ingredient]) {
+        const weightInGrams = quantity * US_CUP_WEIGHTS[ingredient];
 
-        if (unitMatch) {
-          const unitMap: Record<string, UnitType> = {
-            g: "g",
-            gram: "g",
-            grams: "g",
-            kg: "kg",
-            kilogram: "kg",
-            kilograms: "kg",
-            oz: "oz",
-            ounce: "oz",
-            ounces: "oz",
-            lb: "lb",
-            lbs: "lb",
-            pound: "lb",
-            pounds: "lb",
-            ml: "ml",
-            milliliter: "ml",
-            milliliters: "ml",
-            l: "L",
-            liter: "L",
-            liters: "L",
-            cup: "cup",
-            cups: "cup",
-            tbsp: "tbsp",
-            tablespoon: "tbsp",
-            tablespoons: "tbsp",
-            tsp: "tsp",
-            teaspoon: "tsp",
-            teaspoons: "tsp",
-            pt: "pt",
-            pint: "pt",
-            pints: "pt",
-          };
+        return {
+          quantity: Math.round(weightInGrams * 100) / 100,
+          unit: "g",
+          original: input,
+        };
+      }
+    }
 
-          unit = unitMap[unitMatch];
-        }
+    const measurementMatch = trimmed.match(MEASUREMENT_PATTERN);
+    if (measurementMatch?.[1] && measurementMatch[2]) {
+      const quantity = Number.parseFloat(measurementMatch[1].replace(",", "."));
+      if (!Number.isNaN(quantity) && quantity > 0) {
+        const rawUnit = measurementMatch[2].replaceAll(/\s+/g, " ").trim();
+        const unitMap: Record<string, UnitType> = {
+          g: "g",
+          gram: "g",
+          grams: "g",
+          kg: "kg",
+          kilogram: "kg",
+          kilograms: "kg",
+          oz: "oz",
+          ounce: "oz",
+          ounces: "oz",
+          lb: "lb",
+          lbs: "lb",
+          pound: "lb",
+          pounds: "lb",
+          ml: "ml",
+          milliliter: "ml",
+          milliliters: "ml",
+          l: "L",
+          liter: "L",
+          liters: "L",
+          cup: "cup",
+          cups: "cup",
+          tbsp: "tbsp",
+          tablespoon: "tbsp",
+          tablespoons: "tbsp",
+          tsp: "tsp",
+          teaspoon: "tsp",
+          teaspoons: "tsp",
+          pt: "pt",
+          pint: "pt",
+          pints: "pt",
+          "fl oz": "ml",
+        };
 
-        const ingredient = match[3]?.toLowerCase().trim();
-        if (unit === "cup" && ingredient && US_CUP_WEIGHTS[ingredient]) {
-          const weightInGrams = quantity * US_CUP_WEIGHTS[ingredient];
-
+        if (rawUnit === "fl oz") {
           return {
-            quantity: Math.round(weightInGrams * 100) / 100,
-            unit: "g",
+            quantity: Math.round(quantity * 29.5735 * 100) / 100,
+            unit: "ml",
             original: input,
           };
         }
+
+        const unit = unitMap[rawUnit] ?? "g";
 
         return { quantity, unit, original: input };
       }

--- a/frontend/src/hooks/queries/useFoodSearch.test.tsx
+++ b/frontend/src/hooks/queries/useFoodSearch.test.tsx
@@ -1,0 +1,68 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { macrosApi } from "@/api/macros";
+
+import { useFoodSearch } from "./useFoodSearch";
+
+vi.mock("@/api/macros", () => ({
+  macrosApi: {
+    search: vi.fn(),
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  };
+}
+
+describe("useFoodSearch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls macrosApi.search with the expected payload", async () => {
+    (macrosApi.search as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        name: "Chicken Breast",
+        protein: 31,
+        carbs: 0,
+        fats: 3.6,
+        energyKcal: 165,
+        categories: "Meat",
+        servingQuantity: 100,
+        servingUnit: "g",
+      },
+    ]);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFoodSearch("chicken"), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(macrosApi.search).toHaveBeenCalledWith({ query: "chicken" });
+  });
+
+  it("does not call macrosApi.search for short queries", async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFoodSearch("a"), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(true);
+    });
+
+    expect(macrosApi.search).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/queries/useFoodSearch.ts
+++ b/frontend/src/hooks/queries/useFoodSearch.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { type FoodSearchResult,macrosApi } from "@/api/macros";
+import { type FoodSearchResult, macrosApi } from "@/api/macros";
 import { queryKeys } from "@/lib/queryKeys";
 
 export function useFoodSearch(query?: string) {
@@ -9,7 +9,7 @@ export function useFoodSearch(query?: string) {
   return useQuery({
     queryKey: queryKeys.macros.search(normalizedQuery),
     queryFn: async (): Promise<FoodSearchResult[]> => {
-      return macrosApi.search(normalizedQuery);
+      return macrosApi.search({ query: normalizedQuery });
     },
     enabled: normalizedQuery.length >= 2,
     staleTime: 5 * 60 * 1000,


### PR DESCRIPTION
## Summary
- improve OpenFoodFacts ranking and deduplication so simple queries like `eggs` and `chicken` surface cleaner, less noisy results
- parse count-based and `fl oz` quantities consistently and propagate `rawQuantity` through selection so add-entry quantity/unit reflects the chosen food
- add backend and frontend regression tests for ranking, deduplication, quantity parsing, and food search request payload shape

## Testing
- `cd backend && bunx vitest run tests/lib/openfoodfacts-api-client.test.ts`
- `cd backend && bun run typecheck`
- `cd frontend && bunx vitest run src/features/macroTracking/utils/units.test.ts src/features/macroTracking/components/AddEntryForm.test.tsx src/hooks/queries/useFoodSearch.test.tsx src/api/macros.test.ts`
- `cd frontend && bun run typecheck`