### PR TITLE
fix(frontend): add missing todayISO import in EntryHistoryPanel

### DIFF
--- a/frontend/src/features/macroTracking/components/EntryHistoryPanel.tsx
+++ b/frontend/src/features/macroTracking/components/EntryHistoryPanel.tsx
@@ -16,6 +16,7 @@ import {
   PlusCircleIcon,
 } from "@/components/ui";
 import { HistoryLimits, MacroEntry } from "@/types/macro";
+import { todayISO } from "@/utils/dateUtilities";
 
 import DesktopEntryTable from "./DesktopEntryTable";
 import { EntryHistoryContext } from "./EntryHistoryContext";


### PR DESCRIPTION
Added missing `todayISO` import in `EntryHistoryPanel.tsx` to resolve `ReferenceError: todayISO is not defined`.