### PR TITLE
fix(backend,frontend): normalize null ingredients in macro history and initialize query cache on optimistic add

### DIFF
--- a/backend/src/modules/macros/schemas.ts
+++ b/backend/src/modules/macros/schemas.ts
@@ -40,7 +40,7 @@ const macroEntryBase = t.Object({
   mealName: t.Optional(t.String({ default: "" })), // Use camelCase for API
   entryDate: DateSchema, // Changed to camelCase to match frontend
   entryTime: TimeSchema, // Changed to camelCase to match frontend
-  ingredients: t.Optional(t.Array(t.Unknown())), // Store parsed JSON ingredients
+  ingredients: t.Optional(t.Nullable(t.Array(t.Unknown()))), // Store parsed JSON ingredients
 });
 
 // --- Macro Target Percentages Schema (Moved from goals/schemas.ts) ---
@@ -92,7 +92,7 @@ export const MacroSchemas = {
     mealName: t.Optional(t.String()), // camelCase
     entryDate: DateSchema,
     entryTime: TimeSchema,
-    ingredients: t.Optional(t.Array(t.Unknown())),
+    ingredients: t.Optional(t.Nullable(t.Array(t.Unknown()))),
     createdAt: t.String(), // Accept any string format for timestamp
   }),
   macroTotals: t.Object({

--- a/backend/src/modules/macros/service.ts
+++ b/backend/src/modules/macros/service.ts
@@ -86,6 +86,8 @@ export function normalizeMacroEntryRow(
       normalized.ingredients,
       "ingredients",
     );
+  } else if (!normalized.ingredients) {
+    normalized.ingredients = [];
   }
 
   return normalized as unknown as MacroEntryResponse;

--- a/backend/tests/macros/service.test.ts
+++ b/backend/tests/macros/service.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeMacroEntryRow } from "../../src/modules/macros/service";
+
+describe("normalizeMacroEntryRow", () => {
+  it("converts null ingredients to an empty array []", () => {
+    const row = {
+      id: 649,
+      user_id: 1,
+      protein: 25,
+      carbs: 11.3,
+      fats: 9,
+      meal_type: "lunch" as const,
+      meal_name: "Tuna salad",
+      entry_date: "2026-07-27",
+      entry_time: "12:25",
+      ingredients: null,
+      created_at: "2026-07-27 10:28:10",
+    };
+
+    const result = normalizeMacroEntryRow(row);
+    expect(result.ingredients).toEqual([]);
+    expect(result.mealName).toBe("Tuna salad");
+    expect(result.entryDate).toBe("2026-07-27");
+  });
+
+  it("parses valid string JSON ingredients", () => {
+    const row = {
+      id: 650,
+      user_id: 1,
+      protein: 20,
+      carbs: 10,
+      fats: 5,
+      meal_type: "lunch" as const,
+      meal_name: "Salad",
+      entry_date: "2026-07-27",
+      entry_time: "12:30",
+      ingredients: JSON.stringify([{ name: "Tuna", protein: 20, carbs: 0, fats: 5 }]),
+      created_at: "2026-07-27 10:30:00",
+    };
+
+    const result = normalizeMacroEntryRow(row);
+    expect(result.ingredients).toEqual([{ name: "Tuna", protein: 20, carbs: 0, fats: 5 }]);
+  });
+});

--- a/frontend/src/hooks/queries/useMacroQueries.test.tsx
+++ b/frontend/src/hooks/queries/useMacroQueries.test.tsx
@@ -103,6 +103,42 @@ describe("useMacroQueries", () => {
       const historyAfterError = queryClient.getQueryData<any>(queryKeys.macros.historyInfinite(20, undefined, undefined));
       expect(historyAfterError.pages[0].entries).toHaveLength(0);
     });
+
+    it("should initialize history list cache when adding entry if history cache was previously empty or undefined", async () => {
+      const { wrapper, queryClient } = createWrapper();
+
+      const entryDate = "2024-01-01";
+      const newEntry = {
+        foodName: "New Food Item",
+        protein: 20,
+        carbs: 30,
+        fats: 10,
+        mealType: "dinner" as const,
+        entryDate,
+        entryTime: "19:00",
+      };
+
+      (macrosApi.addEntry as any).mockResolvedValueOnce({
+        id: 999,
+        ...newEntry,
+        createdAt: "2024-01-01T19:00:00Z",
+      });
+
+      const { result } = renderHook(() => useAddMacroEntry(), { wrapper });
+
+      act(() => {
+        result.current.mutate(newEntry);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      const historyData = queryClient.getQueryData<any>(queryKeys.macros.historyInfinite());
+      expect(historyData).toBeDefined();
+      expect(historyData.pages[0].entries[0].id).toBe(999);
+      expect(historyData.pages[0].entries[0].foodName).toBe("New Food Item");
+    });
   });
 
   describe("useUpdateMacroEntry", () => {

--- a/frontend/src/hooks/queries/useMacroQueries.ts
+++ b/frontend/src/hooks/queries/useMacroQueries.ts
@@ -97,9 +97,31 @@ function transformHistoryPages(
   queryClient: QueryClient,
   pageTransformer: (page: PaginatedMacroHistory, index: number) => PaginatedMacroHistory
 ) {
+  const snapshots = getMacroHistorySnapshots(queryClient);
+  if (snapshots.length === 0) {
+    queryClient.setQueryData(queryKeys.macros.historyInfinite(), {
+      pages: [
+        pageTransformer(
+          { entries: [], total: 0, limit: 20, offset: 0, hasMore: false },
+          0,
+        ),
+      ],
+      pageParams: [0],
+    });
+    return;
+  }
+
   updateMacroHistoryCaches(queryClient, (oldData) => {
     if (!oldData || oldData.pages.length === 0) {
-      return oldData;
+      return {
+        pages: [
+          pageTransformer(
+            { entries: [], total: 0, limit: 20, offset: 0, hasMore: false },
+            0,
+          ),
+        ],
+        pageParams: [0],
+      };
     }
 
     return {


### PR DESCRIPTION
## Summary of Changes
1. **Backend Row Normalization ()**: Updated `normalizeMacroEntryRow` so `ingredients = null` (or undefined) defaults to an empty array `[]`.
2. **Backend Schema Update (`backend/src/modules/macros/schemas.ts`)**: Updated `macroEntryBase` and `macroEntryResponse` schema definitions to `t.Optional(t.Nullable(t.Array(t.Unknown())))` to gracefully validate both `null` and `[]` values without throwing a 422/400 Elysia response validation error.
3. **Frontend Cache Initialization (`frontend/src/hooks/queries/useMacroQueries.ts`)**: Updated `transformHistoryPages` in `useMacroQueries.ts` to initialize the infinite query cache structure if `oldData` or `snapshots` is `undefined`, ensuring optimistic additions render immediately in the UI even if the history query previously failed or was unpopulated.
4. **Unit Tests**: Added unit tests in `backend/tests/macros/service.test.ts` and `frontend/src/hooks/queries/useMacroQueries.test.tsx`.