### PR TITLE
fix(ci): resolve ESLint import sorting and nullish coalescing lint warnings

### DIFF
--- a/backend/src/modules/macros/service.ts
+++ b/backend/src/modules/macros/service.ts
@@ -86,8 +86,8 @@ export function normalizeMacroEntryRow(
       normalized.ingredients,
       "ingredients",
     );
-  } else if (!normalized.ingredients) {
-    normalized.ingredients = [];
+  } else {
+    normalized.ingredients ??= [];
   }
 
   return normalized as unknown as MacroEntryResponse;

--- a/frontend/src/features/macroTracking/components/EntryHistoryPanel.test.tsx
+++ b/frontend/src/features/macroTracking/components/EntryHistoryPanel.test.tsx
@@ -1,10 +1,11 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
-import EntryHistoryPanel from "./EntryHistoryPanel";
-import { formatEntryDate } from "./EntryHistoryHelpers";
 import { todayISO } from "@/utils/dateUtilities";
+
+import { formatEntryDate } from "./EntryHistoryHelpers";
+import EntryHistoryPanel from "./EntryHistoryPanel";
 
 const createQueryClient = () =>
   new QueryClient({


### PR DESCRIPTION
## Summary of Changes
- Sorted imports in `frontend/src/features/macroTracking/components/EntryHistoryPanel.test.tsx` to comply with `simple-import-sort/imports`.
- Refactored nullish coalescing operator in `backend/src/modules/macros/service.ts` to comply with `@typescript-eslint/prefer-nullish-coalescing`.
- Verified `npm run lint`, `npm run typecheck`, and Vitest test suites pass with 0 errors across frontend and backend.