### PR TITLE
fix(api): enforce Cache-Control no-store headers on backend and fetch options on frontend

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -260,6 +260,12 @@ function registerCoreRoutes(app: Elysia, db: Database): void {
     .use(metricsRoutes)
 
     // Apply middleware after webhook routes to avoid body consumption conflicts
+    .onRequest(({ set }) => {
+      set.headers["Cache-Control"] =
+        "no-store, no-cache, must-revalidate, proxy-revalidate";
+      set.headers["Pragma"] = "no-cache";
+      set.headers["Expires"] = "0";
+    })
     .use(correlationMiddleware)
     .use(enhancedApiLogging)
 

--- a/frontend/src/api/core.ts
+++ b/frontend/src/api/core.ts
@@ -170,6 +170,7 @@ export class ApiClient {
       method: "GET",
       headers,
       credentials: "include",
+      cache: "no-store",
     });
 
     return this.handleResponse(response) as Promise<T>;


### PR DESCRIPTION
## Summary
1. **Backend Anti-Caching Headers (`backend/src/app.ts`)**:
   - Added global `onRequest` response header middleware setting `Cache-Control: no-store, no-cache, must-revalidate, proxy-revalidate`, `Pragma: no-cache`, and `Expires: 0` for all `/api/*` responses.
   - Prevents web browsers and reverse proxies (Cloudflare/Nginx) from performing heuristic HTTP caching on dynamic user endpoints (`/api/macros/history`, `/api/macros/totals`, etc.).

2. **Frontend Fetch Anti-Caching (`frontend/src/api/core.ts`)**:
   - Added `cache: "no-store"` to `fetch` options in `ApiClient.get`.
   - Ensures TanStack Query background refetches always bypass browser disk/memory cache, guaranteeing that optimistic mutations reconcile against fresh SQLite database responses.