### PR TITLE
fix(frontend): preserve local timezone in history dates, track table row IDs, and align query keys

### DIFF
--- a/frontend/src/features/macroTracking/components/DesktopEntryTable.tsx
+++ b/frontend/src/features/macroTracking/components/DesktopEntryTable.tsx
@@ -309,6 +309,8 @@ const DesktopEntryTable = memo(
       data: tableData,
       columns,
       getCoreRowModel: getCoreRowModel(),
+      getRowId: (row) =>
+        row.isGroup ? `group-${row.date}` : `entry-${row.entries[0]?.id}`,
     });
 
     const visibleTableRows = useMemo(() => {

--- a/frontend/src/features/macroTracking/components/EntryHistoryHelpers.ts
+++ b/frontend/src/features/macroTracking/components/EntryHistoryHelpers.ts
@@ -1,11 +1,26 @@
 import type { MacroEntry } from "@/types/macro";
 
-export const formatEntryDate = (dateString: string): string =>
-  new Date(dateString).toLocaleDateString("en-UK", {
+export const formatEntryDate = (dateString: string): string => {
+  if (!dateString) return "";
+  const parts = dateString.split("-");
+  if (parts.length === 3) {
+    const year = Number.parseInt(parts[0], 10);
+    const month = Number.parseInt(parts[1], 10) - 1;
+    const day = Number.parseInt(parts[2], 10);
+    if (!Number.isNaN(year) && !Number.isNaN(month) && !Number.isNaN(day)) {
+      return new Date(year, month, day).toLocaleDateString("en-UK", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      });
+    }
+  }
+  return new Date(dateString).toLocaleDateString("en-UK", {
     year: "numeric",
     month: "short",
     day: "numeric",
   });
+};
 
 export const formatTimeFromEntry = (entry: MacroEntry): string =>
   entry.entryTime ||

--- a/frontend/src/features/macroTracking/components/EntryHistoryPanel.test.tsx
+++ b/frontend/src/features/macroTracking/components/EntryHistoryPanel.test.tsx
@@ -1,19 +1,54 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import EntryHistoryPanel from "./EntryHistoryPanel";
+import { formatEntryDate } from "./EntryHistoryHelpers";
+import { todayISO } from "@/utils/dateUtilities";
 
-describe("EntryHistoryPanel", () => {
-  it("renders without crashing", () => {
-    const { container } = render(
-      <EntryHistoryPanel
-        history={[]}
-        deleteEntry={() => {}}
-        onEdit={() => {}}
-        isDeleting={false}
-        isEditing={false}
-      />,
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+describe("EntryHistoryHelpers & Panel", () => {
+  it("formatEntryDate formats ISO date accurately without UTC off-by-one shifts", () => {
+    expect(formatEntryDate("2026-07-27")).toContain("27 Jul 2026");
+  });
+
+  it("renders today's entries without auto-collapsing", () => {
+    const today = todayISO();
+    const todayEntry = {
+      id: 999,
+      mealName: "Chicken & Rice",
+      mealType: "lunch" as const,
+      protein: 30,
+      carbs: 40,
+      fats: 10,
+      entryDate: today,
+      entryTime: "12:30",
+      createdAt: new Date().toISOString(),
+    };
+
+    const queryClient = createQueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EntryHistoryPanel
+          history={[todayEntry]}
+          deleteEntry={() => {}}
+          onEdit={() => {}}
+          isDeleting={false}
+          isEditing={false}
+        />
+      </QueryClientProvider>,
     );
-    expect(container).toBeDefined();
+
+    expect(screen.getAllByText("Today").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Chicken & Rice").length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/hooks/queries/useMacroQueries.test.tsx
+++ b/frontend/src/hooks/queries/useMacroQueries.test.tsx
@@ -134,7 +134,7 @@ describe("useMacroQueries", () => {
         expect(result.current.isSuccess).toBe(true);
       });
 
-      const historyData = queryClient.getQueryData<any>(queryKeys.macros.historyInfinite());
+      const historyData = queryClient.getQueryData<any>(queryKeys.macros.historyInfinite(20));
       expect(historyData).toBeDefined();
       expect(historyData.pages[0].entries[0].id).toBe(999);
       expect(historyData.pages[0].entries[0].foodName).toBe("New Food Item");

--- a/frontend/src/hooks/queries/useMacroQueries.ts
+++ b/frontend/src/hooks/queries/useMacroQueries.ts
@@ -99,7 +99,7 @@ function transformHistoryPages(
 ) {
   const snapshots = getMacroHistorySnapshots(queryClient);
   if (snapshots.length === 0) {
-    queryClient.setQueryData(queryKeys.macros.historyInfinite(), {
+    queryClient.setQueryData(queryKeys.macros.historyInfinite(20), {
       pages: [
         pageTransformer(
           { entries: [], total: 0, limit: 20, offset: 0, hasMore: false },


### PR DESCRIPTION
## Summary of Changes
1. **Local Timezone Date Formatting ()**: Updated `formatEntryDate` to parse `YYYY-MM-DD` strings using local date components (`new Date(year, month - 1, day)`). This prevents UTC off-by-one shifts in timezones west of GMT (e.g., `"2026-07-27"` previously evaluating to `"26 Jul 2026"`).
2. **Prevent Auto-Collapsing Today's Accordion Group ()**: Aligning formatted date strings ensures today's date group matches `todayFormatted`, preventing the `useEffect` from auto-collapsing today's section on entry addition or deletion.
3. **TanStack Table Row ID Tracking ()**: Provided explicit `getRowId` (`group-${row.date}` / `entry-${row.entries[0]?.id}`) to `useReactTable` so DOM rows re-render cleanly when entries are added or deleted.
4. **Infinite Query Key Fallback Alignment ()**: Updated `transformHistoryPages` fallback to target `queryKeys.macros.historyInfinite(20)` directly, matching `useHistoryPagination(20)`.
5. **Unit Tests**: Added test cases in `EntryHistoryPanel.test.tsx` and updated `useMacroQueries.test.tsx`.