### PR TITLE
fix(frontend): invalidate macro history query cache and handle numeric ID coercion

### DIFF
--- a/frontend/src/hooks/queries/useMacroQueries.test.tsx
+++ b/frontend/src/hooks/queries/useMacroQueries.test.tsx
@@ -242,5 +242,51 @@ describe("useMacroQueries", () => {
       const historyAfterError = queryClient.getQueryData<any>(queryKeys.macros.historyInfinite(20, undefined, undefined));
       expect(historyAfterError.pages[0].entries).toHaveLength(1);
     });
+
+    it("should optimistically delete entry even if string ID is passed and invalidate all macro queries when settled", async () => {
+      const { wrapper, queryClient } = createWrapper();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+      const entryDate = "2024-01-01";
+      const existingEntry = {
+        id: 123,
+        foodName: "Test Food",
+        protein: 10,
+        carbs: 20,
+        fats: 5,
+        mealType: "lunch" as const,
+        entryDate,
+        entryTime: "12:00",
+      };
+
+      queryClient.setQueryData(queryKeys.macros.dailyTotals(entryDate), {
+        protein: 10, carbs: 20, fats: 5, calories: 165,
+      });
+      queryClient.setQueryData(queryKeys.macros.historyInfinite(20, undefined, undefined), {
+        pages: [{ entries: [existingEntry], hasMore: false, totalCount: 1 }],
+        pageParams: [0],
+      });
+
+      (macrosApi.deleteEntry as any).mockResolvedValueOnce({ success: true, id: 123 });
+
+      const { result } = renderHook(() => useDeleteMacroEntry(), { wrapper });
+
+      act(() => {
+        result.current.mutate("123" as any);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      const historyAfterSuccess = queryClient.getQueryData<any>(
+        queryKeys.macros.historyInfinite(20, undefined, undefined),
+      );
+      expect(historyAfterSuccess.pages[0].entries).toHaveLength(0);
+
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: queryKeys.macros.all(),
+      });
+    });
   });
 });

--- a/frontend/src/hooks/queries/useMacroQueries.ts
+++ b/frontend/src/hooks/queries/useMacroQueries.ts
@@ -37,12 +37,16 @@ import { prepareOptimisticUpdate, rollbackOptimisticUpdate } from "./macro/optim
 function findEntryInHistory(queryClient: QueryClient, id: number) {
   const previousHistoryData = getMacroHistorySnapshots(queryClient);
   const historyData = previousHistoryData.find(([, data]) => {
-    return data?.pages.some((page) => page.entries.some((entry) => entry.id === id));
+    return data?.pages.some((page) =>
+      page.entries.some((entry) => Number(entry.id) === Number(id)),
+    );
   })?.[1];
 
   if (historyData?.pages) {
     for (const page of historyData.pages) {
-      const foundEntry = page.entries.find((entry) => entry.id === id);
+      const foundEntry = page.entries.find(
+        (entry) => Number(entry.id) === Number(id),
+      );
       if (foundEntry) {
         return { entry: foundEntry, entryDate: foundEntry.entryDate };
       }
@@ -267,6 +271,7 @@ export function useAddMacroEntry() {
       if (variables.entryDate) {
         queryClient.invalidateQueries({ queryKey: queryKeys.macros.dailyTotals(variables.entryDate) });
       }
+      queryClient.invalidateQueries({ queryKey: queryKeys.macros.all() });
     },
   });
 }
@@ -286,7 +291,9 @@ export function useUpdateMacroEntry() {
 
       transformHistoryPages(queryClient, (page) => ({
         ...page,
-        entries: page.entries.map((entryItem) => entryItem.id === id ? { ...entryItem, ...entry } : entryItem),
+        entries: page.entries.map((entryItem) =>
+          Number(entryItem.id) === Number(id) ? { ...entryItem, ...entry } : entryItem,
+        ),
       }));
 
       if (entryDate && originalEntry) {
@@ -315,6 +322,7 @@ export function useUpdateMacroEntry() {
       if (context?.entryDate) {
         queryClient.invalidateQueries({ queryKey: queryKeys.macros.dailyTotals(context.entryDate) });
       }
+      queryClient.invalidateQueries({ queryKey: queryKeys.macros.all() });
     },
   });
 }
@@ -334,7 +342,7 @@ export function useDeleteMacroEntry() {
 
       transformHistoryPages(queryClient, (page) => ({
         ...page,
-        entries: page.entries.filter((entryItem) => entryItem.id !== id),
+        entries: page.entries.filter((entryItem) => Number(entryItem.id) !== Number(id)),
       }));
 
       if (entryDate && entryToDelete) {
@@ -355,6 +363,7 @@ export function useDeleteMacroEntry() {
       if (context?.entryDate) {
         queryClient.invalidateQueries({ queryKey: queryKeys.macros.dailyTotals(context.entryDate) });
       }
+      queryClient.invalidateQueries({ queryKey: queryKeys.macros.all() });
     },
   });
 }


### PR DESCRIPTION
$(cat << "EOF"
## Summary
- Prevents macro entries from remaining visible in the UI after deletion until page refresh.
- Ensures ID comparisons in `findEntryInHistory`, `useUpdateMacroEntry`, and `useDeleteMacroEntry` handle numeric string coercion (`Number(entry.id) === Number(id)`).
- Calls `queryClient.invalidateQueries({ queryKey: queryKeys.macros.all() })` in `onSettled` for `useAddMacroEntry`, `useUpdateMacroEntry`, and `useDeleteMacroEntry` to ensure macro history queries stay synchronized with server state.
- Added test coverage in `useMacroQueries.test.tsx` for string ID optimistic deletion and cache invalidation.

## Testing
- All 106 frontend test files (710 tests) and 36 backend test files (425 tests) pass.
- `npm run typecheck` passes without errors.
EOF
)