### PR TITLE
feat: Reporting Analytics Refactor, Trend Analysis & Version Bump v2.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ report.txt
 output.json
 rewrite.ts
 scorecard.png
+.serena

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macrotrackr-backend",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Backend API for Macro Trackr application",
   "module": "src/index.ts",
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "macrotrackr-frontend",
   "private": true,
-  "version": "2.3.0",
+  "version": "2.4.0",
   "type": "module",
   "scripts": {
     "dev": "bunx vite",

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -2,85 +2,85 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://macrotrackr.com/</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/blog</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/login</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/register</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/reset-password</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/privacy</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/terms</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/blog/v2-launch-complete-ui-overhaul</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/blog/how-to-estimate-restaurant-meals-without-guessing-blind</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/blog/why-weekly-averages-beat-perfect-days</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/blog/macro-tracking-tips-for-beginners</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/blog/understanding-protein-intake</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/blog/meal-prep-for-macro-tracking</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/blog/carbs-fats-balance</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/frontend/src/components/ui/Icons.tsx
+++ b/frontend/src/components/ui/Icons.tsx
@@ -17,11 +17,14 @@ import {
   ChevronLeft,
   ChevronRight,
   ChevronUp,
+  CircleHelp,
   CircleQuestionMark,
   Clipboard,
   Coffee,
+  Copy,
   Download,
   Droplet,
+  Drumstick,
   Dumbbell,
   Edit,
   ExternalLink,
@@ -34,6 +37,7 @@ import {
   Info,
   Lightbulb,
   Link,
+  Link2,
   Loader,
   Lock,
   LogOut,
@@ -44,6 +48,8 @@ import {
   Minus,
   Moon,
   MoreVertical,
+  MoveLeft,
+  PieChart,
   Plus,
   PlusCircle,
   Ruler,
@@ -53,6 +59,7 @@ import {
   Settings,
   ShieldCheck,
   SmilePlus,
+  Sparkles,
   Star,
   Sun,
   Target,
@@ -61,7 +68,9 @@ import {
   TrendingUp,
   Unlock,
   User,
+  Wheat,
   X,
+  XCircle,
   Zap,
 } from "lucide-react";
 
@@ -176,6 +185,16 @@ export const ProteinIcon = createIcon(Beef);
 export const LinkIcon = createIcon(Link);
 export const ExternalLinkIcon = createIcon(ExternalLink);
 export const ShieldCheckIcon = createIcon(ShieldCheck);
+export const DrumstickIcon = createIcon(Drumstick);
+export const WheatIcon = createIcon(Wheat);
+export const CarbIcon = createIcon(Wheat);
+export const XCircleIcon = createIcon(XCircle);
+export const PieChartIcon = createIcon(PieChart);
+export const MoveLeftIcon = createIcon(MoveLeft);
+export const CircleHelpIcon = createIcon(CircleHelp);
+export const SparklesIcon = createIcon(Sparkles);
+export const CopyIcon = createIcon(Copy);
+export const Link2Icon = createIcon(Link2);
 
 // Social Provider Icons
 const GOOGLE_BRAND_COLORS = {

--- a/frontend/src/components/ui/InfoTooltip.tsx
+++ b/frontend/src/components/ui/InfoTooltip.tsx
@@ -1,9 +1,10 @@
-import { useEffect,useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { Info } from "lucide-react";
-import { AnimatePresence,motion } from "motion/react";
+import { AnimatePresence, motion } from "motion/react";
 
 import { cn } from "@/lib/classnameUtilities";
+
+import { InfoIcon } from "./Icons";
 
 export function InfoTooltip({ text, className }: { text: string; className?: string }) {
   const [isVisible, setIsVisible] = useState(false);
@@ -31,7 +32,7 @@ export function InfoTooltip({ text, className }: { text: string; className?: str
         onMouseLeave={() => setIsVisible(false)}
         onClick={() => setIsVisible(!isVisible)}
       >
-        <Info className="h-4 w-4 cursor-pointer text-muted transition-colors hover:text-foreground" />
+        <InfoIcon className="h-4 w-4 cursor-pointer text-muted transition-colors hover:text-foreground" />
       </button>
 
       {globalThis.window !== undefined &&

--- a/frontend/src/components/ui/NotFoundPage.tsx
+++ b/frontend/src/components/ui/NotFoundPage.tsx
@@ -1,7 +1,8 @@
 import { Link } from "@tanstack/react-router";
-import { MoveLeft } from "lucide-react";
 
 import Button from "@/components/ui/Button";
+
+import { MoveLeftIcon } from "./Icons";
 
 export function NotFoundPage() {
   return (
@@ -17,7 +18,7 @@ export function NotFoundPage() {
       </p>
       <Link to="/">
         <Button size="lg" className="flex items-center gap-2">
-          <MoveLeft className="h-4 w-4" />
+          <MoveLeftIcon className="h-4 w-4" />
           Back to Home
         </Button>
       </Link>

--- a/frontend/src/features/landing/components/BlogNotFound.tsx
+++ b/frontend/src/features/landing/components/BlogNotFound.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router";
-import { ArrowLeft } from "lucide-react";
 
+import { BackIcon } from "@/components/ui";
 import Footer from "@/features/landing/components/Footer";
 import Header from "@/features/landing/components/Header";
 
@@ -22,7 +22,7 @@ export function BlogNotFound() {
             search={{ category: undefined, tag: undefined, q: undefined }}
             className="group inline-flex min-h-11 items-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-medium text-muted transition-colors duration-200 hover:border-primary/40 hover:bg-surface-2 hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none"
           >
-            <ArrowLeft className="h-4 w-4 transition-transform group-hover:-translate-x-1" />
+            <BackIcon className="h-4 w-4 transition-transform group-hover:-translate-x-1" />
             Back to the blog
           </Link>
         </div>

--- a/frontend/src/features/landing/components/TrustIndicators.tsx
+++ b/frontend/src/features/landing/components/TrustIndicators.tsx
@@ -1,21 +1,22 @@
 import React from "react";
-import { CircleHelp, ShieldCheck, Sparkles } from "lucide-react";
+
+import { CircleHelpIcon, ShieldCheckIcon, SparklesIcon } from "@/components/ui";
 
 const indicators = [
   {
-    icon: <ShieldCheck className="h-6 w-6 text-success" aria-hidden="true" />,
+    icon: <ShieldCheckIcon className="h-6 w-6 text-success" aria-hidden="true" />,
     bg: "bg-success/10 border border-success/20",
     title: "Secure by Default",
     desc: "Your account and nutrition data stay protected.",
   },
   {
-    icon: <CircleHelp className="h-6 w-6 text-primary" aria-hidden="true" />,
+    icon: <CircleHelpIcon className="h-6 w-6 text-primary" aria-hidden="true" />,
     bg: "bg-primary/10 border border-primary/20",
     title: "Helpful Support",
     desc: "Get clear answers when you need them.",
   },
   {
-    icon: <Sparkles className="h-6 w-6 text-primary" aria-hidden="true" />,
+    icon: <SparklesIcon className="h-6 w-6 text-primary" aria-hidden="true" />,
     bg: "bg-primary/10 border border-primary/20",
     title: "Actively Improved",
     desc: "We ship practical updates based on real feedback.",

--- a/frontend/src/features/landing/pages/BlogArticlePage.tsx
+++ b/frontend/src/features/landing/pages/BlogArticlePage.tsx
@@ -1,13 +1,12 @@
 import React, { Suspense, useCallback, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { Link, useParams } from "@tanstack/react-router";
-import { ArrowLeft, Check, Copy, Link2 } from "lucide-react";
 import { motion, useReducedMotion, useScroll, useSpring } from "motion/react";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 
-import { ContentImage } from "@/components/ui";
+import { BackIcon, CheckIcon, ContentImage, CopyIcon, Link2Icon } from "@/components/ui";
 import { MealGroupingFlow } from "@/features/landing/components/AnimatedUserFlow";
 import BackToTopButton from "@/features/landing/components/BackToTopButton";
 import { BlogNotFound } from "@/features/landing/components/BlogNotFound";
@@ -110,12 +109,12 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
         >
           {copied ? (
             <>
-              <Check className="h-3.5 w-3.5 text-success" />
+              <CheckIcon className="h-3.5 w-3.5 text-success" />
               <span className="text-success">Copied!</span>
             </>
           ) : (
             <>
-              <Copy className="h-3.5 w-3.5" />
+              <CopyIcon className="h-3.5 w-3.5" />
               <span>Copy</span>
             </>
           )}
@@ -336,7 +335,7 @@ const BlogArticlePage: React.FC = () => {
                 search={{ category: undefined, tag: undefined, q: undefined }}
                 className="group inline-flex min-h-11 items-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-medium text-muted transition-colors duration-200 hover:border-primary/40 hover:bg-surface-2 hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none"
               >
-                <ArrowLeft className="h-4 w-4 transition-transform group-hover:-translate-x-1" />
+                <BackIcon className="h-4 w-4 transition-transform group-hover:-translate-x-1" />
                 Back to the blog
               </Link>
             </motion.div>
@@ -371,9 +370,9 @@ const BlogArticlePage: React.FC = () => {
                 className="inline-flex min-h-11 items-center gap-2 rounded-md border border-border/60 px-3 py-2 transition-colors duration-200 hover:bg-surface hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none"
               >
                 {copiedLink ? (
-                  <Check className="h-4 w-4 text-success" />
+                  <CheckIcon className="h-4 w-4 text-success" />
                 ) : (
-                  <Link2 className="h-4 w-4" />
+                  <Link2Icon className="h-4 w-4" />
                 )}
                 {copiedLink ? "Link copied" : "Copy article link"}
               </button>

--- a/frontend/src/features/macroTracking/components/DesktopEntryTable.tsx
+++ b/frontend/src/features/macroTracking/components/DesktopEntryTable.tsx
@@ -333,6 +333,7 @@ const DesktopEntryTable = memo(
           const parentDate = data.parentDate ?? data.date;
 
           const entryKey = data.entries[0]?.clientId ?? data.entries[0]?.id;
+
           return data.isGroup
             ? `group-${data.date}`
             : `entry-${entryKey}-${parentDate}`;

--- a/frontend/src/features/reporting/components/MacroSummaryStat.tsx
+++ b/frontend/src/features/reporting/components/MacroSummaryStat.tsx
@@ -19,31 +19,69 @@ interface MacroSummaryStatsProps {
     carbsPercentage: number;
     fatsPercentage: number;
   };
+  trackedDays?: number;
+  totalDays?: number;
+  averages?: {
+    calories: number;
+    protein: number;
+    carbs: number;
+    fats: number;
+  };
 }
 
-// Modified function to accept calorieTarget for percentage calculation
+// Modified function to accept calorieTarget and averages/trackedDays for percentage calculation
 function calculateAverageMacros(
   data: MacroSummaryStatsProps["data"],
   calorieTarget: number,
+  averagesFromProps?: MacroSummaryStatsProps["averages"],
+  trackedDaysCount?: number,
 ) {
-  if (data.length === 0) return;
-  const totalMacros = { protein: 0, carbs: 0, fats: 0, calories: 0 };
-  for (const entry of data) {
-    totalMacros.protein += entry.protein;
-    totalMacros.carbs += entry.carbs;
-    totalMacros.fats += entry.fats;
-    totalMacros.calories += entry.calories;
-  }
-  const numberDays = data.length;
-  const avgGrams = {
-    protein: totalMacros.protein / numberDays,
-    carbs: totalMacros.carbs / numberDays,
-    fats: totalMacros.fats / numberDays,
-  };
-  const avgConsumedCalories = totalMacros.calories / numberDays;
+  if (data.length === 0 && !averagesFromProps) return;
 
-  // Calculate percentages based on average grams relative to the calorie TARGET
-  const divisor = calorieTarget > 0 ? calorieTarget : 2000;
+  let avgGrams = { protein: 0, carbs: 0, fats: 0 };
+  let avgConsumedCalories = 0;
+
+  if (averagesFromProps) {
+    avgGrams = {
+      protein: averagesFromProps.protein,
+      carbs: averagesFromProps.carbs,
+      fats: averagesFromProps.fats,
+    };
+    avgConsumedCalories = averagesFromProps.calories;
+  } else {
+    const totalMacros = { protein: 0, carbs: 0, fats: 0, calories: 0 };
+    for (const entry of data) {
+      totalMacros.protein += entry.protein;
+      totalMacros.carbs += entry.carbs;
+      totalMacros.fats += entry.fats;
+      totalMacros.calories += entry.calories;
+    }
+    const numberDays =
+      trackedDaysCount && trackedDaysCount > 0
+        ? trackedDaysCount
+        : data.length > 0
+          ? data.length
+          : 1;
+    avgGrams = {
+      protein: totalMacros.protein / numberDays,
+      carbs: totalMacros.carbs / numberDays,
+      fats: totalMacros.fats / numberDays,
+    };
+    avgConsumedCalories = totalMacros.calories / numberDays;
+  }
+
+  // Calculate percentages based on average grams relative to consumed calories ratio
+  const totalMacroCalories =
+    avgGrams.protein * 4 + avgGrams.carbs * 4 + avgGrams.fats * 9;
+  const divisor =
+    avgConsumedCalories > 0
+      ? avgConsumedCalories
+      : totalMacroCalories > 0
+        ? totalMacroCalories
+        : calorieTarget > 0
+          ? calorieTarget
+          : 2000;
+
   const proteinPct = Math.round(((avgGrams.protein * 4) / divisor) * 100);
   const carbsPct = Math.round(((avgGrams.carbs * 4) / divisor) * 100);
   const fatsPct = Math.round(((avgGrams.fats * 9) / divisor) * 100);
@@ -182,6 +220,9 @@ export default function MacroSummaryStats({
   data,
   calorieTarget,
   macroTarget,
+  trackedDays,
+  _totalDays,
+  averages,
 }: MacroSummaryStatsProps) {
   const effectiveCalorieTarget = calorieTarget || 2000;
 
@@ -210,27 +251,29 @@ export default function MacroSummaryStats({
       carbs: carbsG,
       fats: fatsG,
     };
-    // Dependency updated
   }, [effectiveCalorieTarget, TARGET_MACROS]);
 
-  // Average calories over selected range (still based on actual consumption)
-  const avgCalories = useMemo(() => {
-    if (data.length === 0) return 0;
-    const total = data.reduce((accumulator, d) => accumulator + d.calories, 0);
-
-    return Math.round(total / data.length);
-  }, [data]);
-
   // Macro averages (main display) over selected range
-  // Pass effectiveCalorieTarget to the calculation function
   const macroAvg = useMemo(() => {
-    return calculateAverageMacros(data, effectiveCalorieTarget);
-    // Dependency updated
-  }, [data, effectiveCalorieTarget]);
+    return calculateAverageMacros(
+      data,
+      effectiveCalorieTarget,
+      averages,
+      trackedDays,
+    );
+  }, [data, effectiveCalorieTarget, averages, trackedDays]);
 
-  if (!macroAvg) return; // Updated early return condition
+  const avgCalories = macroAvg?.calories ?? 0;
 
-  const cardClasses = "px-4 py-3 border border-border/40 bg-surface transition-colors duration-200 hover:border-white/20";
+  if (!macroAvg) return null;
+
+  const cardClasses =
+    "px-4 py-3 border border-border/40 bg-surface transition-colors duration-200 hover:border-white/20";
+
+  const trackedSubtext =
+    trackedDays !== undefined
+      ? `Avg over ${trackedDays} tracked ${trackedDays === 1 ? "day" : "days"}`
+      : null;
 
   return (
     <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -241,6 +284,11 @@ export default function MacroSummaryStats({
             <span className="text-sm font-semibold text-foreground">
               Calories
             </span>
+            {trackedSubtext && (
+              <span className="text-[10px] text-muted-foreground">
+                {trackedSubtext}
+              </span>
+            )}
           </div>
           <div className="mb-2 space-y-1">
             <div className="flex items-baseline justify-between">

--- a/frontend/src/features/reporting/components/MealTimeBreakdown.tsx
+++ b/frontend/src/features/reporting/components/MealTimeBreakdown.tsx
@@ -36,10 +36,12 @@ const CustomDonutTooltip = ({
 }) => {
   if (active && payload && payload.length > 0) {
     const data = payload[0].payload;
-    const value = data.value;
-    const unit =
-      selectedStat === "count" ? " meals" : ` ${getUnitForStat(selectedStat)}`;
-    const color = payload[0].payload.fill ?? payload[0].color;
+    const value = data.value as number;
+    const isCount = selectedStat === "count";
+    const unit = isCount
+      ? " meals"
+      : ` ${getUnitForStat(selectedStat)}/day`;
+    const color = (payload[0].payload.fill ?? payload[0].color) as string;
 
     return (
       <div className="rounded-lg border border-border/50 bg-surface-2 p-3 shadow-xl">
@@ -48,7 +50,7 @@ const CustomDonutTooltip = ({
             className="h-3 w-3 rounded-full"
             style={{ backgroundColor: color }}
           />
-          <p className="font-semibold text-foreground">{data.name}</p>
+          <p className="font-semibold text-foreground">{data.name as string}</p>
         </div>
         <div className="mt-2 flex flex-col gap-1">
           <p className="text-sm text-muted">
@@ -58,7 +60,7 @@ const CustomDonutTooltip = ({
             {unit}
           </p>
           <p className="text-xs text-muted/80">
-            {data.percentage}% of daily total
+            {data.percentage as number}% of total intake
           </p>
         </div>
       </div>

--- a/frontend/src/features/reporting/components/TrendDisplay.tsx
+++ b/frontend/src/features/reporting/components/TrendDisplay.tsx
@@ -3,71 +3,130 @@ import { Area, AreaChart, ResponsiveContainer } from "recharts";
 import AnimatedNumber from "@/components/animation/AnimatedNumber";
 import { TrendIcon } from "@/components/ui";
 
-import type { TrendDisplayProps as TrendDisplayProps } from "../types/insightsTypes";
+import type { TrendDisplayProps } from "../types/insightsTypes";
 
-export default function TrendDisplay({ label, trend, data, dataKey }: TrendDisplayProps) {
-  // Chart colors - use CSS variables from design system (recharts renders in DOM so var() works)
+export default function TrendDisplay({
+  label,
+  trend,
+  data,
+  dataKey,
+  icon,
+  iconBgColor = "bg-primary/10",
+  unit = "g",
+}: TrendDisplayProps) {
   const colorMap: Record<string, string> = {
     up: "var(--color-success, #1ed760)",
     down: "var(--color-error, #e91429)",
     stable: "var(--text-muted, #b3b3b3)",
   };
-  const color = colorMap[trend.direction] ?? colorMap.stable;
+  const strokeColor = colorMap[trend.direction] ?? colorMap.stable;
 
-  const gradientId = `sparkline-${dataKey ?? label.toLowerCase().replaceAll(/\s+/g, '-')}`;
+  const gradientId = `sparkline-${dataKey ?? label.toLowerCase().replaceAll(/\s+/g, "-")}`;
+
+  const hasStats =
+    trend.direction !== "insufficient" &&
+    typeof trend.lastAvg === "number" &&
+    typeof trend.firstAvg === "number";
 
   return (
-    <div className="flex flex-col border-b border-border/40 pb-5 last:border-0 last:pb-0">
-      <div className="mb-3 flex items-center justify-between">
-        <div className="flex flex-col">
-          <span className="text-sm font-semibold tracking-tight text-foreground/90">{label}</span>
-          <span className="mt-0.5 text-xs text-muted">
-            {trend.message}
+    <div className="flex flex-col justify-between rounded-xl bg-surface-2/40 p-3.5 border border-border/30 transition-colors hover:border-border/60">
+      {/* Header: Icon + Title & Direction Badge */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          {icon && (
+            <div
+              className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${iconBgColor}`}
+            >
+              {icon}
+            </div>
+          )}
+          <span className="text-xs font-semibold tracking-tight text-foreground/90 uppercase">
+            {label}
           </span>
         </div>
-        
-        <div className="flex items-center rounded-lg border border-border/40 bg-surface-2 px-2.5 py-1.5 text-sm font-medium">
-          <TrendIcon direction={trend.direction} />{" "}
-          <span className="ml-1.5 text-foreground">
+
+        <div className="flex items-center gap-1 rounded-md border border-border/40 bg-surface-2/80 px-2 py-0.5 text-xs font-medium">
+          <TrendIcon direction={trend.direction} />
+          <span className="text-foreground">
             {trend.direction === "stable" ? (
               "Stable"
             ) : trend.direction === "insufficient" ? (
               "N/A"
             ) : (
-              <div className="flex items-center gap-1">
-                <AnimatedNumber
-                  value={trend.percentage}
-                  toFixedValue={0}
-                  suffix="%"
-                  duration={0.6}
-                />
-              </div>
+              <AnimatedNumber
+                value={trend.percentage}
+                toFixedValue={0}
+                suffix="%"
+                duration={0.5}
+              />
             )}
           </span>
         </div>
       </div>
 
-      {/* Sparkline */}
-      {data && data.length > 0 && dataKey && trend.direction !== "insufficient" && (
-        <div className="mt-1 h-12 w-full">
+      {/* Main Metric Value & Baseline Change */}
+      <div className="my-2.5 flex items-baseline justify-between">
+        <div>
+          {hasStats ? (
+            <div className="flex items-baseline gap-1">
+              <span className="text-xl font-bold tracking-tight text-foreground">
+                <AnimatedNumber
+                  value={trend.lastAvg!}
+                  toFixedValue={0}
+                  duration={0.5}
+                />
+              </span>
+              <span className="text-xs font-medium text-muted">
+                {trend.unit ?? unit}/d
+              </span>
+            </div>
+          ) : (
+            <span className="text-xs text-muted leading-tight block max-w-[150px]">
+              {trend.message}
+            </span>
+          )}
+        </div>
+
+        {hasStats && trend.delta !== undefined && (
+          <span
+            className={`text-xs font-medium ${
+              trend.delta > 0
+                ? "text-success"
+                : trend.delta < 0
+                  ? "text-error"
+                  : "text-muted"
+            }`}
+          >
+            {trend.delta > 0 ? `+${trend.delta}` : trend.delta} {trend.unit ?? unit}
+          </span>
+        )}
+      </div>
+
+      {/* Micro Sparkline */}
+      {data && data.length > 0 && dataKey && trend.direction !== "insufficient" ? (
+        <div className="h-9 w-full">
           <ResponsiveContainer width="100%" height="100%">
-            <AreaChart data={data} margin={{ top: 5, right: 0, left: 0, bottom: 0 }}>
+            <AreaChart data={data} margin={{ top: 2, right: 0, left: 0, bottom: 0 }}>
               <defs>
                 <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor={color} stopOpacity={0.3} />
-                  <stop offset="95%" stopColor={color} stopOpacity={0} />
+                  <stop offset="5%" stopColor={strokeColor} stopOpacity={0.35} />
+                  <stop offset="95%" stopColor={strokeColor} stopOpacity={0} />
                 </linearGradient>
               </defs>
-              <Area 
-                type="monotone" 
-                dataKey={dataKey} 
-                stroke={color} 
-                strokeWidth={2}
-                fill={`url(#${gradientId})`} 
+              <Area
+                type="monotone"
+                dataKey={dataKey}
+                stroke={strokeColor}
+                strokeWidth={1.5}
+                fill={`url(#${gradientId})`}
                 isAnimationActive
               />
             </AreaChart>
           </ResponsiveContainer>
+        </div>
+      ) : (
+        <div className="h-9 w-full flex items-center justify-center rounded bg-surface/20 text-[10px] text-muted/60">
+          No sparkline
         </div>
       )}
     </div>

--- a/frontend/src/features/reporting/components/TrendsChartSection.tsx
+++ b/frontend/src/features/reporting/components/TrendsChartSection.tsx
@@ -1,9 +1,9 @@
 import { useMemo, useState } from "react";
-import { Flame, PieChart } from "lucide-react";
 
 import ChartCard from "@/components/chart/ChartCard";
 import type { ChartDataPoint, LineConfig } from "@/components/chart/ChartTypes";
 import LineChartComponent from "@/components/chart/LineChartComponent";
+import { CalorieIcon, PieChartIcon } from "@/components/ui";
 import TabBar from "@/components/ui/TabBar";
 
 interface TrendsChartSectionProps {
@@ -32,7 +32,7 @@ export default function TrendsChartSection({
         key: "calories",
         label: (
           <div className="flex items-center gap-1.5 px-1">
-            <Flame className="h-3.5 w-3.5 text-amber-500" />
+            <CalorieIcon className="h-3.5 w-3.5 text-amber-500" />
             <span>Calories</span>
           </div>
         ),
@@ -41,7 +41,7 @@ export default function TrendsChartSection({
         key: "macros",
         label: (
           <div className="flex items-center gap-1.5 px-1">
-            <PieChart className="h-3.5 w-3.5 text-blue-500" />
+            <PieChartIcon className="h-3.5 w-3.5 text-blue-500" />
             <span>Macros</span>
           </div>
         ),

--- a/frontend/src/features/reporting/components/UnifiedInsights.tsx
+++ b/frontend/src/features/reporting/components/UnifiedInsights.tsx
@@ -1,10 +1,19 @@
 import { useMemo } from "react";
-import { Flame, Target, TrendingUp, XCircle } from "lucide-react";
 import { motion } from "motion/react";
 
 import AnimatedNumber from "@/components/animation/AnimatedNumber";
 import CardContainer from "@/components/form/CardContainer";
-import { LoadingSpinner } from "@/components/ui";
+import {
+  CalorieIcon,
+  DropletIcon,
+  DrumstickIcon,
+  LightningIcon,
+  LoadingSpinner,
+  TargetIcon,
+  TrendingUpIcon,
+  WheatIcon,
+  XCircleIcon,
+} from "@/components/ui";
 import { InfoTooltip } from "@/components/ui/InfoTooltip";
 import { RadialProgress } from "@/components/ui/RadialProgress";
 
@@ -16,6 +25,7 @@ import {
   calculateMacroBalance,
   calculateMacroDensity,
   calculateTrend,
+  generateOverallTrendSummary,
 } from "../utils/insightsCalculations";
 import {
   getTextColorByScore,
@@ -55,6 +65,17 @@ function UnifiedInsights({
         ? dailySeriesForRange
         : aggregatedData;
 
+      const caloriesTrend = calculateTrend(aggregatedData, "calories");
+      const proteinTrend = calculateTrend(aggregatedData, "protein");
+      const carbsTrend = calculateTrend(aggregatedData, "carbs");
+      const fatsTrend = calculateTrend(aggregatedData, "fats");
+      const overallTrendMessage = generateOverallTrendSummary(
+        caloriesTrend,
+        proteinTrend,
+        carbsTrend,
+        fatsTrend,
+      );
+
       return {
         consistencyScore: calculateConsistencyScore(
           Array.isArray(dailySeriesForRange)
@@ -63,8 +84,11 @@ function UnifiedInsights({
           denominator,
         ),
         macroBalance: calculateMacroBalance(averages, macroTarget),
-        caloriesTrend: calculateTrend(aggregatedData, "calories"),
-        proteinTrend: calculateTrend(aggregatedData, "protein"),
+        caloriesTrend,
+        proteinTrend,
+        carbsTrend,
+        fatsTrend,
+        overallTrendMessage,
         dataQuality: calculateDataQuality(dataForQuality, denominator),
         macroDensity: calculateMacroDensity(averages),
       };
@@ -114,6 +138,9 @@ function UnifiedInsights({
     macroBalance,
     caloriesTrend,
     proteinTrend,
+    carbsTrend,
+    fatsTrend,
+    overallTrendMessage,
     dataQuality,
     macroDensity,
   } = insights;
@@ -122,19 +149,7 @@ function UnifiedInsights({
     <div className="flex flex-col gap-6">
       <div className="flex items-center space-x-3">
         <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary">
-          <svg
-            className="h-4 w-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              d="M13 10V3L4 14h7v7l9-11h-7z"
-            />
-          </svg>
+          <LightningIcon className="h-4 w-4" />
         </div>
         <h2 className="text-xl font-bold tracking-tight text-foreground/90">
           Insights
@@ -287,39 +302,40 @@ function UnifiedInsights({
               variant="interactive"
               className="flex h-full flex-col p-5"
             >
-              <div className="mb-4 flex items-center gap-2">
-                <h3 className="text-sm font-semibold tracking-tight text-foreground/90 uppercase">
-                  Tracking Analysis
-                </h3>
-                <InfoTooltip text="Evaluates how regularly and completely you log your meals over the selected period." />
-              </div>
-
-              {/* Days Tracked Header */}
-              <div className="mb-4 flex items-baseline gap-1">
-                <span className="text-3xl font-bold text-foreground">
-                  <AnimatedNumber
-                    value={
-                      typeof dataQuality.daysLogged === "number"
-                        ? dataQuality.daysLogged
-                        : 0
-                    }
-                    toFixedValue={0}
-                    duration={0.5}
-                  />
-                </span>
-                <span className="text-lg text-muted/40">/</span>
-                <span className="text-lg text-muted">
-                  <AnimatedNumber
-                    value={
-                      typeof dataQuality.totalDaysInPeriod === "number"
-                        ? dataQuality.totalDaysInPeriod
-                        : 0
-                    }
-                    toFixedValue={0}
-                    duration={0.5}
-                  />
-                </span>
-                <span className="ml-2 text-sm text-muted">days tracked</span>
+              <div className="mb-4 flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <h3 className="text-sm font-semibold tracking-tight text-foreground/90 uppercase">
+                    Tracking Analysis
+                  </h3>
+                  <InfoTooltip text="Evaluates how regularly and completely you log your meals over the selected period." />
+                </div>
+                {/* Days Tracked Badge */}
+                <div className="flex items-center gap-1.5 rounded-md bg-surface-2/80 px-2.5 py-1 text-xs font-medium text-foreground">
+                  <span className="font-bold text-foreground">
+                    <AnimatedNumber
+                      value={
+                        typeof dataQuality.daysLogged === "number"
+                          ? dataQuality.daysLogged
+                          : 0
+                      }
+                      toFixedValue={0}
+                      duration={0.5}
+                    />
+                  </span>
+                  <span className="text-muted/50">/</span>
+                  <span className="text-muted">
+                    <AnimatedNumber
+                      value={
+                        typeof dataQuality.totalDaysInPeriod === "number"
+                          ? dataQuality.totalDaysInPeriod
+                          : 0
+                      }
+                      toFixedValue={0}
+                      duration={0.5}
+                    />
+                  </span>
+                  <span className="text-muted">tracked</span>
+                </div>
               </div>
 
               {/* Stats Grid 2x2 */}
@@ -327,7 +343,7 @@ function UnifiedInsights({
                 {/* Current Streak */}
                 <div className="flex flex-col items-center justify-center gap-1 rounded-lg bg-surface-2/50 p-3">
                   <div className="flex h-8 w-8 items-center justify-center rounded-full bg-orange-500/10">
-                    <Flame className="h-4 w-4 text-orange-500" />
+                    <CalorieIcon className="h-4 w-4 text-orange-500" />
                   </div>
                   <p className="text-2xl font-bold text-foreground">
                     <AnimatedNumber
@@ -344,7 +360,7 @@ function UnifiedInsights({
                 {/* Best Streak */}
                 <div className="flex flex-col items-center justify-center gap-1 rounded-lg bg-surface-2/50 p-3">
                   <div className="flex h-8 w-8 items-center justify-center rounded-full bg-success/10">
-                    <TrendingUp className="h-4 w-4 text-success" />
+                    <TrendingUpIcon className="h-4 w-4 text-success" />
                   </div>
                   <p className="text-2xl font-bold text-foreground">
                     <AnimatedNumber
@@ -361,7 +377,7 @@ function UnifiedInsights({
                 {/* Missed Days */}
                 <div className="flex flex-col items-center justify-center gap-1 rounded-lg bg-surface-2/50 p-3">
                   <div className="flex h-8 w-8 items-center justify-center rounded-full bg-error/10">
-                    <XCircle className="h-4 w-4 text-error" />
+                    <XCircleIcon className="h-4 w-4 text-error" />
                   </div>
                   <p className="text-2xl font-bold text-foreground">
                     <AnimatedNumber
@@ -378,7 +394,7 @@ function UnifiedInsights({
                 {/* Completion Rate */}
                 <div className="flex flex-col items-center justify-center gap-1 rounded-lg bg-surface-2/50 p-3">
                   <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10">
-                    <Target className="h-4 w-4 text-primary" />
+                    <TargetIcon className="h-4 w-4 text-primary" />
                   </div>
                   <p className="text-2xl font-bold text-foreground">
                     <AnimatedNumber
@@ -419,24 +435,60 @@ function UnifiedInsights({
           >
             <CardContainer
               variant="interactive"
-              className="flex h-full flex-col p-6"
+              className="flex h-full flex-col p-5"
             >
-              <h3 className="mb-6 text-sm font-semibold tracking-tight text-foreground/90 uppercase">
-                Trend Analysis
-              </h3>
-              <div className="flex flex-1 flex-col justify-center gap-5">
+              <div className="mb-4 flex items-center gap-2">
+                <h3 className="text-sm font-semibold tracking-tight text-foreground/90 uppercase">
+                  Trend Analysis
+                </h3>
+                <InfoTooltip text="Compares average intake in the initial part of the selected range against recent days to show trajectory." />
+              </div>
+
+              {/* 2x2 Grid of Trend Cards */}
+              <div className="grid flex-1 grid-cols-2 gap-3">
                 <TrendDisplay
                   label="Calories"
                   trend={caloriesTrend}
                   data={aggregatedData}
                   dataKey="calories"
+                  icon={<CalorieIcon className="h-4 w-4 text-orange-500" />}
+                  iconBgColor="bg-orange-500/10"
+                  unit="kcal"
                 />
                 <TrendDisplay
                   label="Protein"
                   trend={proteinTrend}
                   data={aggregatedData}
                   dataKey="protein"
+                  icon={<DrumstickIcon className="h-4 w-4 text-protein" />}
+                  iconBgColor="bg-protein/10"
+                  unit="g"
                 />
+                <TrendDisplay
+                  label="Carbs"
+                  trend={carbsTrend}
+                  data={aggregatedData}
+                  dataKey="carbs"
+                  icon={<WheatIcon className="h-4 w-4 text-carbs" />}
+                  iconBgColor="bg-carbs/10"
+                  unit="g"
+                />
+                <TrendDisplay
+                  label="Fats"
+                  trend={fatsTrend}
+                  data={aggregatedData}
+                  dataKey="fats"
+                  icon={<DropletIcon className="h-4 w-4 text-fats" />}
+                  iconBgColor="bg-fats/10"
+                  unit="g"
+                />
+              </div>
+
+              {/* Message Banner */}
+              <div className="mt-4 rounded-md border border-primary/20 bg-primary/5 px-3 py-2">
+                <p className="text-xs leading-relaxed font-medium text-primary/90">
+                  {overallTrendMessage}
+                </p>
               </div>
             </CardContainer>
           </motion.div>

--- a/frontend/src/features/reporting/hooks/useMealTimeBreakdown.test.ts
+++ b/frontend/src/features/reporting/hooks/useMealTimeBreakdown.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MacroEntry, useMealTimeBreakdown } from "./useMealTimeBreakdown";
+
+describe("useMealTimeBreakdown", () => {
+  it("returns empty array when history is empty", () => {
+    const { result } = renderHook(() =>
+      useMealTimeBreakdown([], "2026-07-20", "2026-07-27", "calories"),
+    );
+
+    expect(result.current).toEqual([]);
+  });
+
+  it("calculates percentage share and daily average per meal type correctly", () => {
+    const mockHistory: MacroEntry[] = [
+      // Day 1: Lunch 500 kcal, Dinner 1000 kcal
+      {
+        id: 1,
+        protein: 50,
+        carbs: 50,
+        fats: 11.11, // ~500 kcal
+        mealType: "lunch",
+        entryDate: "2026-07-27",
+        createdAt: "2026-07-27T12:00:00Z",
+      },
+      {
+        id: 2,
+        protein: 100,
+        carbs: 100,
+        fats: 22.22, // ~1000 kcal
+        mealType: "dinner",
+        entryDate: "2026-07-27",
+        createdAt: "2026-07-27T18:00:00Z",
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      useMealTimeBreakdown(mockHistory, "2026-07-27", "2026-07-27", "calories"),
+    );
+
+    expect(result.current.length).toBe(4); // breakfast, lunch, dinner, snack
+
+    const lunch = result.current.find((item) => item.name === "Lunch");
+    const dinner = result.current.find((item) => item.name === "Dinner");
+
+    expect(lunch).toBeDefined();
+    expect(dinner).toBeDefined();
+
+    // Lunch is 500 kcal out of 1500 total = 33%
+    expect(lunch?.percentage).toBe(33);
+    // Dinner is 1000 kcal out of 1500 total = 67%
+    expect(dinner?.percentage).toBe(67);
+
+    // Daily averages over 1 tracked day
+    expect(lunch?.value).toBe(500);
+    expect(dinner?.value).toBe(1000);
+  });
+});

--- a/frontend/src/features/reporting/hooks/useMealTimeBreakdown.ts
+++ b/frontend/src/features/reporting/hooks/useMealTimeBreakdown.ts
@@ -45,10 +45,19 @@ function calculateMealTypeDistribution(
     ]),
   );
 
-  // Aggregate data by meal type
+  // Determine unique tracked days in entries
+  const uniqueDays = new Set(
+    entries
+      .map((entry) => entry.entryDate ?? entry.createdAt.split("T")[0])
+      .filter(Boolean),
+  ).size;
+  const trackedDays = uniqueDays > 0 ? uniqueDays : 1;
+
+  // Aggregate raw totals by meal type
   for (const entry of entries) {
     const mealType = entry.mealType;
     const group = groups[mealType];
+    if (!group) continue;
 
     group.protein += entry.protein || 0;
     group.carbs += entry.carbs || 0;
@@ -57,27 +66,32 @@ function calculateMealTypeDistribution(
     group.count += 1;
   }
 
-  // Convert to averages for calories
-  for (const group of Object.values(groups)) {
-    group.calories = group.count > 0 ? group.calories / group.count : 0;
-  }
+  // Calculate total across all meal types for percentage calculation
+  const totalPeriodStat = MEAL_TYPES.reduce((sum, type) => {
+    const group = groups[type];
+    if (selectedStat === "count") return sum + group.count;
 
-  // Calculate totals for percentages
-  const totals = { calories: 0, protein: 0, carbs: 0, fats: 0, count: 0 };
-  for (const group of Object.values(groups)) {
-    totals.calories += group.calories;
-    totals.protein += group.protein;
-    totals.carbs += group.carbs;
-    totals.fats += group.fats;
-    totals.count += group.count;
-  }
+    return sum + (group[selectedStat as keyof typeof group] || 0);
+  }, 0);
 
   // Format for chart
   return MEAL_TYPES.map((mealType) => {
     const group = groups[mealType];
-    const value = group[selectedStat as keyof typeof group];
-    const total = totals[selectedStat as keyof typeof totals];
-    const percentage = total > 0 ? Math.round((value / total) * 100) : 0;
+    const totalStatForMeal =
+      selectedStat === "count"
+        ? group.count
+        : group[selectedStat as keyof typeof group] || 0;
+
+    const percentage =
+      totalPeriodStat > 0
+        ? Math.round((totalStatForMeal / totalPeriodStat) * 100)
+        : 0;
+
+    // For count, value is raw count; for nutrients/calories, value is daily average
+    const value =
+      selectedStat === "count"
+        ? group.count
+        : Math.round(totalStatForMeal / trackedDays);
 
     return {
       name: formatMealType(mealType),

--- a/frontend/src/features/reporting/hooks/useReportingLogic.test.ts
+++ b/frontend/src/features/reporting/hooks/useReportingLogic.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { MacroEntry } from "@/types/macro";
+
+import { useReportingLogic } from "./useReportingLogic";
+
+describe("useReportingLogic", () => {
+  it("handles empty history gracefully", () => {
+    const { result } = renderHook(() =>
+      useReportingLogic([], "week", false),
+    );
+
+    expect(result.current.averages).toEqual({
+      calories: 0,
+      protein: 0,
+      carbs: 0,
+      fats: 0,
+    });
+    expect(result.current.trackedDays).toBe(0);
+    expect(result.current.totalDays).toBe(0);
+  });
+
+  it("calculates averages over tracked days when partially logged in week view", () => {
+    // Suppose user logged food on only 2 of 7 days: 2000 kcal on day 1, 2000 kcal on day 2
+    const mockHistory: MacroEntry[] = [
+      {
+        id: 1,
+        protein: 150, // 600 kcal
+        carbs: 200,   // 800 kcal
+        fats: 66.7,   // 600 kcal -> total 2000 kcal
+        mealType: "lunch",
+        entryDate: "2026-07-27",
+        createdAt: "2026-07-27T12:00:00Z",
+      },
+      {
+        id: 2,
+        protein: 150,
+        carbs: 200,
+        fats: 66.7,
+        mealType: "dinner",
+        entryDate: "2026-07-28",
+        createdAt: "2026-07-28T18:00:00Z",
+      },
+    ];
+
+    const { result } = renderHook(() =>
+      useReportingLogic(mockHistory, "week", false),
+    );
+
+    // Tracked days should be 2
+    expect(result.current.trackedDays).toBe(2);
+    expect(result.current.totalDays).toBe(7);
+
+    // Average calories should be 4000 total / 2 tracked days = 2000 kcal/day (not 4000/7 = 571)
+    expect(result.current.averages.calories).toBe(2000);
+    expect(result.current.averages.protein).toBe(150);
+  });
+});

--- a/frontend/src/features/reporting/hooks/useReportingLogic.ts
+++ b/frontend/src/features/reporting/hooks/useReportingLogic.ts
@@ -186,27 +186,44 @@ export function useReportingLogic(
 
   const isHistoryReady = !isLoadingExternal;
 
-  const averages = useMemo(() => {
-    if (aggregatedData.length === 0) {
-      return { calories: 0, protein: 0, carbs: 0, fats: 0 };
+  const { averages, trackedDays, totalDays } = useMemo(() => {
+    const seriesTotalDays = dailySeries.length;
+    if (seriesTotalDays === 0) {
+      return {
+        averages: { calories: 0, protein: 0, carbs: 0, fats: 0 },
+        trackedDays: 0,
+        totalDays: 0,
+      };
     }
 
-    const totals = { calories: 0, protein: 0, carbs: 0, fats: 0 };
+    const tracked = dailySeries.filter(
+      (d) => d.calories > 0 || d.protein > 0 || d.carbs > 0 || d.fats > 0,
+    );
+    const trackedDaysCount = tracked.length;
 
-    for (const value of aggregatedData) {
+    const totals = { calories: 0, protein: 0, carbs: 0, fats: 0 };
+    const sourceSeries = trackedDaysCount > 0 ? tracked : dailySeries;
+
+    for (const value of sourceSeries) {
       totals.calories += value.calories;
       totals.protein += value.protein;
       totals.carbs += value.carbs;
       totals.fats += value.fats;
     }
 
+    const divisor = trackedDaysCount > 0 ? trackedDaysCount : seriesTotalDays;
+
     return {
-      calories: Math.round(totals.calories / aggregatedData.length),
-      protein: Math.round(totals.protein / aggregatedData.length),
-      carbs: Math.round(totals.carbs / aggregatedData.length),
-      fats: Math.round(totals.fats / aggregatedData.length),
+      averages: {
+        calories: Math.round(totals.calories / divisor),
+        protein: Math.round(totals.protein / divisor),
+        carbs: Math.round(totals.carbs / divisor),
+        fats: Math.round(totals.fats / divisor),
+      },
+      trackedDays: trackedDaysCount,
+      totalDays: seriesTotalDays,
     };
-  }, [aggregatedData]);
+  }, [dailySeries]);
 
   const handleDownloadCSV = useCallback(() => {
     if (aggregatedData.length === 0) {
@@ -237,6 +254,8 @@ export function useReportingLogic(
     aggregatedData,
     dailySeries,
     averages,
+    trackedDays,
+    totalDays,
     handleDownloadCSV,
     isHistoryReady,
   };

--- a/frontend/src/features/reporting/pages/ReportingPage.tsx
+++ b/frontend/src/features/reporting/pages/ReportingPage.tsx
@@ -106,6 +106,8 @@ export default function ReportingPage() {
     dailySeries,
     isHistoryReady,
     averages,
+    trackedDays,
+    totalDays,
     handleDownloadCSV,
   } = useReportingLogic(history, dateRange, isHistoryLoading);
 
@@ -207,6 +209,9 @@ export default function ReportingPage() {
                             data={aggregatedData}
                             calorieTarget={calorieTarget}
                             macroTarget={macroTarget ?? undefined}
+                            trackedDays={trackedDays}
+                            totalDays={totalDays}
+                            averages={averages}
                           />
                         );
                       })()}

--- a/frontend/src/features/reporting/types/insightsTypes.ts
+++ b/frontend/src/features/reporting/types/insightsTypes.ts
@@ -38,6 +38,10 @@ export interface TrendResult {
   direction: "up" | "down" | "stable" | "insufficient";
   percentage: number;
   message: string;
+  firstAvg?: number;
+  lastAvg?: number;
+  delta?: number;
+  unit?: string;
 }
 
 export interface DataQualityResult {
@@ -60,8 +64,11 @@ export interface InsightsData {
   macroBalance: MacroBalanceResult;
   caloriesTrend: TrendResult;
   proteinTrend: TrendResult;
+  carbsTrend: TrendResult;
+  fatsTrend: TrendResult;
   dataQuality: DataQualityResult;
   macroDensity: MacroDensityResult;
+  overallTrendMessage?: string;
 }
 
 export interface DailyAverageItem {
@@ -97,4 +104,7 @@ export interface TrendDisplayProps {
   trend: TrendResult;
   data?: Record<string, unknown>[];
   dataKey?: string;
+  icon?: React.ReactNode;
+  iconBgColor?: string;
+  unit?: string;
 }

--- a/frontend/src/features/reporting/utils/insightsCalculations.test.ts
+++ b/frontend/src/features/reporting/utils/insightsCalculations.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { calculateConsistencyScore } from "./insightsCalculations";
+import {
+  calculateConsistencyScore,
+  calculateDataQuality,
+  calculateTrend,
+  generateOverallTrendSummary,
+} from "./insightsCalculations";
 
 describe("insightsCalculations", () => {
   describe("calculateConsistencyScore", () => {
@@ -16,6 +21,99 @@ describe("insightsCalculations", () => {
       ];
       const score = calculateConsistencyScore(data);
       expect(score).toBeGreaterThan(0);
+    });
+  });
+
+  describe("calculateTrend", () => {
+    it("returns insufficient for less than required days", () => {
+      const result = calculateTrend([], "calories");
+      expect(result.direction).toBe("insufficient");
+      expect(result.unit).toBe("kcal");
+    });
+
+    it("calculates upward trend and baseline statistics accurately", () => {
+      const data = [
+        { name: "D1", calories: 2000, protein: 100, carbs: 200, fats: 60 },
+        { name: "D2", calories: 2000, protein: 100, carbs: 200, fats: 60 },
+        { name: "D3", calories: 2000, protein: 100, carbs: 200, fats: 60 },
+        { name: "D4", calories: 2500, protein: 120, carbs: 250, fats: 70 },
+        { name: "D5", calories: 2500, protein: 120, carbs: 250, fats: 70 },
+        { name: "D6", calories: 2500, protein: 120, carbs: 250, fats: 70 },
+        { name: "D7", calories: 2500, protein: 120, carbs: 250, fats: 70 },
+      ];
+
+      const calTrend = calculateTrend(data, "calories");
+      expect(calTrend.direction).toBe("up");
+      expect(calTrend.firstAvg).toBe(2000);
+      expect(calTrend.lastAvg).toBe(2500);
+      expect(calTrend.delta).toBe(500);
+      expect(calTrend.percentage).toBe(25);
+    });
+  });
+
+  describe("generateOverallTrendSummary", () => {
+    it("generates summary message based on macro trends", () => {
+      const calTrend = { direction: "up" as const, percentage: 10, message: "", delta: 200 };
+      const proTrend = { direction: "up" as const, percentage: 15, message: "", delta: 20 };
+      const carbsTrend = { direction: "stable" as const, percentage: 0, message: "", delta: 0 };
+      const fatsTrend = { direction: "stable" as const, percentage: 0, message: "", delta: 0 };
+
+      const summary = generateOverallTrendSummary(calTrend, proTrend, carbsTrend, fatsTrend);
+      expect(summary).toContain("Calories are trending upward");
+      expect(summary).toContain("protein +20g/day");
+    });
+  });
+
+  describe("calculateDataQuality", () => {
+    it("calculates current streak = 1 when only today is tracked out of 7 days", () => {
+      const data = [
+        { name: "D1", calories: 0, protein: 0, carbs: 0, fats: 0 },
+        { name: "D2", calories: 0, protein: 0, carbs: 0, fats: 0 },
+        { name: "D3", calories: 0, protein: 0, carbs: 0, fats: 0 },
+        { name: "D4", calories: 0, protein: 0, carbs: 0, fats: 0 },
+        { name: "D5", calories: 0, protein: 0, carbs: 0, fats: 0 },
+        { name: "D6", calories: 0, protein: 0, carbs: 0, fats: 0 },
+        { name: "D7", calories: 2000, protein: 100, carbs: 200, fats: 60 },
+      ];
+
+      const result = calculateDataQuality(data, 7);
+      expect(result.daysLogged).toBe(1);
+      expect(result.currentStreak).toBe(1);
+      expect(result.longestStreak).toBe(1);
+    });
+
+    it("calculates current streak = 1 when only yesterday is tracked (today in progress)", () => {
+      const data = [
+        { name: "D1", calories: 0, protein: 0, carbs: 0, fats: 0 },
+        { name: "D2", calories: 0, protein: 0, carbs: 0, fats: 0 },
+        { name: "D3", calories: 0, protein: 0, carbs: 0, fats: 0 },
+        { name: "D4", calories: 0, protein: 0, carbs: 0, fats: 0 },
+        { name: "D5", calories: 0, protein: 0, carbs: 0, fats: 0 },
+        { name: "D6", calories: 2000, protein: 100, carbs: 200, fats: 60 },
+        { name: "D7", calories: 0, protein: 0, carbs: 0, fats: 0 },
+      ];
+
+      const result = calculateDataQuality(data, 7);
+      expect(result.daysLogged).toBe(1);
+      expect(result.currentStreak).toBe(1);
+      expect(result.longestStreak).toBe(1);
+    });
+
+    it("calculates current streak = 0 when tracked day was 3 days ago", () => {
+      const data = [
+        { name: "D1", calories: 0, protein: 0, carbs: 0, fats: 0 },
+        { name: "D2", calories: 0, protein: 0, carbs: 0, fats: 0 },
+        { name: "D3", calories: 0, protein: 0, carbs: 0, fats: 0 },
+        { name: "D4", calories: 2000, protein: 100, carbs: 200, fats: 60 },
+        { name: "D5", calories: 0, protein: 0, carbs: 0, fats: 0 },
+        { name: "D6", calories: 0, protein: 0, carbs: 0, fats: 0 },
+        { name: "D7", calories: 0, protein: 0, carbs: 0, fats: 0 },
+      ];
+
+      const result = calculateDataQuality(data, 7);
+      expect(result.daysLogged).toBe(1);
+      expect(result.currentStreak).toBe(0);
+      expect(result.longestStreak).toBe(1);
     });
   });
 });

--- a/frontend/src/features/reporting/utils/insightsCalculations.ts
+++ b/frontend/src/features/reporting/utils/insightsCalculations.ts
@@ -72,12 +72,15 @@ export function calculateMacroBalance(
   averages: NutritionAverage,
   macroTarget?: MacroTargetSettings | undefined,
 ): MacroBalanceResult {
-  const total = averages.protein + averages.carbs + averages.fats;
+  const proteinCals = averages.protein * 4;
+  const carbsCals = averages.carbs * 4;
+  const fatsCals = averages.fats * 9;
+  const totalCals = proteinCals + carbsCals + fatsCals;
   const target = macroTarget ?? DEFAULT_MACRO_TARGET;
 
   const idealRatioString = `${target.proteinPercentage}/${target.carbsPercentage}/${target.fatsPercentage}`;
 
-  if (total === 0) {
+  if (totalCals === 0) {
     return {
       score: 0,
       idealRatio: idealRatioString,
@@ -88,9 +91,9 @@ export function calculateMacroBalance(
   }
 
   const [proteinPct, carbsPct, fatsPct] = [
-    Math.round((averages.protein / total) * 100),
-    Math.round((averages.carbs / total) * 100),
-    Math.round((averages.fats / total) * 100),
+    Math.round((proteinCals / totalCals) * 100),
+    Math.round((carbsCals / totalCals) * 100),
+    Math.round((fatsCals / totalCals) * 100),
   ];
 
   const [idealProtein, idealCarbs, idealFats] = [
@@ -155,28 +158,32 @@ export function calculateTrend(
   data: AggregatedDataPoint[],
   metric: keyof AggregatedDataPoint,
 ): TrendResult {
+  const unit = metric === "calories" ? "kcal" : "g";
+
   if (!data.length || data.length < TREND_DAYS_REQUIRED) {
     return {
       direction: "insufficient" as const,
       percentage: 0,
       message: `Need at least ${TREND_DAYS_REQUIRED} days of data to analyse trends.`,
+      unit,
     };
   }
 
   const firstDays = data
     .slice(0, TREND_AVG_DAYS)
     .map((d) => Number(d[metric]))
-    .filter(Boolean);
+    .filter((v) => !isNaN(v) && v > 0);
   const lastDays = data
     .slice(-TREND_AVG_DAYS)
     .map((d) => Number(d[metric]))
-    .filter(Boolean);
+    .filter((v) => !isNaN(v) && v > 0);
 
   if (firstDays.length === 0 || lastDays.length === 0) {
     return {
       direction: "insufficient" as const,
       percentage: 0,
       message: "Not enough data points to calculate trends.",
+      unit,
     };
   }
 
@@ -190,10 +197,12 @@ export function calculateTrend(
       direction: "insufficient" as const,
       percentage: 0,
       message: "Unable to calculate percentage change from zero baseline.",
+      unit,
     };
   }
 
-  const percentChange = ((lastAvg - firstAvg) / firstAvg) * 100;
+  const rawDelta = lastAvg - firstAvg;
+  const percentChange = (rawDelta / firstAvg) * 100;
   const direction =
     percentChange > TREND_THRESHOLD.up
       ? "up"
@@ -201,18 +210,80 @@ export function calculateTrend(
         ? "down"
         : "stable";
 
+  const roundedFirstAvg = Math.round(firstAvg);
+  const roundedLastAvg = Math.round(lastAvg);
+  const roundedDelta = Math.round(rawDelta);
+
+  const metricLabel = metric.charAt(0).toUpperCase() + metric.slice(1);
   const message =
     direction === "stable"
-      ? "Your intake has been stable."
-      : `Your ${metric} intake is ${
+      ? `${metricLabel} intake has been stable (${roundedLastAvg} ${unit}/day).`
+      : `${metricLabel} intake is ${
           direction === "up" ? "trending upward" : "trending downward"
-        }.`;
+        } (${roundedDelta > 0 ? "+" : ""}${roundedDelta} ${unit}/day).`;
 
   return {
     direction,
     percentage: Math.abs(Math.round(percentChange)),
     message,
+    firstAvg: roundedFirstAvg,
+    lastAvg: roundedLastAvg,
+    delta: roundedDelta,
+    unit,
   };
+}
+
+export function generateOverallTrendSummary(
+  caloriesTrend: TrendResult,
+  proteinTrend: TrendResult,
+  carbsTrend: TrendResult,
+  fatsTrend: TrendResult,
+): string {
+  if (
+    caloriesTrend.direction === "insufficient" ||
+    proteinTrend.direction === "insufficient"
+  ) {
+    return "Log your meals consistently across the selected period to unlock overall trend insights.";
+  }
+
+  if (
+    caloriesTrend.direction === "stable" &&
+    proteinTrend.direction === "stable" &&
+    carbsTrend.direction === "stable" &&
+    fatsTrend.direction === "stable"
+  ) {
+    return "Your daily calories and macro intake have stayed consistent across this period.";
+  }
+
+  const calText =
+    caloriesTrend.direction === "stable"
+      ? "Calories remain steady"
+      : `Calories are trending ${caloriesTrend.direction === "up" ? "upward" : "downward"} (${
+          caloriesTrend.delta && caloriesTrend.delta > 0 ? "+" : ""
+        }${caloriesTrend.delta} kcal/day)`;
+
+  const macroDrivers: string[] = [];
+  if (proteinTrend.direction !== "stable") {
+    macroDrivers.push(
+      `protein ${proteinTrend.direction === "up" ? "+" : ""}${proteinTrend.delta}g/day`,
+    );
+  }
+  if (carbsTrend.direction !== "stable") {
+    macroDrivers.push(
+      `carbs ${carbsTrend.direction === "up" ? "+" : ""}${carbsTrend.delta}g/day`,
+    );
+  }
+  if (fatsTrend.direction !== "stable") {
+    macroDrivers.push(
+      `fats ${fatsTrend.direction === "up" ? "+" : ""}${fatsTrend.delta}g/day`,
+    );
+  }
+
+  if (macroDrivers.length > 0) {
+    return `${calText}, influenced by changes in ${macroDrivers.join(", ")}.`;
+  }
+
+  return `${calText} while macronutrient distribution remains relatively stable.`;
 }
 
 function calculateStreaks(data: AggregatedDataPoint[]): {
@@ -224,13 +295,27 @@ function calculateStreaks(data: AggregatedDataPoint[]): {
   // Create array of booleans indicating if day has data (calories > 0)
   const hasDataArray = data.map((d) => d.calories > 0);
 
-  // Calculate current streak (consecutive days from the end)
+  // Calculate current streak (consecutive days from the end).
+  // If the last day (today) has no logs yet, but yesterday was logged,
+  // treat yesterday as the active streak anchor since today is in progress.
   let currentStreak = 0;
-  for (let index = hasDataArray.length - 1; index >= 0; index--) {
-    if (hasDataArray[index]) {
-      currentStreak++;
-    } else {
-      break;
+  const lastIndex = hasDataArray.length - 1;
+
+  if (hasDataArray[lastIndex]) {
+    for (let index = lastIndex; index >= 0; index--) {
+      if (hasDataArray[index]) {
+        currentStreak++;
+      } else {
+        break;
+      }
+    }
+  } else if (lastIndex > 0 && hasDataArray[lastIndex - 1]) {
+    for (let index = lastIndex - 1; index >= 0; index--) {
+      if (hasDataArray[index]) {
+        currentStreak++;
+      } else {
+        break;
+      }
     }
   }
 

--- a/frontend/src/hooks/queries/useMacroQueries.ts
+++ b/frontend/src/hooks/queries/useMacroQueries.ts
@@ -112,6 +112,7 @@ function transformHistoryPages(
         pageParams: [0],
       },
     );
+
     return;
   }
 

--- a/frontend/src/hooks/queries/useReportingQueries.ts
+++ b/frontend/src/hooks/queries/useReportingQueries.ts
@@ -19,15 +19,24 @@ export function useMacroDensitySummary(
     queryFn: async () => {
       const data = await reportingApi.getMacroDensitySummary({ startDate, endDate, groupBy });
 
-      return data.map(item => {
-        const total = item.protein + item.carbs + item.fats;
-        
+      return data.map((item) => {
+        const proteinCal = (item.protein || 0) * 4;
+        const carbsCal = (item.carbs || 0) * 4;
+        const fatsCal = (item.fats || 0) * 9;
+        const totalMacroCalories = proteinCal + carbsCal + fatsCal;
+
         let label = item.period;
         if (groupBy === "day" && label.length === 10) {
-          label = new Date(label + "T00:00:00").toLocaleString("en-US", { month: "short", day: "numeric" });
+          label = new Date(label + "T00:00:00").toLocaleString("en-US", {
+            month: "short",
+            day: "numeric",
+          });
         } else if (groupBy === "month" && label.length === 7) {
           const [year, month] = label.split("-");
-          label = new Date(Number(year), Number(month) - 1, 1).toLocaleString("en-US", { month: "short" });
+          label = new Date(Number(year), Number(month) - 1, 1).toLocaleString(
+            "en-US",
+            { month: "short" },
+          );
         } else if (groupBy === "week") {
           // Just use the week string or implement week to date range formatting
           label = label.replace("-W", " Wk ");
@@ -36,9 +45,13 @@ export function useMacroDensitySummary(
         return {
           period: label,
           calories: item.calories,
-          protein: total > 0 ? item.protein / total : 0,
-          carbs: total > 0 ? item.carbs / total : 0,
-          fats: total > 0 ? item.fats / total : 0,
+          protein:
+            totalMacroCalories > 0 ? proteinCal / totalMacroCalories : 0,
+          carbs: totalMacroCalories > 0 ? carbsCal / totalMacroCalories : 0,
+          fats: totalMacroCalories > 0 ? fatsCal / totalMacroCalories : 0,
+          proteinGrams: item.protein,
+          carbsGrams: item.carbs,
+          fatsGrams: item.fats,
           count: item.count,
         };
       });


### PR DESCRIPTION
## Changes
- **Reporting Period Averages**: Updated `useReportingLogic` to calculate period averages over active/tracked days (days with logged entries) rather than total calendar days. Added tracked day subtext labels on `MacroSummaryStat` cards.
- **Meal Time Breakdown**: Fixed distribution math in `useMealTimeBreakdown` so donut segment percentages reflect share of total intake per meal type across the period. Tooltips now display both daily average intake and percentage share of total intake.
- **Macro Density Caloric Weighting**: Pre-converted macro grams to caloric values (`protein * 4`, `carbs * 4`, `fats * 9`) for stacked bar visualization so fat's caloric contribution is accurately represented.
- **Trend Analysis Panel Rework**: Extended trajectory calculations across all 4 core metrics (Calories, Protein, Carbs, Fats). Rebuilt `TrendDisplay` cards with direction badges, daily averages with net change deltas, and micro sparkline area charts. Arranged into a symmetrical 2x2 grid with an explanatory tooltip and bottom summary banner.
- **Streak Grace Period**: Fixed `calculateStreaks` to allow today to be unlogged while holding yesterday's active streak, preventing streak resets when opening the app on a day in progress.
- **Icon Registry Consolidation**: Centralized icon exports in `Icons.tsx` as the single source of truth and refactored components across reporting, landing, and UI pages to import from `@/components/ui`.
- **Unit Tests**: Added comprehensive unit test coverage in `useReportingLogic.test.ts`, `useMealTimeBreakdown.test.ts`, and `insightsCalculations.test.ts` (109 test files, 732 tests passing).
- **Version Bump**: Bumped app version to `2.4.0` in package manifests.