### PR TITLE
fix(frontend): scale calories and macros in food search results to match portion size

### DIFF
--- a/frontend/src/features/macroTracking/components/AddEntryForm.test.tsx
+++ b/frontend/src/features/macroTracking/components/AddEntryForm.test.tsx
@@ -5,22 +5,40 @@ import AddEntryForm from "./AddEntryForm";
 
 vi.mock("@/features/macroTracking/components/CalorieSearchForm", () => ({
   default: ({ onResult }: { onResult: (value: unknown) => void }) => (
-    <button
-      type="button"
-      onClick={() =>
-        onResult({
-          protein: "12.6",
-          carbs: "0.2",
-          fats: "9",
-          name: "Eggs",
-          servingQuantity: 100,
-          servingUnit: "g",
-          rawQuantity: "6 eggs",
-        })
-      }
-    >
-      Select mocked food
-    </button>
+    <div>
+      <button
+        type="button"
+        onClick={() =>
+          onResult({
+            protein: "12.6",
+            carbs: "0.2",
+            fats: "9",
+            name: "Eggs",
+            servingQuantity: 100,
+            servingUnit: "g",
+            rawQuantity: "6 eggs",
+          })
+        }
+      >
+        Select mocked food
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          onResult({
+            protein: "4.0",
+            carbs: "10.0",
+            fats: "0.5",
+            name: "Full Cream Milk",
+            servingQuantity: 250,
+            servingUnit: "g",
+            rawQuantity: "250g",
+          })
+        }
+      >
+        Select milk
+      </button>
+    </div>
   ),
 }));
 
@@ -42,5 +60,25 @@ describe("AddEntryForm", () => {
 
     expect(quantityInput.value).toBe("6");
     expect(unitSelect.value).toBe("unit");
+  });
+
+  it("calculates initial scaled macros and calories upon food item selection", () => {
+    render(<AddEntryForm onSubmit={async () => {}} isSaving={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Select milk" }));
+
+    const quantityInput = screen.getByPlaceholderText("100") as HTMLInputElement;
+    const unitSelect = screen.getByDisplayValue("g") as HTMLSelectElement;
+
+    expect(quantityInput.value).toBe("250");
+    expect(unitSelect.value).toBe("g");
+
+    const proteinInput = screen.getByLabelText("Protein") as HTMLInputElement;
+    const carbsInput = screen.getByLabelText("Carbs") as HTMLInputElement;
+    const fatsInput = screen.getByLabelText("Fats") as HTMLInputElement;
+
+    expect(proteinInput.value).toBe("10");
+    expect(carbsInput.value).toBe("25");
+    expect(fatsInput.value).toBe("1.3");
   });
 });

--- a/frontend/src/features/macroTracking/components/AddEntryForm.tsx
+++ b/frontend/src/features/macroTracking/components/AddEntryForm.tsx
@@ -148,48 +148,59 @@ function AddEntry({ onSubmit, isSaving: _isSaving }: AddEntryProps) {
         carbs: Number.parseFloat(c),
         fats: Number.parseFloat(f),
       };
-      setBaseMacros(per100g);
-      setBaseIngredients(undefined);
-      setMealName(name);
-      setQuantity(servingQuantity);
+
+      let targetQuantity = servingQuantity;
+      let targetUnit = servingUnit as UnitType;
 
       if (rawQuantity) {
         const parsed = UnitConverter.parseQuantity(rawQuantity);
-        setUnit(parsed.unit);
-        setQuantity(parsed.quantity);
-        setSearchResult(name);
-
-        return;
-      }
-
-      let displayUnit = servingUnit as UnitType;
-
-      const validUnits: UnitType[] = [
-        "g",
-        "kg",
-        "oz",
-        "lb",
-        "ml",
-        "L",
-        "cup",
-        "tbsp",
-        "tsp",
-        "pt",
-        "unit",
-      ];
-      if (!validUnits.includes(displayUnit)) {
-        displayUnit = "g";
-      }
-
-      if (displayUnit === "lb") {
-        const metric = UnitConverter.toMetric(servingQuantity, displayUnit);
-        setUnit(metric.unit);
-        setQuantity(metric.quantity);
+        targetUnit = parsed.unit;
+        targetQuantity = parsed.quantity;
       } else {
-        setUnit(displayUnit);
-        setQuantity(servingQuantity);
+        const validUnits: UnitType[] = [
+          "g",
+          "kg",
+          "oz",
+          "lb",
+          "ml",
+          "L",
+          "cup",
+          "tbsp",
+          "tsp",
+          "pt",
+          "unit",
+        ];
+        if (!validUnits.includes(targetUnit)) {
+          targetUnit = "g";
+        }
+
+        if (targetUnit === "lb") {
+          const metric = UnitConverter.toMetric(servingQuantity, targetUnit);
+          targetUnit = metric.unit;
+          targetQuantity = metric.quantity;
+        }
       }
+
+      setBaseMacros(per100g);
+      setBaseIngredients(undefined);
+      setMealName(name);
+      setUnit(targetUnit);
+      setQuantity(targetQuantity);
       setSearchResult(name);
+
+      let qtyInGrams: number;
+      if (UnitConverter.isWeightUnit(targetUnit)) {
+        qtyInGrams = UnitConverter.convert(targetQuantity, targetUnit, "g");
+      } else if (UnitConverter.isVolumeUnit(targetUnit)) {
+        qtyInGrams = UnitConverter.convert(targetQuantity, targetUnit, "ml");
+      } else {
+        qtyInGrams = targetQuantity * 100;
+      }
+
+      const factor = qtyInGrams / 100;
+      setProtein(Number((per100g.protein * factor).toFixed(1)));
+      setCarbs(Number((per100g.carbs * factor).toFixed(1)));
+      setFats(Number((per100g.fats * factor).toFixed(1)));
     },
     [],
   );

--- a/frontend/src/features/macroTracking/components/CalorieSearchForm.test.tsx
+++ b/frontend/src/features/macroTracking/components/CalorieSearchForm.test.tsx
@@ -1,8 +1,16 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { macrosApi } from "@/api/macros";
 
 import CalorieSearchForm from "./CalorieSearchForm";
+
+vi.mock("@/api/macros", () => ({
+  macrosApi: {
+    search: vi.fn(),
+  },
+}));
 
 const createQueryClient = () =>
   new QueryClient({
@@ -22,10 +30,63 @@ const renderWithQueryClient = (ui: React.ReactElement) => {
 };
 
 describe("CalorieSearchForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders without crashing", () => {
     const { container } = renderWithQueryClient(
       <CalorieSearchForm onResult={() => {}} onSelectSavedMeal={() => {}} />,
     );
     expect(container).toBeDefined();
+  });
+
+  it("scales calories and macros in dropdown according to portion size", async () => {
+    (macrosApi.search as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        name: "Full Cream Milk",
+        protein: 4.0,
+        carbs: 10.0,
+        fats: 0.5,
+        energyKcal: 60,
+        categories: "Dairy",
+        servingQuantity: 250,
+        servingUnit: "g",
+        rawQuantity: "250g",
+      },
+    ]);
+
+    const onResultMock = vi.fn();
+
+    renderWithQueryClient(
+      <CalorieSearchForm onResult={onResultMock} onSelectSavedMeal={() => {}} />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Search for food" });
+    fireEvent.change(input, { target: { value: "milk" } });
+
+    const searchButton = screen.getByRole("button", { name: "Search for food" });
+    fireEvent.click(searchButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("Full Cream Milk")).toBeInTheDocument();
+    });
+
+    // 60 kcal * 2.5 = 150.0 kcal, 4g P * 2.5 = 10.0g, 10g C * 2.5 = 25.0g, 0.5g F * 2.5 = 1.3g
+    expect(screen.getByText(/Calories: 150.0 kcal/)).toBeInTheDocument();
+
+    const resultButton = screen.getByRole("button", { name: /Full Cream Milk/ });
+    fireEvent.click(resultButton);
+
+    expect(onResultMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Full Cream Milk",
+        servingQuantity: 250,
+        servingUnit: "g",
+        protein: "4.0",
+        carbs: "10.0",
+        fats: "0.5",
+      }),
+    );
   });
 });

--- a/frontend/src/features/macroTracking/components/CalorieSearchForm.tsx
+++ b/frontend/src/features/macroTracking/components/CalorieSearchForm.tsx
@@ -152,17 +152,12 @@ const CalorieSearch = memo(function CalorieSearch({
     const quantity = parsedQuantity.quantity;
     const unit = hasSupportedUnit ? parsedUnit : defaultUnit;
 
-    const metric =
-      unit === "unit"
-        ? { quantity, unit }
-        : UnitConverter.toMetric(quantity, unit);
-
     return {
       protein: item.protein.toFixed(1),
       carbs: item.carbs.toFixed(1),
       fats: item.fats.toFixed(1),
       name: item.name,
-      servingQuantity: metric.quantity,
+      servingQuantity: quantity,
       servingUnit: unit,
       rawQuantity: item.rawQuantity,
     };
@@ -215,24 +210,63 @@ const CalorieSearch = memo(function CalorieSearch({
     return !(item.protein === 0 && item.carbs === 0 && item.fats === 0);
   }, []);
 
+  const getPortionFactor = useCallback((item: FoodSearchResult): number => {
+    const defaultUnit = (item.servingUnit || "g") as UnitType;
+    const parsed = item.rawQuantity
+      ? UnitConverter.parseQuantity(item.rawQuantity)
+      : {
+          quantity: item.servingQuantity || 100,
+          unit: defaultUnit,
+          original: "",
+        };
+
+    const qty = parsed.quantity;
+    const unit = parsed.unit as UnitType;
+
+    if (unit === "unit") {
+      return qty;
+    }
+
+    if (UnitConverter.isWeightUnit(unit)) {
+      const grams = UnitConverter.convert(qty, unit, "g");
+      return grams / 100;
+    }
+
+    if (UnitConverter.isVolumeUnit(unit)) {
+      const ml = UnitConverter.convert(qty, unit, "ml");
+      return ml / 100;
+    }
+
+    return 1;
+  }, []);
+
   const displayResults = useMemo(() => {
     if (activePanel !== "results" || results.length === 0) return [];
 
     return results
       .filter((item) => hasNutrients(item))
-      .map((item, index) => ({
-        item,
-        displayQuantity: getQuantityDisplay(item),
-        calories: calculateDisplayCalories(item),
-        hasNutrients: hasNutrients(item),
-        id: `${item.name}-${index}`,
-      }));
+      .map((item, index) => {
+        const factor = getPortionFactor(item);
+        const baseCalories = calculateDisplayCalories(item);
+
+        return {
+          item,
+          displayQuantity: getQuantityDisplay(item),
+          calories: baseCalories * factor,
+          protein: item.protein * factor,
+          carbs: item.carbs * factor,
+          fats: item.fats * factor,
+          hasNutrients: hasNutrients(item),
+          id: `${item.name}-${index}`,
+        };
+      });
   }, [
     activePanel,
     results,
     hasNutrients,
     getQuantityDisplay,
     calculateDisplayCalories,
+    getPortionFactor,
   ]);
 
   const searchErrorMessage = searchError
@@ -292,7 +326,8 @@ const CalorieSearch = memo(function CalorieSearch({
         <div className="absolute top-full left-0 z-50 mt-2 h-64 w-full overflow-hidden rounded-xl border border-border bg-surface shadow-xl">
           <div className="h-full overflow-y-auto pr-2" onScroll={handleScroll}>
             {displayResults.map((resultData) => {
-              const { item, displayQuantity, calories } = resultData;
+              const { item, displayQuantity, calories, protein, carbs, fats } =
+                resultData;
 
               return (
                 <button
@@ -307,8 +342,8 @@ const CalorieSearch = memo(function CalorieSearch({
                   <div className="text-xs text-foreground">
                     {displayQuantity ? `${displayQuantity} | ` : ""}
                     Calories: {calories.toFixed(1)} kcal | Protein:{" "}
-                    {item.protein.toFixed(1)}g, Carbs: {item.carbs.toFixed(1)}
-                    g, Fats: {item.fats.toFixed(1)}g
+                    {protein.toFixed(1)}g, Carbs: {carbs.toFixed(1)}
+                    g, Fats: {fats.toFixed(1)}g
                   </div>
                   {item.categories && (
                     <div className="text-xs text-foreground">

--- a/frontend/src/features/macroTracking/utils/units.test.ts
+++ b/frontend/src/features/macroTracking/utils/units.test.ts
@@ -95,6 +95,26 @@ describe("units", () => {
         expect(berries.quantity).toBe(140);
       });
 
+      it("extracts parenthetical portion weights/volumes", () => {
+        expect(UnitConverter.parseQuantity("1 container (170g)")).toEqual({
+          quantity: 170,
+          unit: "g",
+          original: "1 container (170g)",
+        });
+
+        expect(UnitConverter.parseQuantity("1 serving (30 g)")).toEqual({
+          quantity: 30,
+          unit: "g",
+          original: "1 serving (30 g)",
+        });
+
+        expect(UnitConverter.parseQuantity("1 bottle (250 ml)")).toEqual({
+          quantity: 250,
+          unit: "ml",
+          original: "1 bottle (250 ml)",
+        });
+      });
+
       it("falls back to defaults for invalid or empty inputs", () => {
         expect(UnitConverter.parseQuantity("")).toEqual({
           quantity: 100,

--- a/frontend/src/features/macroTracking/utils/units.ts
+++ b/frontend/src/features/macroTracking/utils/units.ts
@@ -70,6 +70,42 @@ export const UnitConverter = {
       return { quantity: 1, unit: "unit", original: input };
     }
 
+    const parentheticalMatch = trimmed.match(/\(([^)]+)\)/);
+    if (parentheticalMatch?.[1]) {
+      const innerMeasurement = parentheticalMatch[1].trim();
+      const innerMatch = innerMeasurement.match(MEASUREMENT_PATTERN);
+      if (innerMatch?.[1] && innerMatch[2]) {
+        const quantity = Number.parseFloat(innerMatch[1].replace(",", "."));
+        if (!Number.isNaN(quantity) && quantity > 0) {
+          const rawUnit = innerMatch[2].replaceAll(/\s+/g, " ").trim();
+          const unitMap: Record<string, UnitType> = {
+            g: "g", gram: "g", grams: "g",
+            kg: "kg", kilogram: "kg", kilograms: "kg",
+            oz: "oz", ounce: "oz", ounces: "oz",
+            lb: "lb", lbs: "lb", pound: "lb", pounds: "lb",
+            ml: "ml", milliliter: "ml", milliliters: "ml",
+            l: "L", liter: "L", liters: "L",
+            cup: "cup", cups: "cup",
+            tbsp: "tbsp", tablespoon: "tbsp", tablespoons: "tbsp",
+            tsp: "tsp", teaspoon: "tsp", teaspoons: "tsp",
+            pt: "pt", pint: "pt", pints: "pt",
+            "fl oz": "ml",
+          };
+
+          if (rawUnit === "fl oz") {
+            return {
+              quantity: Math.round(quantity * 29.5735 * 100) / 100,
+              unit: "ml",
+              original: input,
+            };
+          }
+
+          const unit = unitMap[rawUnit] ?? "g";
+          return { quantity, unit, original: input };
+        }
+      }
+    }
+
     const countBasedMatch = trimmed.match(COUNT_BASED_QUANTITY_PATTERN);
     if (countBasedMatch?.[1]) {
       const count = Number.parseFloat(countBasedMatch[1].replace(",", "."));


### PR DESCRIPTION
## Summary of Changes
1. **Parenthetical Unit Parsing ()**: Enhanced  to extract weight and volume measurements inside parentheses (e.g. `"1 container (170g)"` -> `170g`), enabling proper portion factor scaling against 100g base macros.
2. **Search Dropdown Display ()**: Calculated `portionFactor` based on the displayed portion quantity and scaled calories, protein, carbs, and fats in the search result dropdown so displayed values match portion sizes (\text{g} \rightarrow 150\text{ kcal}$).
3. **Aligned Quantity/Unit State ( & )**: Ensured matching `{ servingQuantity, servingUnit }` pairs are returned upon selection, and synchronized initial form macro and calorie values to match search results.
4. **Unit Tests**: Updated and added unit tests in `units.test.ts`, `CalorieSearchForm.test.tsx`, and `AddEntryForm.test.tsx`.