### PR TITLE
fix(backend): resolve flaky numeric id generator test by preventing collisions

### DIFF
--- a/backend/src/utils/id-generator.ts
+++ b/backend/src/utils/id-generator.ts
@@ -8,8 +8,16 @@ export function generateUUID(): string {
   return crypto.randomUUID();
 }
 
+let lastTimestamp = 0;
+let counter = 0;
+
 export function generateNumericId(): number {
   const timestamp = Date.now();
-  const random = Math.floor(Math.random() * 1000);
-  return parseInt(`${timestamp}${random.toString().padStart(3, "0")}`);
+  if (timestamp === lastTimestamp) {
+    counter = (counter + 1) % 1000;
+  } else {
+    lastTimestamp = timestamp;
+    counter = Math.floor(Math.random() * 1000);
+  }
+  return parseInt(`${timestamp}${counter.toString().padStart(3, "0")}`);
 }


### PR DESCRIPTION
## Summary
- The `generateNumericId` test in `backend/tests/utils/id-generator.test.ts` occasionally failed because it relied on `Math.random() * 1000` inside a loop, causing birthday-paradox collisions when selecting 100 random values.
- Updated `generateNumericId` in `backend/src/utils/id-generator.ts` to use a localized counter within the same millisecond timestamp. This guarantees collision-free numeric IDs.