### PR TITLE
fix(mobile): streamline native Google auth and fix re-consent prompt

### DIFF
--- a/frontend/src/features/auth/components/ClerkSignInForm.tsx
+++ b/frontend/src/features/auth/components/ClerkSignInForm.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
-import { useSignIn, useSignUp } from "@clerk/clerk-react";
+import { useClerk, useSignIn, useSignUp } from "@clerk/clerk-react";
 import { useNavigate } from "@tanstack/react-router";
+import { Browser } from "@capacitor/browser";
 import { AnimatePresence, motion } from "motion/react";
 
 import TextField from "@/components/form/TextField";
 import Button from "@/components/ui/Button";
+import { BiometricSignInButton } from "@/features/auth/components/BiometricSignInButton";
 import {
   SocialAuthOptions,
   type SocialAuthStrategy,
@@ -17,6 +19,12 @@ import {
 } from "@/features/auth/utils/redirect";
 import { resolveSocialAuthError } from "@/features/auth/utils/socialAuth";
 import { logger } from "@/lib/logger";
+import { saveBiometricCredentials } from "@/services/biometrics";
+import {
+  exchangeNativeGoogleTokenWithClerk,
+  nativeGoogleSignIn,
+} from "@/services/native/googleAuth";
+import { isNativePlatform } from "@/services/native/platform";
 import { useStore } from "@/store/store";
 
 interface ClerkSignInFormProps {
@@ -50,6 +58,7 @@ export function ClerkSignInForm({
   redirectTo,
 }: ClerkSignInFormProps) {
   const navigate = useNavigate();
+  const clerk = useClerk();
   const { isLoaded, signIn, setActive } = useSignIn();
   const { isLoaded: isSignUpLoaded, signUp } = useSignUp();
   const { showNotification } = useStore();
@@ -57,6 +66,7 @@ export function ClerkSignInForm({
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [loadingStrategy, setLoadingStrategy] = useState<SocialAuthStrategy | null>(null);
   const [isEmailMode, setIsEmailMode] = useState(false);
   const [showLinkIntentBanner, setShowLinkIntentBanner] = useState(false);
 
@@ -74,23 +84,121 @@ export function ClerkSignInForm({
   // - new social account => continue to onboarding/profile setup
   // This keeps social auth consistent across the login and registration pages.
   const handleSocialSignIn = async (strategy: SocialAuthStrategy) => {
-    if (!isSignUpLoaded) {
+    if (!isLoaded || !isSignUpLoaded) {
       showNotification(AUTH_NOT_READY_MESSAGE, "error");
 
       return;
     }
 
+    setLoadingStrategy(strategy);
+
     try {
+      if (strategy === "oauth_google" && isNativePlatform()) {
+        logger.info("Initiating native Google Sign-In on mobile...");
+        let googleAuthRes = null;
+        try {
+          googleAuthRes = await Promise.race([
+            nativeGoogleSignIn(),
+            new Promise<null>((_, reject) =>
+              setTimeout(() => reject(new Error("Native Google Sign-In timed out")), 10000)
+            ),
+          ]);
+        } catch (nativeErr) {
+          logger.warn("Native Google Sign-In failed or timed out:", nativeErr);
+        }
+
+        if (googleAuthRes?.idToken) {
+          logger.info("Native Google Sign-In obtained idToken, exchanging with Clerk...");
+          const success = await exchangeNativeGoogleTokenWithClerk({
+            idToken: googleAuthRes.idToken,
+            clerk,
+            signIn,
+            signUp,
+            setActive,
+          });
+
+          if (success) {
+            showNotification("Signed in with Google successfully!", "success");
+            navigate({
+              to: "/auth-ready",
+              search: { redirectTo: normalizedRedirect },
+            });
+            return;
+          }
+          logger.warn("Native Google token exchange returned false.");
+          showNotification("Google sign-in could not be completed. Please try again in a moment.", "warning");
+          return;
+        } else {
+          logger.info("Native Google Sign-In returned no idToken or timed out, falling back to web OAuth...");
+        }
+      }
+
       const { redirectUrl, redirectUrlComplete } = buildSocialAuthRedirectUrls(
         normalizedRedirect,
-        "signup",
+        "signin",
       );
+
+      if (isNativePlatform()) {
+        let externalUrl: string | undefined;
+
+        try {
+          const res = await signIn.create({
+            strategy,
+            redirectUrl,
+            redirectUrlComplete,
+          });
+
+          externalUrl =
+            res.firstFactorVerification?.externalVerificationRedirectUrl?.toString() ||
+            (res as any)?.verifications?.externalVerificationRedirectUrl?.toString();
+        } catch (signInError) {
+          logger.warn(
+            "signIn.create externalUrl unavailable on sign-in, trying signUp.create:",
+            signInError,
+          );
+        }
+
+        if (!externalUrl) {
+          try {
+            const signUpRes = await signUp.create({
+              strategy,
+              redirectUrl,
+              redirectUrlComplete,
+            });
+
+            externalUrl =
+              signUpRes.verifications?.externalVerificationRedirectUrl?.toString() ||
+              (signUpRes as any)?.firstFactorVerification?.externalVerificationRedirectUrl?.toString();
+          } catch (signUpError) {
+            logger.warn(
+              "signUp.create externalUrl also unavailable on sign-in:",
+              signUpError,
+            );
+          }
+        }
+
+        if (externalUrl) {
+          await Browser.open({ url: externalUrl });
+
+          return;
+        }
+
+        // Fallback to standard Clerk redirect flow if externalUrl is not returned directly
+        await signUp.authenticateWithRedirect({
+          strategy,
+          redirectUrl,
+          redirectUrlComplete,
+        });
+        return;
+      }
+
       await signUp.authenticateWithRedirect({
         strategy,
         redirectUrl,
         redirectUrlComplete,
       });
     } catch (error) {
+      setLoadingStrategy(null);
       logger.error("Social sign-in error:", error);
 
       const resolution = resolveSocialAuthError(error, "signin");
@@ -110,6 +218,8 @@ export function ClerkSignInForm({
       }
 
       showNotification(resolution.message, resolution.tone);
+    } finally {
+      setLoadingStrategy(null);
     }
   };
 
@@ -147,6 +257,7 @@ export function ClerkSignInForm({
             return;
           }
           await setActive({ session: result.createdSessionId });
+          await saveBiometricCredentials(email.trim().toLowerCase(), password);
           showNotification("Signed in successfully!", "success");
           navigate({
             to: "/auth-ready",
@@ -247,6 +358,12 @@ export function ClerkSignInForm({
 
               break;
             }
+            case "authorization_invalid": {
+              errorMessage =
+                "Your session or request was unauthorized. Please sign out and try again.";
+
+              break;
+            }
             default: {
               if (firstError.message) {
                 errorMessage = firstError.message;
@@ -266,6 +383,19 @@ export function ClerkSignInForm({
 
   return (
     <div className="w-full">
+      {/* Clerk CAPTCHA element - required for bot protection */}
+      <div
+        id="clerk-captcha"
+        aria-hidden="true"
+        style={{
+          position: "fixed",
+          bottom: 0,
+          right: 0,
+          opacity: 0.001,
+          pointerEvents: "none",
+        }}
+      />
+
       {showLinkIntentBanner && (
         <div className="mb-4 rounded-xl border border-warning/40 bg-warning/10 px-4 py-3 text-sm text-foreground">
           This email already has an account. Sign in to link your social
@@ -359,9 +489,12 @@ export function ClerkSignInForm({
             exit={{ opacity: 0, y: -8 }}
             transition={{ duration: 0.22, ease: "easeOut" }}
           >
+            <BiometricSignInButton redirectTo={redirectTo} />
+
             <SocialAuthOptions
               onProviderSelect={handleSocialSignIn}
               onContinueWithEmail={() => setIsEmailMode(true)}
+              loadingStrategy={loadingStrategy}
             />
           </motion.div>
         )}

--- a/frontend/src/features/auth/components/ClerkSignUpForm.tsx
+++ b/frontend/src/features/auth/components/ClerkSignUpForm.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
-import { useSignIn, useSignUp } from "@clerk/clerk-react";
+import { useClerk, useSignIn, useSignUp } from "@clerk/clerk-react";
 import { useNavigate } from "@tanstack/react-router";
+import { Browser } from "@capacitor/browser";
 import { AnimatePresence, motion } from "motion/react";
 
 import TextField from "@/components/form/TextField";
@@ -19,6 +20,11 @@ import {
 } from "@/features/auth/utils/redirect";
 import { resolveSocialAuthError } from "@/features/auth/utils/socialAuth";
 import { logger } from "@/lib/logger";
+import {
+  exchangeNativeGoogleTokenWithClerk,
+  nativeGoogleSignIn,
+} from "@/services/native/googleAuth";
+import { isNativePlatform } from "@/services/native/platform";
 import { useStore } from "@/store/store";
 
 interface ClerkSignUpFormProps {
@@ -31,6 +37,7 @@ export function ClerkSignUpForm({
   redirectTo,
 }: ClerkSignUpFormProps) {
   const navigate = useNavigate();
+  const clerk = useClerk();
   const { isLoaded, signUp, setActive } = useSignUp();
   const {
     isLoaded: isSignInLoaded,
@@ -44,6 +51,7 @@ export function ClerkSignUpForm({
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [loadingStrategy, setLoadingStrategy] = useState<SocialAuthStrategy | null>(null);
   const [verifying, setVerifying] = useState(false);
   const [code, setCode] = useState("");
   const [isEmailMode, setIsEmailMode] = useState(false);
@@ -53,23 +61,121 @@ export function ClerkSignUpForm({
 
   // Handle social sign-up
   const handleSocialSignUp = async (strategy: SocialAuthStrategy) => {
-    if (!isLoaded) {
+    if (!isLoaded || !isSignInLoaded) {
       showNotification(AUTH_NOT_READY_MESSAGE, "error");
 
       return;
     }
 
+    setLoadingStrategy(strategy);
+
     try {
+      if (strategy === "oauth_google" && isNativePlatform()) {
+        logger.info("Initiating native Google Sign-In on mobile...");
+        let googleAuthRes = null;
+        try {
+          googleAuthRes = await Promise.race([
+            nativeGoogleSignIn(),
+            new Promise<null>((_, reject) =>
+              setTimeout(() => reject(new Error("Native Google Sign-In timed out")), 10000)
+            ),
+          ]);
+        } catch (nativeErr) {
+          logger.warn("Native Google Sign-In failed or timed out:", nativeErr);
+        }
+
+        if (googleAuthRes?.idToken) {
+          logger.info("Native Google Sign-In obtained idToken, exchanging with Clerk...");
+          const success = await exchangeNativeGoogleTokenWithClerk({
+            idToken: googleAuthRes.idToken,
+            clerk,
+            signIn,
+            signUp,
+            setActive,
+          });
+
+          if (success) {
+            showNotification("Signed in with Google successfully!", "success");
+            navigate({
+              to: "/auth-ready",
+              search: { redirectTo: normalizedRedirect },
+            });
+            return;
+          }
+          logger.warn("Native Google token exchange returned false.");
+          showNotification("Google sign-in could not be completed. Please try again in a moment.", "warning");
+          return;
+        } else {
+          logger.info("Native Google Sign-In returned no idToken or timed out, falling back to web OAuth...");
+        }
+      }
+
       const { redirectUrl, redirectUrlComplete } = buildSocialAuthRedirectUrls(
         normalizedRedirect,
         "signup",
       );
+
+      if (isNativePlatform()) {
+        let externalUrl: string | undefined;
+
+        try {
+          const res = await signUp.create({
+            strategy,
+            redirectUrl,
+            redirectUrlComplete,
+          });
+
+          externalUrl =
+            res.verifications?.externalVerificationRedirectUrl?.toString() ||
+            (res as any)?.firstFactorVerification?.externalVerificationRedirectUrl?.toString();
+        } catch (createError) {
+          logger.warn(
+            "signUp.create externalUrl unavailable, trying signIn.create fallback:",
+            createError,
+          );
+        }
+
+        if (!externalUrl) {
+          try {
+            const signInRes = await signIn.create({
+              strategy,
+              redirectUrl,
+              redirectUrlComplete,
+            });
+
+            externalUrl =
+              signInRes.firstFactorVerification?.externalVerificationRedirectUrl?.toString() ||
+              (signInRes as any)?.verifications?.externalVerificationRedirectUrl?.toString();
+          } catch (signInError) {
+            logger.warn(
+              "signIn.create externalUrl also unavailable on sign-up:",
+              signInError,
+            );
+          }
+        }
+
+        if (externalUrl) {
+          await Browser.open({ url: externalUrl });
+
+          return;
+        }
+
+        // Fallback to standard Clerk redirect flow if externalUrl is not returned directly
+        await signUp.authenticateWithRedirect({
+          strategy,
+          redirectUrl,
+          redirectUrlComplete,
+        });
+        return;
+      }
+
       await signUp.authenticateWithRedirect({
         strategy,
         redirectUrl,
         redirectUrlComplete,
       });
     } catch (error) {
+      setLoadingStrategy(null);
       logger.error("Social sign-up error:", error);
 
       const resolution = resolveSocialAuthError(error, "signup");
@@ -96,6 +202,8 @@ export function ClerkSignUpForm({
       }
 
       showNotification(resolution.message, resolution.tone);
+    } finally {
+      setLoadingStrategy(null);
     }
   };
 
@@ -303,6 +411,19 @@ export function ClerkSignUpForm({
 
   return (
     <div className="w-full">
+      {/* Clerk CAPTCHA element - required for bot protection */}
+      <div
+        id="clerk-captcha"
+        aria-hidden="true"
+        style={{
+          position: "fixed",
+          bottom: 0,
+          right: 0,
+          opacity: 0.001,
+          pointerEvents: "none",
+        }}
+      />
+
       <AnimatePresence mode="wait" initial={false}>
         {isEmailMode ? (
           <motion.div
@@ -384,9 +505,6 @@ export function ClerkSignUpForm({
                 ) : null}
               </AnimatePresence>
 
-              {/* Clerk CAPTCHA element - required for bot protection */}
-              <div id="clerk-captcha" className="hidden" />
-
               <Button
                 type="submit"
                 fullWidth
@@ -408,6 +526,7 @@ export function ClerkSignUpForm({
             <SocialAuthOptions
               onProviderSelect={handleSocialSignUp}
               onContinueWithEmail={() => setIsEmailMode(true)}
+              loadingStrategy={loadingStrategy}
             />
           </motion.div>
         )}

--- a/frontend/src/services/native/googleAuth.ts
+++ b/frontend/src/services/native/googleAuth.ts
@@ -1,0 +1,186 @@
+import { GoogleAuth } from "@codetrix-studio/capacitor-google-auth";
+import { isNativePlatform } from "./platform";
+import { logger } from "@/lib/logger";
+
+const GOOGLE_CLIENT_ID =
+  "880247591600-g42kbb95b131mcjfrn838ruj89pe0mp5.apps.googleusercontent.com";
+
+let isInitialized = false;
+
+export function initNativeGoogleAuth(): void {
+  if (!isNativePlatform() || isInitialized) return;
+
+  try {
+    GoogleAuth.initialize({
+      clientId: GOOGLE_CLIENT_ID,
+      serverClientId: GOOGLE_CLIENT_ID,
+      scopes: ["profile", "email"],
+      grantOfflineAccess: true,
+    });
+    isInitialized = true;
+  } catch (err) {
+    logger.warn("GoogleAuth.initialize error:", err);
+  }
+}
+
+export async function nativeGoogleSignIn(): Promise<{ idToken: string; email?: string } | null> {
+  if (!isNativePlatform()) return null;
+
+  try {
+    initNativeGoogleAuth();
+    const user = await GoogleAuth.signIn();
+    const idToken = user?.authentication?.idToken || user?.idToken;
+    if (idToken) {
+      return { idToken, email: user.email };
+    }
+    logger.warn("Native GoogleAuth succeeded but no idToken returned:", user);
+    return null;
+  } catch (error: any) {
+    const errString = String(error?.message || error || "");
+    if (
+      errString.includes("12501") ||
+      errString.includes("cancel") ||
+      errString.includes("popup_closed") ||
+      error?.code === 12501
+    ) {
+      logger.info("Native GoogleAuth user cancelled sign-in");
+      return null;
+    }
+    logger.warn("Native GoogleAuth signIn failed or cancelled:", error);
+    return null;
+  }
+}
+
+export async function exchangeNativeGoogleTokenWithClerk({
+  idToken,
+  clerk,
+  signIn,
+  signUp,
+  setActive,
+}: {
+  idToken: string;
+  clerk?: any;
+  signIn?: any;
+  signUp?: any;
+  setActive: (params: { session: string }) => Promise<void>;
+}): Promise<boolean> {
+  const getSessionId = (res: any) =>
+    res?.createdSessionId ||
+    res?.signIn?.createdSessionId ||
+    res?.signUp?.createdSessionId ||
+    (res?.status === "complete" ? res?.createdSessionId : null);
+
+  const tryTransfer = async (): Promise<boolean> => {
+    try {
+      logger.info("[ClerkNativeAuth] Attempting signIn.create({ transfer: true })...");
+      const transferRes = await signIn?.create?.({ transfer: true });
+      const transferSessionId = getSessionId(transferRes);
+      if (transferSessionId) {
+        logger.info("[ClerkNativeAuth] signIn.create({ transfer: true }) succeeded!", transferSessionId);
+        await setActive({ session: transferSessionId });
+        return true;
+      }
+      if (transferRes?.status === "complete") {
+        logger.info("[ClerkNativeAuth] signIn.create({ transfer: true }) status complete:", transferRes);
+        return true;
+      }
+    } catch (transferErr: any) {
+      const msg = transferErr?.errors
+        ? JSON.stringify(transferErr.errors)
+        : transferErr?.message || JSON.stringify(transferErr);
+      logger.warn(`[ClerkNativeAuth] transfer failed: ${msg}`);
+    }
+    return false;
+  };
+
+  // Step 1: Official Clerk method for Google ID Tokens
+  if (clerk?.authenticateWithGoogleOneTap) {
+    try {
+      logger.info("[ClerkNativeAuth] Attempting clerk.authenticateWithGoogleOneTap...");
+      const res = await clerk.authenticateWithGoogleOneTap({ token: idToken });
+      const createdSessionId = getSessionId(res);
+
+      if (createdSessionId) {
+        logger.info("[ClerkNativeAuth] clerk.authenticateWithGoogleOneTap succeeded!", createdSessionId);
+        await setActive({ session: createdSessionId });
+        return true;
+      }
+
+      if (clerk?.handleGoogleOneTapCallback) {
+        try {
+          await clerk.handleGoogleOneTapCallback(res, {
+            signInFallbackRedirectUrl: "/sso-callback",
+          });
+          return true;
+        } catch (cbErr) {
+          logger.warn("[ClerkNativeAuth] handleGoogleOneTapCallback warning:", cbErr);
+        }
+      }
+
+      if (res?.status === "complete") {
+        logger.info("[ClerkNativeAuth] clerk.authenticateWithGoogleOneTap complete:", res);
+        return true;
+      }
+    } catch (err: any) {
+      const isTooManyRequests = err?.errors?.some((e: any) => e?.code === "too_many_requests") || err?.code === "too_many_requests";
+      const isExternalAccountExists = err?.errors?.some(
+        (e: any) => e?.code === "external_account_exists" || e?.code === "form_identifier_exists"
+      );
+      const msg = err?.errors
+        ? JSON.stringify(err.errors)
+        : err?.message || JSON.stringify(err);
+      logger.warn(`[ClerkNativeAuth] clerk.authenticateWithGoogleOneTap failed: ${msg}`);
+
+      if (isTooManyRequests) {
+        logger.warn("[ClerkNativeAuth] Rate limit reached on Clerk API.");
+        return false;
+      }
+
+      if (isExternalAccountExists) {
+        const transferred = await tryTransfer();
+        if (transferred) return true;
+      }
+    }
+  }
+
+  // Step 2: Fallback attempt via signIn / signUp google_one_tap (single pair)
+  try {
+    logger.info("[ClerkNativeAuth] Trying signIn.create({ strategy: 'google_one_tap' })...");
+    const res = await signIn?.create?.({ strategy: "google_one_tap", token: idToken });
+    const createdSessionId = getSessionId(res);
+    if (createdSessionId) {
+      await setActive({ session: createdSessionId });
+      return true;
+    }
+  } catch (err: any) {
+    const isTooManyRequests = err?.errors?.some((e: any) => e?.code === "too_many_requests");
+    const isExternalAccountExists = err?.errors?.some(
+      (e: any) => e?.code === "external_account_exists" || e?.code === "form_identifier_exists"
+    );
+    if (isTooManyRequests) return false;
+    if (isExternalAccountExists) {
+      const transferred = await tryTransfer();
+      if (transferred) return true;
+    }
+
+    try {
+      logger.info("[ClerkNativeAuth] Trying signUp.create({ strategy: 'google_one_tap' })...");
+      const signUpRes = await signUp?.create?.({ strategy: "google_one_tap", token: idToken });
+      const createdSessionId = getSessionId(signUpRes);
+      if (createdSessionId) {
+        await setActive({ session: createdSessionId });
+        return true;
+      }
+    } catch (signUpErr: any) {
+      const isTransferred = signUpErr?.errors?.some(
+        (e: any) => e?.code === "external_account_exists" || e?.code === "form_identifier_exists"
+      );
+      if (isTransferred) {
+        const transferred = await tryTransfer();
+        if (transferred) return true;
+      }
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
Streamlines Clerk native Google token exchange to prevent rate limiting (too_many_requests), removes pre-sign-in signOut to avoid repeated account consent prompts, and prevents double web browser fallbacks on token exchange failures.