### PR TITLE
fix(history): show load more dates button when backend has more entries

### DIFF
--- a/frontend/src/features/macroTracking/components/EntryHistoryPanel.test.tsx
+++ b/frontend/src/features/macroTracking/components/EntryHistoryPanel.test.tsx
@@ -181,4 +181,59 @@ describe("EntryHistoryHelpers & Panel", () => {
 
     expect(screen.getAllByText("Protein Shake").length).toBeGreaterThan(0);
   });
+
+  it("renders Load More Dates button and triggers onLoadMore when hasMore is true even if currently loaded dates count < 5", async () => {
+    const queryClient = createQueryClient();
+    let loadMoreCalled = false;
+
+    // Create entries for 2 distinct dates (fewer than displayedDateCount default of 5)
+    const entries = [
+      {
+        id: 1,
+        mealName: "Meal 1",
+        mealType: "lunch" as const,
+        protein: 20,
+        carbs: 30,
+        fats: 10,
+        entryDate: "2026-07-31",
+        entryTime: "12:00",
+        createdAt: new Date().toISOString(),
+      },
+      {
+        id: 2,
+        mealName: "Meal 2",
+        mealType: "dinner" as const,
+        protein: 25,
+        carbs: 35,
+        fats: 12,
+        entryDate: "2026-07-30",
+        entryTime: "19:00",
+        createdAt: new Date().toISOString(),
+      },
+    ];
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EntryHistoryPanel
+          history={entries}
+          deleteEntry={() => {}}
+          onEdit={() => {}}
+          isDeleting={false}
+          isEditing={false}
+          hasMore
+          onLoadMore={() => {
+            loadMoreCalled = true;
+          }}
+        />
+      </QueryClientProvider>,
+    );
+
+    const loadMoreButton = screen.getByRole("button", { name: /load more dates/i });
+    expect(loadMoreButton).toBeDefined();
+
+    loadMoreButton.click();
+    await waitFor(() => {
+      expect(loadMoreCalled).toBe(true);
+    });
+  });
 });

--- a/frontend/src/features/macroTracking/components/EntryHistoryPanel.tsx
+++ b/frontend/src/features/macroTracking/components/EntryHistoryPanel.tsx
@@ -422,14 +422,14 @@ const EntryHistoryComponent = function EntryHistory({
             </div>
           </EntryHistoryContext.Provider>
 
-          {((hasMoreDates ?? hasMore) || displayedDateCount > 5) && (
+          {((hasMoreDates || hasMore) || displayedDateCount > 5) && (
             <motion.div
               className="flex justify-center py-4"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.3 }}
             >
-              {(hasMoreDates ?? hasMore) && (
+              {(hasMoreDates || hasMore) && (
                 <motion.button
                   onClick={loadMoreDates}
                   className={`flex items-center gap-2 rounded-lg border border-border bg-transparent px-4 py-2 text-sm text-muted transition-colors hover:bg-surface hover:text-foreground ${


### PR DESCRIPTION
## Summary
Fixes an issue where the "Load More Dates" button in  was hidden when the initial page of entries spanned fewer than 5 dates, even though additional pages existed on the backend.

## Cause
 evaluated to  when loaded dates < 5. The nullish coalescing operator  evaluated  to , suppressing the button.

## Solution
Updated  to  so the button remains available whenever  is . Added unit test covering this scenario.