### PR TITLE
refactor(mobile): simplify native helper functions

### DIFF
--- a/frontend/src/services/native/camera.ts
+++ b/frontend/src/services/native/camera.ts
@@ -1,0 +1,21 @@
+import { Camera, CameraResultType, CameraSource } from "@capacitor/camera";
+import { isNativePlatform } from "./platform";
+
+async function getPhotoFromSource(source: CameraSource): Promise<string | null> {
+  if (!isNativePlatform()) return null;
+  try {
+    const photo = await Camera.getPhoto({
+      quality: 85,
+      allowEditing: false,
+      resultType: CameraResultType.Uri,
+      source,
+    });
+    return photo.webPath || photo.path || null;
+  } catch (error) {
+    console.debug("Camera/Gallery operation canceled or unavailable:", error);
+    return null;
+  }
+}
+
+export const capturePhoto = () => getPhotoFromSource(CameraSource.Camera);
+export const pickPhotoFromGallery = () => getPhotoFromSource(CameraSource.Photos);

--- a/frontend/src/services/native/platform.ts
+++ b/frontend/src/services/native/platform.ts
@@ -1,0 +1,11 @@
+import { Capacitor } from "@capacitor/core";
+
+export const isNativePlatform = (): boolean => Capacitor.isNativePlatform();
+
+export const getPlatform = (): "ios" | "android" | "web" => {
+  const p = Capacitor.getPlatform();
+  return p === "ios" || p === "android" ? p : "web";
+};
+
+export const isIOS = (): boolean => Capacitor.getPlatform() === "ios";
+export const isAndroid = (): boolean => Capacitor.getPlatform() === "android";

--- a/frontend/src/services/native/statusBar.ts
+++ b/frontend/src/services/native/statusBar.ts
@@ -1,0 +1,15 @@
+import { Capacitor } from "@capacitor/core";
+import { StatusBar, Style } from "@capacitor/status-bar";
+import { isNativePlatform } from "./platform";
+
+export async function setupStatusBar(isDark = true): Promise<void> {
+  if (!isNativePlatform()) return;
+  try {
+    await StatusBar.setStyle({ style: isDark ? Style.Dark : Style.Light });
+    if (Capacitor.getPlatform() === "android") {
+      await StatusBar.setBackgroundColor({ color: isDark ? "#09090b" : "#ffffff" });
+    }
+  } catch (error) {
+    console.debug("StatusBar setup failed or not supported:", error);
+  }
+}


### PR DESCRIPTION
Applies ponytail code review simplifications to native mobile helpers: removes orphaned import in statusBar.ts, consolidates duplicate camera capture options, and streamlines platform getters.