### PR TITLE
feat: Edit Modal Quantity & Unit Refactor & Version Bump v2.3.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macrotrackr-backend",
-  "version": "1.0.0",
+  "version": "2.3.0",
   "description": "Backend API for Macro Trackr application",
   "module": "src/index.ts",
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "macrotrackr-frontend",
   "private": true,
-  "version": "0.0.0",
+  "version": "2.3.0",
   "type": "module",
   "scripts": {
     "dev": "bunx vite",

--- a/frontend/src/components/form/QuantityUnitField.tsx
+++ b/frontend/src/components/form/QuantityUnitField.tsx
@@ -14,6 +14,10 @@ export interface QuantityUnitFieldProps {
   unit: UnitType;
   onQuantityChange: (value: number | undefined) => void;
   onUnitChange: (value: UnitType) => void;
+  onQuantityUnitChange?: (
+    quantity: number | undefined,
+    unit: UnitType,
+  ) => void;
   disabled?: boolean;
   placeholder?: string;
   required?: boolean;
@@ -21,12 +25,71 @@ export interface QuantityUnitFieldProps {
   helperText?: string;
 }
 
+const getGramsEquivalent = (
+  quantity: number | undefined,
+  unit: string | undefined,
+): number => {
+  if (!quantity || quantity <= 0) return 0;
+  const unitString = unit ?? "g";
+
+  if (
+    unitString === "unit" ||
+    unitString === "pcs" ||
+    unitString === "pc" ||
+    unitString === "piece" ||
+    unitString === "pieces"
+  ) {
+    return quantity * 100;
+  }
+
+  if (UnitConverter.isWeightUnit(unitString as UnitType)) {
+    return UnitConverter.convert(quantity, unitString as UnitType, "g");
+  }
+
+  if (UnitConverter.isVolumeUnit(unitString as UnitType)) {
+    return UnitConverter.convert(quantity, unitString as UnitType, "ml");
+  }
+
+  return quantity * 100;
+};
+
+const convertQuantity = (
+  currentQty: number,
+  fromUnit: UnitType,
+  toUnit: UnitType,
+): number => {
+  if (fromUnit === toUnit) return currentQty;
+
+  const fromGrams = getGramsEquivalent(currentQty, fromUnit);
+  const isToPcs =
+    toUnit === "unit" ||
+    (toUnit as string) === "pcs" ||
+    (toUnit as string) === "pc" ||
+    (toUnit as string) === "piece" ||
+    (toUnit as string) === "pieces";
+
+  if (isToPcs) {
+    return Number((fromGrams / 100).toFixed(3));
+  }
+
+  if (UnitConverter.isWeightUnit(toUnit)) {
+    return Number(UnitConverter.convert(fromGrams, "g", toUnit).toFixed(3));
+  }
+
+  if (UnitConverter.isVolumeUnit(toUnit)) {
+    return Number(UnitConverter.convert(fromGrams, "ml", toUnit).toFixed(3));
+  }
+
+  return Number((fromGrams / 100).toFixed(3));
+};
+
 const QuantityUnitField = memo(function QuantityUnitField({
   label,
   quantity,
   unit,
   onQuantityChange,
   onUnitChange,
+  onQuantityUnitChange,
   disabled = false,
   placeholder = "100",
   required = false,
@@ -48,16 +111,25 @@ const QuantityUnitField = memo(function QuantityUnitField({
   ];
 
   const handleQuantityChange = (value: number | undefined) => {
-    onQuantityChange(value);
+    if (onQuantityUnitChange) {
+      onQuantityUnitChange(value, unit);
+    } else {
+      onQuantityChange(value);
+    }
   };
 
   const handleUnitChange = (value: string | number) => {
     const newUnit = value as UnitType;
 
-    // Convert quantity to the new unit if we have a valid quantity
     if (quantity && quantity > 0) {
-      const convertedQuantity = UnitConverter.convert(quantity, unit, newUnit);
-      onQuantityChange(Number(convertedQuantity.toFixed(3)));
+      const convertedQuantity = convertQuantity(quantity, unit, newUnit);
+      if (onQuantityUnitChange) {
+        onQuantityUnitChange(convertedQuantity, newUnit);
+
+        return;
+      }
+
+      onQuantityChange(convertedQuantity);
     }
 
     onUnitChange(newUnit);

--- a/frontend/src/features/landing/components/HeroSection.tsx
+++ b/frontend/src/features/landing/components/HeroSection.tsx
@@ -17,7 +17,7 @@ const HeroSection: React.FC = () => (
       >
         <span className="mb-6 flex items-center gap-2 rounded-full border border-border bg-surface-2 px-3 py-1 text-xs font-medium text-foreground transition-colors hover:bg-surface-3">
           <span className="h-1.5 w-1.5 rounded-full bg-primary" />
-          MacroTrackr 2.1 is now LIVE!
+          MacroTrackr 2.3 is now LIVE!
         </span>
         <h1 className="mb-6 max-w-4xl text-5xl font-bold tracking-tighter text-balance text-foreground sm:text-6xl lg:text-[5rem] lg:leading-[1.1]">
           Master your macros.

--- a/frontend/src/features/macroTracking/components/DesktopEntryTable.tsx
+++ b/frontend/src/features/macroTracking/components/DesktopEntryTable.tsx
@@ -112,8 +112,9 @@ const DesktopEntryTable = memo(
               );
             } else {
               const entry = data.entries[0];
-              const hasIngredients =
-                entry.ingredients && entry.ingredients.length > 0;
+              const hasIngredients = Boolean(
+                entry.ingredients && entry.ingredients.length > 1,
+              );
 
               return (
                 <div className="flex items-center gap-2 pl-6 text-sm whitespace-nowrap text-foreground">
@@ -415,12 +416,14 @@ const DesktopEntryTable = memo(
             ))}
           </div>
           <AnimatePresence initial={false}>
-            {!isGroup && expandedEntries.has(data.entries[0].id) && (
-              <IngredientsList
-                ingredients={data.entries[0].ingredients ?? []}
-                calculateCalories={calculateCalories}
-              />
-            )}
+            {!isGroup &&
+              (data.entries[0].ingredients?.length ?? 0) > 1 &&
+              expandedEntries.has(data.entries[0].id) && (
+                <IngredientsList
+                  ingredients={data.entries[0].ingredients ?? []}
+                  calculateCalories={calculateCalories}
+                />
+              )}
           </AnimatePresence>
         </motion.div>
       );

--- a/frontend/src/features/macroTracking/components/EditModal.test.tsx
+++ b/frontend/src/features/macroTracking/components/EditModal.test.tsx
@@ -1,0 +1,236 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { MacroEntry } from "@/types/macro";
+
+import EditModal from "./EditModal";
+
+const mockSingleEntry: MacroEntry = {
+  id: 1,
+  mealName: "Oatmeal",
+  protein: 10,
+  carbs: 40,
+  fats: 5,
+  mealType: "breakfast",
+  createdAt: "2026-07-27T00:00:00Z",
+  entryDate: "2026-07-27",
+  entryTime: "08:00",
+  ingredients: [
+    {
+      name: "Oatmeal",
+      protein: 10,
+      carbs: 40,
+      fats: 5,
+      quantity: 100,
+      unit: "g",
+      baseProtein: 10,
+      baseCarbs: 40,
+      baseFats: 5,
+      baseQuantity: 100,
+      baseUnit: "g",
+    },
+  ],
+};
+
+const mockMultiIngredientEntry: MacroEntry = {
+  id: 2,
+  mealName: "Chicken Bowl",
+  protein: 40,
+  carbs: 50,
+  fats: 10,
+  mealType: "lunch",
+  createdAt: "2026-07-27T00:00:00Z",
+  entryDate: "2026-07-27",
+  entryTime: "12:00",
+  ingredients: [
+    {
+      name: "Chicken Breast",
+      protein: 30,
+      carbs: 0,
+      fats: 3,
+      quantity: 150,
+      unit: "g",
+    },
+    {
+      name: "Rice",
+      protein: 10,
+      carbs: 50,
+      fats: 7,
+      quantity: 200,
+      unit: "g",
+    },
+  ],
+};
+
+describe("EditModal", () => {
+  beforeEach(() => {
+    let modalRoot = document.querySelector("#modal-root");
+    if (!modalRoot) {
+      modalRoot = document.createElement("div");
+      modalRoot.setAttribute("id", "modal-root");
+      document.body.appendChild(modalRoot);
+    }
+  });
+
+  it("renders single item entry with quantity and unit fields and without IngredientsPanel", () => {
+    render(
+      <EditModal
+        isOpen
+        entry={mockSingleEntry}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+        isSaving={false}
+      />,
+    );
+
+    // Checks Food Name is rendered
+    expect(screen.getByDisplayValue("Oatmeal")).toBeInTheDocument();
+
+    // Quantity & Unit controls are rendered
+    expect(screen.getByText("Quantity & Unit")).toBeInTheDocument();
+
+    // Single item convert button is rendered
+    expect(
+      screen.getByRole("button", {
+        name: /add ingredient \(convert to multi-ingredient meal\)/i,
+      }),
+    ).toBeInTheDocument();
+
+    // Ingredients section header button is NOT rendered for single items
+    expect(
+      screen.queryByRole("button", { name: /^ingredients/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders multi-ingredient entry with IngredientsPanel and disables top-level macro fields", () => {
+    render(
+      <EditModal
+        isOpen
+        entry={mockMultiIngredientEntry}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+        isSaving={false}
+      />,
+    );
+
+    // Food Name
+    expect(screen.getByDisplayValue("Chicken Bowl")).toBeInTheDocument();
+
+    // Ingredients header button IS rendered for multi-ingredient meals
+    expect(screen.getByRole("button", { name: /ingredients/i })).toBeInTheDocument();
+
+    // Check ingredient cards
+    expect(screen.getByDisplayValue("Chicken Breast")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Rice")).toBeInTheDocument();
+  });
+
+  it("converts single item to multi-ingredient meal when clicking Add Ingredient", () => {
+    render(
+      <EditModal
+        isOpen
+        entry={mockSingleEntry}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+        isSaving={false}
+      />,
+    );
+
+    const convertButton = screen.getByRole("button", {
+      name: /add ingredient \(convert to multi-ingredient meal\)/i,
+    });
+    fireEvent.click(convertButton);
+
+    // Now IngredientsPanel is rendered
+    expect(screen.getByRole("button", { name: /ingredients/i })).toBeInTheDocument();
+  });
+
+  it("scales macros proportionally when quantity changes in single item mode with pcs unit", () => {
+    const mockPcsEntry: MacroEntry = {
+      id: 3,
+      mealName: "Apple",
+      protein: 0.5,
+      carbs: 25,
+      fats: 0.3,
+      mealType: "snack",
+      createdAt: "2026-07-27T00:00:00Z",
+      entryDate: "2026-07-27",
+      entryTime: "15:00",
+      ingredients: [
+        {
+          name: "Apple",
+          protein: 0.5,
+          carbs: 25,
+          fats: 0.3,
+          quantity: 1,
+          unit: "unit",
+          baseProtein: 0.5,
+          baseCarbs: 25,
+          baseFats: 0.3,
+          baseQuantity: 1,
+          baseUnit: "unit",
+        },
+      ],
+    };
+
+    render(
+      <EditModal
+        isOpen
+        entry={mockPcsEntry}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+        isSaving={false}
+      />,
+    );
+
+    // Initial quantity is 1 pcs, carbs is 25
+    const qtyInput = screen.getByDisplayValue("1");
+    expect(qtyInput).toBeInTheDocument();
+    expect(screen.getByDisplayValue("25")).toBeInTheDocument();
+
+    // Change quantity to 2 pcs
+    fireEvent.change(qtyInput, { target: { value: "2" } });
+
+    // Carbs should scale to 50
+    expect(screen.getByDisplayValue("50")).toBeInTheDocument();
+
+    // Now switch unit from pcs to g
+    const unitDropdown = screen.getByRole("combobox");
+    fireEvent.change(unitDropdown, { target: { value: "g" } });
+
+    // 2 pcs should convert to 200g, carbs should remain 50
+    expect(screen.getByDisplayValue("200")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("50")).toBeInTheDocument();
+
+    // Change quantity to 100g
+    const qtyInputG = screen.getByDisplayValue("200");
+    fireEvent.change(qtyInputG, { target: { value: "100" } });
+
+    // Carbs should scale to 25
+    expect(screen.getByDisplayValue("25")).toBeInTheDocument();
+  });
+
+  it("scales macros proportionally when quantity changes in single item mode", () => {
+    render(
+      <EditModal
+        isOpen
+        entry={mockSingleEntry}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+        isSaving={false}
+      />,
+    );
+
+    // Quantity field should initially be 100
+    const qtyInput = screen.getByDisplayValue("100");
+    expect(qtyInput).toBeInTheDocument();
+
+    // Protein initial value is 10
+    expect(screen.getByDisplayValue("10")).toBeInTheDocument();
+
+    // Change quantity to 200
+    fireEvent.change(qtyInput, { target: { value: "200" } });
+
+    // Protein should scale proportionally to 20
+    expect(screen.getByDisplayValue("20")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/macroTracking/components/EditModal.tsx
+++ b/frontend/src/features/macroTracking/components/EditModal.tsx
@@ -28,24 +28,40 @@ const calculateTotalsFromIngredients = (ingredients: Ingredient[]) => {
     totalFats += ingredient.fats || 0;
   }
 
-  return { protein: totalProtein, carbs: totalCarbs, fats: totalFats };
+  return {
+    protein: Number(totalProtein.toFixed(1)),
+    carbs: Number(totalCarbs.toFixed(1)),
+    fats: Number(totalFats.toFixed(1)),
+  };
 };
 
 const roundValue = (value: number) => Number(value.toFixed(1));
 
-// Normalize quantity to comparable value (weight in grams, volume in ml, or unit)
-const normalizeQuantity = (quantity: number, unit: string): { value: number; type: 'weight' | 'volume' | 'unit' } => {
-  const normalizedUnit = unit === "l" ? "L" : unit;
-  const unitType = normalizedUnit as UnitType;
+const getGramsEquivalent = (
+  quantity: number | undefined,
+  unit: string | undefined,
+): number => {
+  if (!quantity || quantity <= 0) return 0;
+  const unitString =
+    unit === "l"
+      ? "L"
+      : unit === "pcs" || unit === "pc" || unit === "piece" || unit === "pieces"
+        ? "unit"
+        : unit ?? "g";
 
-  if (UnitConverter.isWeightUnit(unitType)) {
-    return { value: UnitConverter.convert(quantity, unitType, "g"), type: 'weight' };
-  }
-  if (UnitConverter.isVolumeUnit(unitType)) {
-    return { value: UnitConverter.convert(quantity, unitType, "ml"), type: 'volume' };
+  if (unitString === "unit") {
+    return quantity * 100;
   }
 
-  return { value: quantity, type: 'unit' };
+  if (UnitConverter.isWeightUnit(unitString as UnitType)) {
+    return UnitConverter.convert(quantity, unitString as UnitType, "g");
+  }
+
+  if (UnitConverter.isVolumeUnit(unitString as UnitType)) {
+    return UnitConverter.convert(quantity, unitString as UnitType, "ml");
+  }
+
+  return quantity * 100;
 };
 
 export default function EditModal({
@@ -58,27 +74,40 @@ export default function EditModal({
   const [editedEntry, setEditedEntry] = useState<MacroEntry | null>(null);
   const [originalEntry, setOriginalEntry] = useState<MacroEntry | null>(null);
   const [formValid, setFormValid] = useState(true);
-  const [showIngredients, setShowIngredients] = useState(false);
+  const [showIngredients, setShowIngredients] = useState(true);
   const [showUnsavedWarning, setShowUnsavedWarning] = useState(false);
-  const [baseIngredientsForScaling, setBaseIngredientsForScaling] = useState<Ingredient[] | null>(null);
+  const [baseIngredientsForScaling, setBaseIngredientsForScaling] = useState<
+    Ingredient[] | null
+  >(null);
   const [scaleFactor, setScaleFactor] = useState<number>(1);
 
-  // Update editedEntry when entry prop changes (to handle fresh data from cache)
+  // Single-item / manual entry scaling state
+  const [singleQuantity, setSingleQuantity] = useState<number | undefined>(100);
+  const [singleUnit, setSingleUnit] = useState<UnitType>("g");
+  const [singleBaseProtein, setSingleBaseProtein] = useState<number>(0);
+  const [singleBaseCarbs, setSingleBaseCarbs] = useState<number>(0);
+  const [singleBaseFats, setSingleBaseFats] = useState<number>(0);
+  const [singleBaseQuantity, setSingleBaseQuantity] = useState<number>(100);
+  const [singleBaseUnit, setSingleBaseUnit] = useState<UnitType>("g");
+
+  // Update editedEntry when entry prop changes
   useEffect(() => {
     if (entry) {
-      const ingredientsWithBase = entry.ingredients?.map(ing => ({
-        ...ing,
-        protein: roundValue(ing.protein),
-        carbs: roundValue(ing.carbs),
-        fats: roundValue(ing.fats),
-        quantity: ing.quantity === undefined ? undefined : roundValue(ing.quantity),
-        baseProtein: ing.baseProtein ?? ing.protein,
-        baseCarbs: ing.baseCarbs ?? ing.carbs,
-        baseFats: ing.baseFats ?? ing.fats,
-        baseQuantity: ing.baseQuantity ?? ing.quantity,
-        baseUnit: ing.baseUnit ?? ing.unit,
-      })) ?? [];
-      
+      const ingredientsWithBase =
+        entry.ingredients?.map((ing) => ({
+          ...ing,
+          protein: roundValue(ing.protein),
+          carbs: roundValue(ing.carbs),
+          fats: roundValue(ing.fats),
+          quantity:
+            ing.quantity === undefined ? undefined : roundValue(ing.quantity),
+          baseProtein: ing.baseProtein ?? ing.protein,
+          baseCarbs: ing.baseCarbs ?? ing.carbs,
+          baseFats: ing.baseFats ?? ing.fats,
+          baseQuantity: ing.baseQuantity ?? ing.quantity,
+          baseUnit: ing.baseUnit ?? ing.unit,
+        })) ?? [];
+
       const roundedEntry = {
         ...entry,
         protein: roundValue(entry.protein),
@@ -91,6 +120,18 @@ export default function EditModal({
       setOriginalEntry(roundedEntry);
       setBaseIngredientsForScaling(ingredientsWithBase);
       setScaleFactor(1);
+
+      const firstIng = ingredientsWithBase[0];
+      const initialQty = firstIng?.quantity ?? 100;
+      const initialUnit = (firstIng?.unit as UnitType) ?? "g";
+
+      setSingleQuantity(initialQty);
+      setSingleUnit(initialUnit);
+      setSingleBaseProtein(firstIng?.baseProtein ?? roundValue(entry.protein));
+      setSingleBaseCarbs(firstIng?.baseCarbs ?? roundValue(entry.carbs));
+      setSingleBaseFats(firstIng?.baseFats ?? roundValue(entry.fats));
+      setSingleBaseQuantity(firstIng?.baseQuantity ?? initialQty);
+      setSingleBaseUnit((firstIng?.baseUnit as UnitType) ?? initialUnit);
     }
   }, [entry]);
 
@@ -140,27 +181,176 @@ export default function EditModal({
       previous
         ? {
             ...previous,
-            [field]: field === "mealName" ? value : Number(value) || 0,
+            [field]: value,
           }
         : null,
     );
   };
 
-  const handleNumberChange = (
-    field: keyof MacroEntry,
+  const isMultiIngredient = Boolean(
+    editedEntry?.ingredients && editedEntry.ingredients.length > 1,
+  );
+
+  // Single-item / manual entry quantity and unit change
+  const handleSingleQuantityUnitChange = (
+    newQty: number | undefined,
+    newUnit: UnitType,
+  ) => {
+    setSingleQuantity(newQty);
+    setSingleUnit(newUnit);
+    if (!editedEntry) return;
+
+    const isPcsUnit = (u?: string) =>
+      u === "unit" ||
+      u === "pcs" ||
+      u === "pc" ||
+      u === "piece" ||
+      u === "pieces";
+
+    const qtyValue = newQty ?? (isPcsUnit(newUnit) ? 1 : 100);
+
+    const baseGrams = getGramsEquivalent(
+      singleBaseQuantity,
+      singleBaseUnit,
+    );
+    const targetGrams = getGramsEquivalent(qtyValue, newUnit);
+
+    let factor = 1;
+    if (baseGrams > 0) {
+      factor = targetGrams / baseGrams;
+    }
+
+    const newP = roundValue(singleBaseProtein * factor);
+    const newC = roundValue(singleBaseCarbs * factor);
+    const newF = roundValue(singleBaseFats * factor);
+
+    let updatedIngredients = editedEntry.ingredients;
+    if (editedEntry.ingredients?.length === 1) {
+      updatedIngredients = [
+        {
+          ...editedEntry.ingredients[0],
+          quantity: newQty,
+          unit: newUnit,
+          protein: newP,
+          carbs: newC,
+          fats: newF,
+        },
+      ];
+    }
+
+    setEditedEntry({
+      ...editedEntry,
+      protein: newP,
+      carbs: newC,
+      fats: newF,
+      ingredients: updatedIngredients,
+    });
+  };
+
+  const handleSingleQuantityChange = (newQty: number | undefined) => {
+    handleSingleQuantityUnitChange(newQty, singleUnit);
+  };
+
+  const handleSingleUnitChange = (newUnit: UnitType) => {
+    handleSingleQuantityUnitChange(singleQuantity, newUnit);
+  };
+
+  // Single-item / manual entry macro change
+  const handleSingleMacroChange = (
+    field: "protein" | "carbs" | "fats",
     value: number | undefined,
   ) => {
-    setEditedEntry((previous) =>
-      previous
-        ? {
-            ...previous,
-            [field]: roundValue(value ?? 0),
-          }
-        : null,
-    );
+    if (!editedEntry) return;
+    const numValue = roundValue(value ?? 0);
+
+    const updatedP = field === "protein" ? numValue : editedEntry.protein;
+    const updatedC = field === "carbs" ? numValue : editedEntry.carbs;
+    const updatedF = field === "fats" ? numValue : editedEntry.fats;
+
+    const currentQty = singleQuantity ?? 100;
+    const currentU = singleUnit;
+
+    setSingleBaseProtein(updatedP);
+    setSingleBaseCarbs(updatedC);
+    setSingleBaseFats(updatedF);
+    setSingleBaseQuantity(currentQty);
+    setSingleBaseUnit(currentU);
+
+    let updatedIngredients = editedEntry.ingredients;
+    if (editedEntry.ingredients?.length === 1) {
+      updatedIngredients = [
+        {
+          ...editedEntry.ingredients[0],
+          [field]: numValue,
+          baseProtein: updatedP,
+          baseCarbs: updatedC,
+          baseFats: updatedF,
+          baseQuantity: currentQty,
+          baseUnit: currentU,
+        },
+      ];
+    }
+
+    setEditedEntry({
+      ...editedEntry,
+      protein: updatedP,
+      carbs: updatedC,
+      fats: updatedF,
+      ingredients: updatedIngredients,
+    });
   };
 
-  // Reset the baseline only after persistence succeeds.
+  // Convert single item or manual entry to multi-ingredient meal
+  const handleConvertToMultiIngredient = () => {
+    if (!editedEntry) return;
+
+    let currentIngredients = editedEntry.ingredients ?? [];
+    if (currentIngredients.length === 0) {
+      const firstIng: Ingredient = {
+        name: editedEntry.mealName || "Ingredient 1",
+        protein: editedEntry.protein,
+        carbs: editedEntry.carbs,
+        fats: editedEntry.fats,
+        quantity: singleQuantity,
+        unit: singleUnit,
+        baseProtein: singleBaseProtein,
+        baseCarbs: singleBaseCarbs,
+        baseFats: singleBaseFats,
+        baseQuantity: singleBaseQuantity,
+        baseUnit: singleBaseUnit,
+      };
+      const secondIng: Ingredient = {
+        name: "",
+        protein: 0,
+        carbs: 0,
+        fats: 0,
+      };
+      currentIngredients = [firstIng, secondIng];
+    } else if (currentIngredients.length === 1) {
+      const secondIng: Ingredient = {
+        name: "",
+        protein: 0,
+        carbs: 0,
+        fats: 0,
+      };
+      currentIngredients = [...currentIngredients, secondIng];
+    }
+
+    const totals = calculateTotalsFromIngredients(currentIngredients);
+    setBaseIngredientsForScaling(currentIngredients);
+    setScaleFactor(1);
+    setShowIngredients(true);
+
+    setEditedEntry({
+      ...editedEntry,
+      ingredients: currentIngredients,
+      protein: totals.protein,
+      carbs: totals.carbs,
+      fats: totals.fats,
+    });
+  };
+
+  // Reset baseline only after persistence succeeds
   const handleSaveWithReset = () => {
     if (!formValid || !editedEntry) return;
 
@@ -174,7 +364,7 @@ export default function EditModal({
       });
   };
 
-  // Ingredient management functions
+  // Multi-ingredient management functions
   const addIngredient = () => {
     if (!editedEntry) return;
     const newIngredient: Ingredient = {
@@ -201,8 +391,21 @@ export default function EditModal({
 
   const removeIngredient = (index: number) => {
     if (!editedEntry) return;
-    const updatedIngredients = editedEntry.ingredients?.filter((_, index_) => index_ !== index) ?? [];
+    const updatedIngredients =
+      editedEntry.ingredients?.filter((_, index_) => index_ !== index) ?? [];
     const totals = calculateTotalsFromIngredients(updatedIngredients);
+
+    if (updatedIngredients.length === 1) {
+      const remaining = updatedIngredients[0];
+      setSingleQuantity(remaining.quantity ?? 100);
+      setSingleUnit((remaining.unit as UnitType) ?? "g");
+      setSingleBaseProtein(remaining.baseProtein ?? remaining.protein);
+      setSingleBaseCarbs(remaining.baseCarbs ?? remaining.carbs);
+      setSingleBaseFats(remaining.baseFats ?? remaining.fats);
+      setSingleBaseQuantity(remaining.baseQuantity ?? remaining.quantity ?? 100);
+      setSingleBaseUnit((remaining.baseUnit as UnitType) ?? (remaining.unit as UnitType) ?? "g");
+    }
+
     setBaseIngredientsForScaling(updatedIngredients);
     setScaleFactor(1);
     setEditedEntry({
@@ -217,74 +420,87 @@ export default function EditModal({
   const updateIngredient = (
     index: number,
     field: keyof Ingredient,
-    value: string | number | undefined
+    value: string | number | undefined,
   ) => {
     if (!editedEntry) return;
 
-    const updatedIngredients = editedEntry.ingredients?.map((ing, index_) => {
-      if (index_ !== index) return ing;
+    const updatedIngredients =
+      editedEntry.ingredients?.map((ing, index_) => {
+        if (index_ !== index) return ing;
 
-      let updatedIng = { ...ing };
+        let updatedIng = { ...ing };
 
-      // Handle quantity or unit change - recalculate macros from base values
-      if (field === 'quantity' || field === 'unit') {
-        const newQuantity = field === 'quantity' 
-          ? (typeof value === 'number' ? value : (value ? Number(value) : undefined))
-          : ing.quantity;
-        const newUnit = field === 'unit' ? String(value) : ing.unit;
+        if (field === "quantity" || field === "unit") {
+          const isPcs = (unit_?: string) =>
+            unit_ === "unit" ||
+            unit_ === "pcs" ||
+            unit_ === "pc" ||
+            unit_ === "piece" ||
+            unit_ === "pieces";
+          const newQuantity =
+            field === "quantity"
+              ? typeof value === "number"
+                ? value
+                : value
+                  ? Number(value)
+                  : undefined
+              : ing.quantity;
+          const newUnit = field === "unit" ? String(value) : ing.unit;
 
-        // Get base values - use stored base or current as base if not set
-        const baseQty = ing.baseQuantity ?? ing.quantity ?? 100;
-        const baseU = ing.baseUnit ?? ing.unit ?? 'g';
-        const baseP = ing.baseProtein ?? ing.protein;
-        const baseC = ing.baseCarbs ?? ing.carbs;
-        const baseF = ing.baseFats ?? ing.fats;
+          const defaultBase = isPcs(ing.unit) ? 1 : 100;
+          const baseQty = ing.baseQuantity ?? ing.quantity ?? defaultBase;
+          const baseU = ing.baseUnit ?? ing.unit ?? "g";
+          const baseP = ing.baseProtein ?? ing.protein;
+          const baseC = ing.baseCarbs ?? ing.carbs;
+          const baseF = ing.baseFats ?? ing.fats;
 
-        // Calculate scaling factor
-        const baseNormalized = normalizeQuantity(baseQty, baseU);
-        const newNormalized = normalizeQuantity(newQuantity ?? 100, newUnit ?? 'g');
+          const baseGrams = getGramsEquivalent(baseQty, baseU);
+          const targetGrams = getGramsEquivalent(
+            newQuantity ?? (isPcs(newUnit) ? 1 : 100),
+            newUnit ?? "g",
+          );
 
-        let localScaleFactor = 1;
-        if (baseNormalized.type === newNormalized.type && baseNormalized.value > 0) {
-          localScaleFactor = newNormalized.value / baseNormalized.value;
-        }
+          let localScaleFactor = 1;
+          if (baseGrams > 0) {
+            localScaleFactor = targetGrams / baseGrams;
+          }
 
-        // Update the ingredient with recalculated macros
-        updatedIng = {
-          ...updatedIng,
-          quantity: newQuantity,
-          unit: newUnit,
-          protein: roundValue(baseP * localScaleFactor),
-          carbs: roundValue(baseC * localScaleFactor),
-          fats: roundValue(baseF * localScaleFactor),
-        };
-      } else {
-        // Regular field update (name, protein, carbs, fats)
-        const stringFields = ['name', 'unit'];
-        const isStringField = stringFields.includes(field as string);
-        
-        updatedIng = {
-          ...updatedIng,
-          [field]: isStringField ? value : roundValue(Number(value) || 0),
-        };
-        
-        // If macros changed directly, update base values to track new reference
-        if (field === 'protein' || field === 'carbs' || field === 'fats') {
-          const currentQty = ing.quantity ?? 100;
-          const currentUnit = ing.unit ?? 'g';
           updatedIng = {
             ...updatedIng,
-            baseProtein: field === 'protein' ? roundValue(Number(value)) : ing.protein,
-            baseCarbs: field === 'carbs' ? roundValue(Number(value)) : ing.carbs,
-            baseFats: field === 'fats' ? roundValue(Number(value)) : ing.fats,
-            baseQuantity: currentQty,
-            baseUnit: currentUnit,
+            quantity: newQuantity,
+            unit: newUnit,
+            protein: roundValue(baseP * localScaleFactor),
+            carbs: roundValue(baseC * localScaleFactor),
+            fats: roundValue(baseF * localScaleFactor),
           };
-        }
-      }
+        } else {
+          const stringFields = ["name", "unit"];
+          const isStringField = stringFields.includes(field as string);
 
-      return updatedIng;
-    }) ?? [];
+          updatedIng = {
+            ...updatedIng,
+            [field]: isStringField ? value : roundValue(Number(value) || 0),
+          };
+
+          if (field === "protein" || field === "carbs" || field === "fats") {
+            const currentQty = ing.quantity ?? 100;
+            const currentUnit = ing.unit ?? "g";
+            updatedIng = {
+              ...updatedIng,
+              baseProtein:
+                field === "protein" ? roundValue(Number(value)) : ing.protein,
+              baseCarbs:
+                field === "carbs" ? roundValue(Number(value)) : ing.carbs,
+              baseFats:
+                field === "fats" ? roundValue(Number(value)) : ing.fats,
+              baseQuantity: currentQty,
+              baseUnit: currentUnit,
+            };
+          }
+        }
+
+        return updatedIng;
+      }) ?? [];
 
     const totals = calculateTotalsFromIngredients(updatedIngredients);
     setBaseIngredientsForScaling(updatedIngredients);
@@ -298,11 +514,14 @@ export default function EditModal({
     });
   };
 
-  const hasIngredients = editedEntry?.ingredients && editedEntry.ingredients.length > 0;
-
   // Scale all ingredients by a factor
   const handleScaleIngredients = (newFactor: number) => {
-    if (!editedEntry || !baseIngredientsForScaling || baseIngredientsForScaling.length === 0) return;
+    if (
+      !editedEntry ||
+      !baseIngredientsForScaling ||
+      baseIngredientsForScaling.length === 0
+    )
+      return;
 
     setScaleFactor(newFactor);
     const scaledIngredients = baseIngredientsForScaling.map((ing) => ({
@@ -310,7 +529,9 @@ export default function EditModal({
       protein: roundValue(ing.protein * newFactor),
       carbs: roundValue(ing.carbs * newFactor),
       fats: roundValue(ing.fats * newFactor),
-      quantity: ing.quantity ? roundValue(ing.quantity * newFactor) : undefined,
+      quantity: ing.quantity
+        ? roundValue(ing.quantity * newFactor)
+        : undefined,
     }));
 
     const totals = calculateTotalsFromIngredients(scaledIngredients);
@@ -360,20 +581,42 @@ export default function EditModal({
             protein={editedEntry.protein}
             carbs={editedEntry.carbs}
             fats={editedEntry.fats}
+            quantity={singleQuantity}
+            unit={singleUnit}
+            isMultiIngredient={isMultiIngredient}
             onMealNameChange={(value) => handleInputChange("mealName", value)}
-            onMacroChange={handleNumberChange}
+            onMacroChange={
+              isMultiIngredient
+                ? () => {}
+                : handleSingleMacroChange
+            }
+            onQuantityChange={
+              isMultiIngredient ? undefined : handleSingleQuantityChange
+            }
+            onUnitChange={
+              isMultiIngredient ? undefined : handleSingleUnitChange
+            }
+            onQuantityUnitChange={
+              isMultiIngredient ? undefined : handleSingleQuantityUnitChange
+            }
+            onAddIngredient={
+              isMultiIngredient ? undefined : handleConvertToMultiIngredient
+            }
           />
-          <IngredientsPanel
-            ingredients={editedEntry.ingredients ?? []}
-            hasIngredients={Boolean(hasIngredients)}
-            showIngredients={showIngredients}
-            scaleFactor={scaleFactor}
-            onToggle={() => setShowIngredients(!showIngredients)}
-            onScale={handleScaleIngredients}
-            onUpdateIngredient={updateIngredient}
-            onRemoveIngredient={removeIngredient}
-            onAddIngredient={addIngredient}
-          />
+
+          {isMultiIngredient && (
+            <IngredientsPanel
+              ingredients={editedEntry.ingredients ?? []}
+              hasIngredients
+              showIngredients={showIngredients}
+              scaleFactor={scaleFactor}
+              onToggle={() => setShowIngredients(!showIngredients)}
+              onScale={handleScaleIngredients}
+              onUpdateIngredient={updateIngredient}
+              onRemoveIngredient={removeIngredient}
+              onAddIngredient={addIngredient}
+            />
+          )}
         </div>
       </Modal>
     </>

--- a/frontend/src/features/macroTracking/components/EntryCard.tsx
+++ b/frontend/src/features/macroTracking/components/EntryCard.tsx
@@ -38,7 +38,9 @@ export const EntryCard = memo(
     onToggleSelection,
   }: EntryCardProps) => {
     const [isExpanded, setIsExpanded] = useState(false);
-    const hasIngredients = entry.ingredients && entry.ingredients.length > 0;
+    const hasIngredients = Boolean(
+      entry.ingredients && entry.ingredients.length > 1,
+    );
 
     return (
       <motion.div

--- a/frontend/src/features/macroTracking/components/edit-modal/MealDetailsSection.tsx
+++ b/frontend/src/features/macroTracking/components/edit-modal/MealDetailsSection.tsx
@@ -1,16 +1,28 @@
 import NumberField from "@/components/form/NumberField";
+import QuantityUnitField from "@/components/form/QuantityUnitField";
 import TextField from "@/components/form/TextField";
+import type { UnitType } from "@/features/macroTracking/utils/units";
 
 interface MealDetailsSectionProps {
   mealName: string;
   protein: number;
   carbs: number;
   fats: number;
+  quantity?: number;
+  unit?: string;
+  isMultiIngredient: boolean;
   onMealNameChange: (value: string) => void;
   onMacroChange: (
     field: "protein" | "carbs" | "fats",
     value: number | undefined,
   ) => void;
+  onQuantityChange?: (value: number | undefined) => void;
+  onUnitChange?: (value: UnitType) => void;
+  onQuantityUnitChange?: (
+    quantity: number | undefined,
+    unit: UnitType,
+  ) => void;
+  onAddIngredient?: () => void;
 }
 
 export default function MealDetailsSection({
@@ -18,8 +30,15 @@ export default function MealDetailsSection({
   protein,
   carbs,
   fats,
+  quantity,
+  unit = "g",
+  isMultiIngredient,
   onMealNameChange,
   onMacroChange,
+  onQuantityChange,
+  onUnitChange,
+  onQuantityUnitChange,
+  onAddIngredient,
 }: MealDetailsSectionProps) {
   const calories = Math.round(protein * 4 + carbs * 4 + fats * 9);
 
@@ -30,7 +49,9 @@ export default function MealDetailsSection({
           Meal Details
         </p>
         <p className="text-xs text-muted">
-          Totals update from ingredients below.
+          {isMultiIngredient
+            ? "Totals update from ingredients below."
+            : "Adjust quantity, unit, or macros directly."}
         </p>
       </div>
 
@@ -42,6 +63,17 @@ export default function MealDetailsSection({
         required
       />
 
+      {!isMultiIngredient && onQuantityChange && onUnitChange && (
+        <QuantityUnitField
+          label="Quantity & Unit"
+          quantity={quantity}
+          unit={(unit as UnitType) || "g"}
+          onQuantityChange={onQuantityChange}
+          onUnitChange={onUnitChange}
+          onQuantityUnitChange={onQuantityUnitChange}
+        />
+      )}
+
       <div className="grid gap-4 md:grid-cols-3">
         <NumberField
           label="Protein (g)"
@@ -49,6 +81,7 @@ export default function MealDetailsSection({
           onChange={(value) => onMacroChange("protein", value)}
           min={0}
           step={0.1}
+          disabled={isMultiIngredient}
         />
         <NumberField
           label="Carbs (g)"
@@ -56,6 +89,7 @@ export default function MealDetailsSection({
           onChange={(value) => onMacroChange("carbs", value)}
           min={0}
           step={0.1}
+          disabled={isMultiIngredient}
         />
         <NumberField
           label="Fats (g)"
@@ -63,6 +97,7 @@ export default function MealDetailsSection({
           onChange={(value) => onMacroChange("fats", value)}
           min={0}
           step={0.1}
+          disabled={isMultiIngredient}
         />
       </div>
 
@@ -100,6 +135,31 @@ export default function MealDetailsSection({
           </p>
         </div>
       </div>
+
+      {!isMultiIngredient && onAddIngredient && (
+        <div className="pt-2">
+          <button
+            type="button"
+            onClick={onAddIngredient}
+            className="flex w-full items-center justify-center gap-2 rounded-2xl border border-dashed border-border/80 bg-surface-2/30 py-3 text-sm font-medium text-foreground transition-[background-color,border-color,color,transform] duration-200 hover:border-primary/40 hover:bg-primary/5 hover:text-primary focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:outline-none active:scale-[0.98]"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 4v16m8-8H4"
+              />
+            </svg>
+            Add Ingredient (Convert to Multi-Ingredient Meal)
+          </button>
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Changes
- **Edit Entry Modal Refactor**: Enabled Quantity & Unit controls for single items and manual entries with proportional macro scaling.
- **Cross-Unit & Pieces Scaling**: Normalized unit aliases (`pcs`, `pc`, `piece`) and implemented proportional cross-unit conversions between pieces, weight (`g`, `kg`, `oz`, `lbs`), and volume (`ml`, `l`, `fl oz`, `cups`).
- **History Card Cleanup**: Single-item entries no longer display ingredients expander toggle or sub-list in history cards/tables.
- **Version Bump**: Bumped app version to `2.3.0` in package manifests and hero section.