### PR TITLE
fix(frontend): update DesktopEntryTable reactivity and prevent date group re-collapsing

### DIFF
--- a/frontend/src/features/macroTracking/components/DesktopEntryTable.tsx
+++ b/frontend/src/features/macroTracking/components/DesktopEntryTable.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo, useRef, useState } from "react";
+import React, { memo, useCallback, useMemo, useRef, useState } from "react";
 import {
   createColumnHelper,
   flexRender,
@@ -87,15 +87,6 @@ const DesktopEntryTable = memo(
 
       return data;
     }, [groupedEntries]);
-
-    const totalEntries = useMemo(() => {
-      return groupedEntries.reduce(
-        (sum, group) => sum + group.entries.length,
-        0,
-      );
-    }, [groupedEntries]);
-
-    const shouldVirtualize = totalEntries > 50;
 
     const columns = useMemo(
       () => [
@@ -324,12 +315,28 @@ const DesktopEntryTable = memo(
 
         return !isDateCollapsed(parentDate);
       });
-    }, [table, isDateCollapsed]);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [table, tableData, isDateCollapsed]);
+
+    const shouldVirtualize = visibleTableRows.length > 50;
 
     const virtualizer = useVirtualizer({
       count: visibleTableRows.length,
       getScrollElement: () => tableContainerReference.current,
       estimateSize: () => 48,
+      getItemKey: useCallback(
+        (index: number) => {
+          const row = visibleTableRows[index];
+          if (!row) return index;
+          const data = row.original;
+          const parentDate = data.parentDate ?? data.date;
+
+          return data.isGroup
+            ? `group-${data.date}`
+            : `entry-${data.entries[0]?.id}-${parentDate}`;
+        },
+        [visibleTableRows],
+      ),
       overscan: 10,
     });
 
@@ -337,7 +344,11 @@ const DesktopEntryTable = memo(
       row: Row<TableRowData>,
       data: TableRowData,
       isVirtualized: boolean,
-      virtualRowProps?: { start: number; measureRef: (el: HTMLDivElement | null) => void },
+      virtualRowProps?: {
+        index: number;
+        start: number;
+        measureRef: (el: HTMLDivElement | null) => void;
+      },
     ) => {
       const isGroup = data.isGroup;
       const parentDate = data.parentDate ?? data.date;
@@ -368,6 +379,7 @@ const DesktopEntryTable = memo(
               transform: `translateY(${virtualRowProps?.start}px)`,
             },
             ref: virtualRowProps?.measureRef,
+            "data-index": virtualRowProps?.index,
           }
         : {
             initial: { height: 0, opacity: 0 },
@@ -423,21 +435,20 @@ const DesktopEntryTable = memo(
             width: "100%",
           }}
         >
-          <AnimatePresence initial={false}>
-            {virtualItems.map((virtualRow) => {
-              const row = visibleTableRows[virtualRow.index];
-              if (!row) {
-                return null;
-              }
+          {virtualItems.map((virtualRow) => {
+            const row = visibleTableRows[virtualRow.index];
+            if (!row) {
+              return null;
+            }
 
-              const data = row.original;
+            const data = row.original;
 
-              return renderRow(row, data, true, {
-                start: virtualRow.start,
-                measureRef: virtualizer.measureElement,
-              });
-            })}
-          </AnimatePresence>
+            return renderRow(row, data, true, {
+              index: virtualRow.index,
+              start: virtualRow.start,
+              measureRef: virtualizer.measureElement,
+            });
+          })}
         </div>
       );
     };

--- a/frontend/src/features/macroTracking/components/EntryHistoryPanel.test.tsx
+++ b/frontend/src/features/macroTracking/components/EntryHistoryPanel.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { todayISO } from "@/utils/dateUtilities";
@@ -51,5 +51,82 @@ describe("EntryHistoryHelpers & Panel", () => {
 
     expect(screen.getAllByText("Today").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Chicken & Rice").length).toBeGreaterThan(0);
+  });
+
+  it("updates entry list dynamically when history prop changes without closing date tab", async () => {
+    const today = todayISO();
+    const entry1 = {
+      id: 101,
+      mealName: "Oatmeal",
+      mealType: "breakfast" as const,
+      protein: 15,
+      carbs: 50,
+      fats: 5,
+      entryDate: today,
+      entryTime: "08:00",
+      createdAt: new Date().toISOString(),
+    };
+
+    const entry2 = {
+      id: 102,
+      mealName: "Salmon Salad",
+      mealType: "lunch" as const,
+      protein: 35,
+      carbs: 10,
+      fats: 20,
+      entryDate: today,
+      entryTime: "12:00",
+      createdAt: new Date().toISOString(),
+    };
+
+    const queryClient = createQueryClient();
+
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <EntryHistoryPanel
+          history={[entry1]}
+          deleteEntry={() => {}}
+          onEdit={() => {}}
+          isDeleting={false}
+          isEditing={false}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getAllByText("Oatmeal").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Salmon Salad")).toBeNull();
+
+    // Rerender with added entry
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <EntryHistoryPanel
+          history={[entry1, entry2]}
+          deleteEntry={() => {}}
+          onEdit={() => {}}
+          isDeleting={false}
+          isEditing={false}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getAllByText("Salmon Salad").length).toBeGreaterThan(0);
+
+    // Rerender with deleted entry
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <EntryHistoryPanel
+          history={[entry2]}
+          deleteEntry={() => {}}
+          onEdit={() => {}}
+          isDeleting={false}
+          isEditing={false}
+        />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("Oatmeal")).toBeNull();
+    });
+    expect(screen.getAllByText("Salmon Salad").length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/features/macroTracking/components/EntryHistoryPanel.tsx
+++ b/frontend/src/features/macroTracking/components/EntryHistoryPanel.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { AnimatePresence, motion } from "motion/react";
 
@@ -67,6 +67,7 @@ const EntryHistoryComponent = function EntryHistory({
   isExportingCsv = false,
 }: EntryHistoryProps) {
   const [collapsedDates, setCollapsedDates] = useState<Set<string>>(new Set());
+  const initializedDatesReference = useRef<Set<string>>(new Set());
   const [displayedDateCount, setDisplayedDateCount] = useState(5);
 
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -188,24 +189,31 @@ const EntryHistoryComponent = function EntryHistory({
   useEffect(() => {
     setCollapsedDates((previous) => {
       const allDates = totalEntries.map((group) => group.date);
+      let changed = false;
+      const newSet = new Set(previous);
 
-      const newDatesToAdd = allDates.filter(
-        (date) => date !== todayFormatted && !previous.has(date),
-      );
+      for (const group of totalEntries) {
+        if (!initializedDatesReference.current.has(group.date)) {
+          initializedDatesReference.current.add(group.date);
+          const isTodayGroup =
+            group.date === todayFormatted ||
+            group.date === formatEntryDate(todayISO());
 
-      const datesToRemove = [...previous].filter(
-        (date) => !allDates.includes(date),
-      );
-
-      if (newDatesToAdd.length > 0 || datesToRemove.length > 0) {
-        const newSet = new Set(previous);
-        for (const date of newDatesToAdd) newSet.add(date);
-        for (const date of datesToRemove) newSet.delete(date);
-
-        return newSet;
+          if (!isTodayGroup) {
+            newSet.add(group.date);
+            changed = true;
+          }
+        }
       }
 
-      return previous;
+      for (const date of previous) {
+        if (!allDates.includes(date)) {
+          newSet.delete(date);
+          changed = true;
+        }
+      }
+
+      return changed ? newSet : previous;
     });
   }, [totalEntries, todayFormatted]);
 


### PR DESCRIPTION
## Summary
1. **Desktop Entry Table Memoization Fix ()**:
   - Added `tableData` to `visibleTableRows`'s `useMemo` dependency array (`[table, tableData, isDateCollapsed]`). Previously, TanStack Table's `table` reference remained stable when `tableData` changed on entry addition or deletion, causing `visibleTableRows` to return stale cached row models until a date tab collapse state was manually toggled.
   - Configured `getItemKey` on `useVirtualizer` with stable IDs (`group-${date}` / `entry-${id}-${parentDate}`).
   - Added `data-index={virtualRowProps?.index}` to `motion.div` in `renderRow` for TanStack Virtual v3 dynamic height measurements.
   - Removed `<AnimatePresence>` wrapping virtual items in `renderVirtualizedBody` to prevent unmounted virtual rows from lingering during height transitions.
   - Updated `shouldVirtualize` to check `visibleTableRows.length > 50`.

2. **Entry History Panel Auto-Collapse Prevention ()**:
   - Added `initializedDatesReference = useRef<Set<string>>(new Set())` so newly discovered date groups are initialized once without overriding existing collapse/expansion states when `totalEntries` updates on entry mutations.
   - Strengthened Today date matching check (`group.date === todayFormatted || group.date === formatEntryDate(todayISO())`) so Today's date section never auto-collapses on entry additions/deletions.

3. **Unit Tests**:
   - Added reactivity unit test in `EntryHistoryPanel.test.tsx` verifying entry additions and deletions update the DOM instantly without closing and reopening date tabs.