### PR TITLE
fix: add noscript legal links for trust & safety crawlers

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -65,6 +65,11 @@
     <title>MacroTrackr</title>
   </head>
   <body>
+    <noscript>
+      MacroTrackr requires JavaScript to run. Please enable JavaScript to use the app.
+      <br />
+      <a href="/privacy">Privacy Policy</a> | <a href="/terms">Terms of Service</a>
+    </noscript>
     <div id="root"></div>
     <div id="modal-root"></div>
     <!-- Add this div for portals -->

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -2,37 +2,37 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://macrotrackr.com/</loc>
-    <lastmod>2026-05-01</lastmod>
+    <lastmod>2026-05-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/login</loc>
-    <lastmod>2026-05-01</lastmod>
+    <lastmod>2026-05-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/register</loc>
-    <lastmod>2026-05-01</lastmod>
+    <lastmod>2026-05-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/reset-password</loc>
-    <lastmod>2026-05-01</lastmod>
+    <lastmod>2026-05-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/privacy</loc>
-    <lastmod>2026-05-01</lastmod>
+    <lastmod>2026-05-06</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/terms</loc>
-    <lastmod>2026-05-01</lastmod>
+    <lastmod>2026-05-06</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>
   </url>


### PR DESCRIPTION
## Summary
- Added a `<noscript>` tag to `frontend/index.html` containing links to the Privacy Policy and Terms of Service.
- Resolves an issue where automated crawlers (that do not execute JavaScript) fail to locate required legal links on the homepage.
- Verified that modern browsers correctly ignore the tag while still rendering the app, and the build passes all checks.