### PR TITLE
fix(frontend): prevent duplicate optimistic entries in transformHistoryPages

### DIFF
--- a/frontend/src/hooks/queries/useMacroQueries.test.tsx
+++ b/frontend/src/hooks/queries/useMacroQueries.test.tsx
@@ -83,6 +83,7 @@ describe("useMacroQueries", () => {
       });
 
       const historyDuringMutation = queryClient.getQueryData<any>(queryKeys.macros.historyInfinite(20, undefined, undefined));
+      expect(historyDuringMutation.pages[0].entries).toHaveLength(1);
       expect(historyDuringMutation.pages[0].entries[0].foodName).toBe("Test Food");
       expect(historyDuringMutation.pages[0].entries[0].optimistic).toBe(true);
 

--- a/frontend/src/hooks/queries/useMacroQueries.ts
+++ b/frontend/src/hooks/queries/useMacroQueries.ts
@@ -97,45 +97,35 @@ function transformHistoryPages(
   queryClient: QueryClient,
   pageTransformer: (page: PaginatedMacroHistory, index: number) => PaginatedMacroHistory
 ) {
-  // 1. Synchronously update or initialize the primary historyInfinite(20) key
-  queryClient.setQueryData(
-    queryKeys.macros.historyInfinite(20),
-    (oldData: { pages: PaginatedMacroHistory[]; pageParams: number[] } | undefined) => {
-      if (!oldData || oldData.pages.length === 0) {
-        return {
-          pages: [
-            pageTransformer(
-              { entries: [], total: 0, limit: 20, offset: 0, hasMore: false },
-              0,
-            ),
-          ],
-          pageParams: [0],
-        };
-      }
-
-      return {
-        ...oldData,
-        pages: oldData.pages.map(pageTransformer),
-        pageParams: oldData.pageParams,
-      };
-    },
-  );
-
-  // 2. Also update all matching historyInfinite cache queries
   const snapshots = getMacroHistorySnapshots(queryClient);
-  if (snapshots.length > 0) {
-    updateMacroHistoryCaches(queryClient, (oldData) => {
-      if (!oldData || oldData.pages.length === 0) {
-        return oldData;
-      }
 
-      return {
-        ...oldData,
-        pages: oldData.pages.map(pageTransformer),
-        pageParams: oldData.pageParams,
-      };
-    });
+  if (snapshots.length === 0) {
+    queryClient.setQueryData(
+      queryKeys.macros.historyInfinite(20),
+      {
+        pages: [
+          pageTransformer(
+            { entries: [], total: 0, limit: 20, offset: 0, hasMore: false },
+            0,
+          ),
+        ],
+        pageParams: [0],
+      },
+    );
+    return;
   }
+
+  updateMacroHistoryCaches(queryClient, (oldData) => {
+    if (!oldData || oldData.pages.length === 0) {
+      return oldData;
+    }
+
+    return {
+      ...oldData,
+      pages: oldData.pages.map(pageTransformer),
+      pageParams: oldData.pageParams,
+    };
+  });
 }
 
 // --- Queries ---


### PR DESCRIPTION
## Description
Fixes an issue where adding a macro entry caused duplicate entries to appear in the UI state until refreshed.

## Cause
`transformHistoryPages` was modifying `queryKeys.macros.historyInfinite(20)` directly using `setQueryData`, and then calling `updateMacroHistoryCaches`, which uses `setQueriesData` on `['macros', 'history-infinite']`. Because `historyInfinite(20)` matches the query key pattern, the transformer ran twice on the exact same cache query, duplicating the optimistic entry in React Query cache.

## Fix
Check if snapshots exist first. If no query is cached yet, initialize `historyInfinite(20)`. Otherwise, update cached queries only once via `updateMacroHistoryCaches`.