### PR TITLE
fix(billing): correct Stripe portal request payload format

### DIFF
--- a/frontend/src/features/settings/components/BillingForm.tsx
+++ b/frontend/src/features/settings/components/BillingForm.tsx
@@ -60,7 +60,7 @@ const BillingForm: React.FC = () => {
     setIsLoading(true);
     try {
       const returnUrl = globalThis.location.origin + "/settings";
-      const { url } = await billingApi.createPortalSession(returnUrl);
+      const { url } = await billingApi.createPortalSession({ returnUrl });
 
       // Validation for successful URL generation
       if (!url?.startsWith("https://")) {


### PR DESCRIPTION
## Problem
The Stripe customer billing portal link was throwing a `400 Bad Request (VALIDATION_ERROR)` on the backend.

### Cause
In `/frontend/src/features/settings/components/BillingForm.tsx`, the `createPortalSession` endpoint was called by passing the string `returnUrl` directly:
```typescript
const { url } = await billingApi.createPortalSession(returnUrl);
```
However, the `createPortalSession` function in `/frontend/src/api/billing.ts` expects an **object** with the `returnUrl` property:
```typescript
createPortalSession: async ({ returnUrl }: { returnUrl: string }) => ...
```
This resulted in `returnUrl` being destructured as `undefined` and sent as an empty payload `{}` to the backend.

### Fix
Correctly wrap the argument as an object:
```typescript
const { url } = await billingApi.createPortalSession({ returnUrl });
```