### PR TITLE
feat(macro-tracking): enable custom entry quantity scaling & star save-as-meal

### DIFF
--- a/frontend/src/features/macroTracking/components/AddEntryForm.test.tsx
+++ b/frontend/src/features/macroTracking/components/AddEntryForm.test.tsx
@@ -182,4 +182,77 @@ describe("AddEntryForm", () => {
       }),
     );
   });
+
+  it("allows editing quantity/unit for custom entries and scales macros on quantity change", async () => {
+    const handleSubmit = vi.fn();
+    render(<AddEntryForm onSubmit={handleSubmit} isSaving={false} />);
+
+    const mealNameInput = screen.getByPlaceholderText("e.g. Chicken Salad");
+    fireEvent.change(mealNameInput, { target: { value: "Custom Chicken" } });
+
+    const proteinInput = screen.getByLabelText("Protein");
+    const carbsInput = screen.getByLabelText("Carbs");
+    const fatsInput = screen.getByLabelText("Fats");
+
+    fireEvent.change(proteinInput, { target: { value: "20" } });
+    fireEvent.change(carbsInput, { target: { value: "10" } });
+    fireEvent.change(fatsInput, { target: { value: "5" } });
+
+    const quantityInput = screen.getByPlaceholderText("100") as HTMLInputElement;
+    expect(quantityInput.disabled).toBe(false);
+
+    // Double quantity from 100g to 200g
+    fireEvent.change(quantityInput, { target: { value: "200" } });
+
+    expect((proteinInput as HTMLInputElement).value).toBe("40");
+    expect((carbsInput as HTMLInputElement).value).toBe("20");
+    expect((fatsInput as HTMLInputElement).value).toBe("10");
+
+    fireEvent.click(screen.getByRole("button", { name: /add entry/i }));
+
+    expect(handleSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mealName: "Custom Chicken",
+        protein: 40,
+        carbs: 20,
+        fats: 10,
+        ingredients: [
+          expect.objectContaining({
+            name: "Custom Chicken",
+            quantity: 200,
+            unit: "g",
+            baseProtein: 20,
+            baseCarbs: 10,
+            baseFats: 5,
+            baseQuantity: 100,
+            baseUnit: "g",
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("submits saveAsMeal flag when Save as Meal button is toggled", async () => {
+    const handleSubmit = vi.fn();
+    render(<AddEntryForm onSubmit={handleSubmit} isSaving={false} />);
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. Chicken Salad"), {
+      target: { value: "Oatmeal" },
+    });
+    fireEvent.change(screen.getByLabelText("Protein"), { target: { value: "10" } });
+    fireEvent.change(screen.getByLabelText("Carbs"), { target: { value: "40" } });
+    fireEvent.change(screen.getByLabelText("Fats"), { target: { value: "5" } });
+
+    const saveAsMealButton = screen.getByRole("button", { name: /save as meal/i });
+    fireEvent.click(saveAsMealButton);
+
+    fireEvent.click(screen.getByRole("button", { name: /add entry/i }));
+
+    expect(handleSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mealName: "Oatmeal",
+        saveAsMeal: true,
+      }),
+    );
+  });
 });

--- a/frontend/src/features/macroTracking/components/AddEntryForm.tsx
+++ b/frontend/src/features/macroTracking/components/AddEntryForm.tsx
@@ -8,7 +8,7 @@ import { formStyles } from "@/components/form/FormStyles";
 import NumberField from "@/components/form/NumberField";
 import QuantityUnitField from "@/components/form/QuantityUnitField";
 import TimeField from "@/components/form/TimeField";
-import { Button, PlusIcon, TrashIcon } from "@/components/ui";
+import { Button, PlusIcon, StarIcon, TrashIcon } from "@/components/ui";
 import CalorieSearch from "@/features/macroTracking/components/CalorieSearchForm";
 import { cn } from "@/lib/classnameUtilities";
 import { type Ingredient, MealType } from "@/types/macro";
@@ -27,8 +27,26 @@ interface AddEntryProps {
     entryDate: string;
     entryTime: string;
     ingredients?: Ingredient[];
+    saveAsMeal?: boolean;
   }) => Promise<void>;
   isSaving: boolean;
+}
+
+function getFactor(
+  quantity: number | undefined,
+  unit: UnitType,
+): number | undefined {
+  if (typeof quantity !== "number" || quantity <= 0) return undefined;
+  if (unit === "unit") return quantity;
+  let qtyInGrams: number;
+  if (UnitConverter.isWeightUnit(unit)) {
+    qtyInGrams = UnitConverter.convert(quantity, unit, "g");
+  } else if (UnitConverter.isVolumeUnit(unit)) {
+    qtyInGrams = UnitConverter.convert(quantity, unit, "ml");
+  } else {
+    qtyInGrams = quantity * 100;
+  }
+  return qtyInGrams / 100;
 }
 
 function AddEntry({ onSubmit, isSaving: _isSaving }: AddEntryProps) {
@@ -37,6 +55,7 @@ function AddEntry({ onSubmit, isSaving: _isSaving }: AddEntryProps) {
   const [fats, setFats] = useState<number | undefined>();
   const [quantity, setQuantity] = useState<number | undefined>(100);
   const [unit, setUnit] = useState<UnitType>("g");
+  const [saveAsMeal, setSaveAsMeal] = useState(false);
   const [baseMacros, setBaseMacros] = useState<
     | {
         protein: number;
@@ -97,18 +116,8 @@ function AddEntry({ onSubmit, isSaving: _isSaving }: AddEntryProps) {
   );
 
   useEffect(() => {
-    if (baseMacros && typeof quantity === "number" && quantity > 0) {
-      let quantityInGrams: number;
-
-      if (UnitConverter.isWeightUnit(unit)) {
-        quantityInGrams = UnitConverter.convert(quantity, unit, "g");
-      } else if (UnitConverter.isVolumeUnit(unit)) {
-        quantityInGrams = UnitConverter.convert(quantity, unit, "ml");
-      } else {
-        quantityInGrams = quantity * 100;
-      }
-
-      const factor = quantityInGrams / 100;
+    const factor = getFactor(quantity, unit);
+    if (baseMacros && factor !== undefined) {
       setProtein(Number((baseMacros.protein * factor).toFixed(1)));
       setCarbs(Number((baseMacros.carbs * factor).toFixed(1)));
       setFats(Number((baseMacros.fats * factor).toFixed(1)));
@@ -215,14 +224,40 @@ function AddEntry({ onSubmit, isSaving: _isSaving }: AddEntryProps) {
     setFats(undefined);
     setQuantity(100);
     setUnit("g" as UnitType);
+    setSaveAsMeal(false);
   }, []);
 
   const handleManualMacroChange =
-    (setter: (value: number | undefined) => void) =>
+    (
+      setter: (value: number | undefined) => void,
+      field: "protein" | "carbs" | "fats",
+    ) =>
     (value: number | undefined) => {
       setter(value);
-      setBaseMacros(undefined);
       setBaseIngredients(undefined);
+
+      const currentValues = {
+        protein: field === "protein" ? value : protein,
+        carbs: field === "carbs" ? value : carbs,
+        fats: field === "fats" ? value : fats,
+      };
+
+      const factor = getFactor(quantity, unit);
+      if (
+        factor !== undefined &&
+        factor > 0 &&
+        currentValues.protein !== undefined &&
+        currentValues.carbs !== undefined &&
+        currentValues.fats !== undefined
+      ) {
+        setBaseMacros({
+          protein: currentValues.protein / factor,
+          carbs: currentValues.carbs / factor,
+          fats: currentValues.fats / factor,
+        });
+      } else {
+        setBaseMacros(undefined);
+      }
     };
 
   const handleSelectSavedMeal = useCallback(
@@ -325,76 +360,70 @@ function AddEntry({ onSubmit, isSaving: _isSaving }: AddEntryProps) {
       if (!isFormValid) return;
 
       let finalIngredients = baseIngredients;
-      if (typeof quantity === "number" && quantity > 0) {
-        let factor = 1;
-        if (unit === "unit") {
-          factor = quantity;
-        } else {
-          let quantityInBaseUnit: number;
-          if (UnitConverter.isWeightUnit(unit)) {
-            quantityInBaseUnit = UnitConverter.convert(quantity, unit, "g");
-          } else if (UnitConverter.isVolumeUnit(unit)) {
-            quantityInBaseUnit = UnitConverter.convert(quantity, unit, "ml");
-          } else {
-            quantityInBaseUnit = quantity * 100;
-          }
-          factor = quantityInBaseUnit / 100;
-        }
+      const factor = getFactor(quantity, unit) ?? 1;
 
-        if (baseIngredients && baseIngredients.length > 0) {
-          if (baseIngredients.length === 1) {
-            const ing = baseIngredients[0];
-            finalIngredients = [
-              {
-                ...ing,
-                name: ing.name || mealName,
-                protein: protein as number,
-                carbs: carbs as number,
-                fats: fats as number,
-                quantity: typeof quantity === "number" ? quantity : ing.quantity,
-                unit: unit || ing.unit,
-                baseProtein: baseMacros?.protein ?? ing.baseProtein,
-                baseCarbs: baseMacros?.carbs ?? ing.baseCarbs,
-                baseFats: baseMacros?.fats ?? ing.baseFats,
-                baseQuantity: ing.baseQuantity ?? (unit === "unit" ? 1 : 100),
-                baseUnit: ing.baseUnit ?? (unit === "unit" ? "unit" : unit),
-              },
-            ];
-          } else {
-            finalIngredients = baseIngredients.map((ing) => ({
-              ...ing,
-              protein: Number((ing.protein * factor).toFixed(1)),
-              carbs: Number((ing.carbs * factor).toFixed(1)),
-              fats: Number((ing.fats * factor).toFixed(1)),
-              quantity: ing.quantity
-                ? Number((ing.quantity * factor).toFixed(1))
-                : undefined,
-            }));
-          }
-        } else if (baseMacros) {
+      if (baseIngredients && baseIngredients.length > 0) {
+        if (baseIngredients.length === 1) {
+          const ing = baseIngredients[0];
           finalIngredients = [
             {
-              name: mealName,
+              ...ing,
+              name: ing.name || mealName,
               protein: protein as number,
               carbs: carbs as number,
               fats: fats as number,
-              quantity,
-              unit,
-              baseProtein: baseMacros.protein,
-              baseCarbs: baseMacros.carbs,
-              baseFats: baseMacros.fats,
-              baseQuantity: unit === "unit" ? 1 : 100,
-              baseUnit:
-                unit === "unit"
-                  ? "unit"
-                  : UnitConverter.isWeightUnit(unit)
-                    ? "g"
-                    : UnitConverter.isVolumeUnit(unit)
-                      ? "ml"
-                      : unit,
+              quantity: typeof quantity === "number" ? quantity : ing.quantity,
+              unit: unit || ing.unit,
+              baseProtein:
+                baseMacros?.protein ?? ing.baseProtein ?? (protein as number) / factor,
+              baseCarbs:
+                baseMacros?.carbs ?? ing.baseCarbs ?? (carbs as number) / factor,
+              baseFats:
+                baseMacros?.fats ?? ing.baseFats ?? (fats as number) / factor,
+              baseQuantity: ing.baseQuantity ?? (unit === "unit" ? 1 : 100),
+              baseUnit: ing.baseUnit ?? (unit === "unit" ? "unit" : unit),
             },
           ];
+        } else {
+          finalIngredients = baseIngredients.map((ing) => ({
+            ...ing,
+            protein: Number((ing.protein * factor).toFixed(1)),
+            carbs: Number((ing.carbs * factor).toFixed(1)),
+            fats: Number((ing.fats * factor).toFixed(1)),
+            quantity: ing.quantity
+              ? Number((ing.quantity * factor).toFixed(1))
+              : undefined,
+          }));
         }
+      } else {
+        const effectiveBaseMacros = baseMacros ?? {
+          protein: (protein as number) / factor,
+          carbs: (carbs as number) / factor,
+          fats: (fats as number) / factor,
+        };
+
+        finalIngredients = [
+          {
+            name: mealName,
+            protein: protein as number,
+            carbs: carbs as number,
+            fats: fats as number,
+            quantity: typeof quantity === "number" ? quantity : 100,
+            unit,
+            baseProtein: effectiveBaseMacros.protein,
+            baseCarbs: effectiveBaseMacros.carbs,
+            baseFats: effectiveBaseMacros.fats,
+            baseQuantity: unit === "unit" ? 1 : 100,
+            baseUnit:
+              unit === "unit"
+                ? "unit"
+                : UnitConverter.isWeightUnit(unit)
+                  ? "g"
+                  : UnitConverter.isVolumeUnit(unit)
+                    ? "ml"
+                    : unit,
+          },
+        ];
       }
 
       await onSubmit({
@@ -406,6 +435,7 @@ function AddEntry({ onSubmit, isSaving: _isSaving }: AddEntryProps) {
         entryDate,
         entryTime,
         ingredients: finalIngredients,
+        saveAsMeal,
       });
 
       handleClearSearch();
@@ -425,6 +455,7 @@ function AddEntry({ onSubmit, isSaving: _isSaving }: AddEntryProps) {
       baseIngredients,
       quantity,
       unit,
+      saveAsMeal,
     ],
   );
 
@@ -457,34 +488,55 @@ function AddEntry({ onSubmit, isSaving: _isSaving }: AddEntryProps) {
                 unit={unit}
                 onQuantityChange={setQuantity}
                 onUnitChange={setUnit}
-                disabled={!baseMacros}
                 placeholder="100"
               />
             </div>
             <div className="sm:col-span-2">
               <div className="space-y-2">
-                <div className="relative flex items-center">
+                <div className="relative flex items-center justify-between">
                   <label htmlFor="meal-name-input" className={formStyles.label}>
                     Meal Name
                   </label>
-                  <AnimatePresence>
-                    {(searchResult ?? mealName.length > 0) && (
-                      <motion.button
-                        type="button"
-                        onClick={handleClearSearch}
-                        initial={{ opacity: 0, scale: 0.8 }}
-                        animate={{ opacity: 1, scale: 1 }}
-                        exit={{ opacity: 0, scale: 0.8 }}
-                        transition={{ duration: 0.15 }}
-                        className="absolute right-0 flex items-center gap-1 rounded-md px-2 py-0.5 text-xs text-muted transition-colors hover:bg-error/10 hover:text-error"
-                        aria-label="Clear search"
-                        title="Clear search result"
-                      >
-                        <TrashIcon className="h-3 w-3" />
-                        Clear
-                      </motion.button>
-                    )}
-                  </AnimatePresence>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setSaveAsMeal((previous) => !previous)}
+                      className={cn(
+                        "flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium transition-colors cursor-pointer",
+                        saveAsMeal
+                          ? "bg-amber-500/15 text-amber-500 hover:bg-amber-500/25 dark:bg-amber-400/20 dark:text-amber-300"
+                          : "text-muted hover:bg-muted/10 hover:text-foreground",
+                      )}
+                      aria-label="Save as Meal"
+                      title={saveAsMeal ? "Will save as reusable meal" : "Save as reusable meal"}
+                    >
+                      <StarIcon
+                        className={cn(
+                          "h-3.5 w-3.5 transition-colors",
+                          saveAsMeal ? "fill-current text-amber-500 dark:text-amber-300" : "",
+                        )}
+                      />
+                      <span>{saveAsMeal ? "Saved as Meal" : "Save as Meal"}</span>
+                    </button>
+                    <AnimatePresence>
+                      {(searchResult ?? mealName.length > 0) && (
+                        <motion.button
+                          type="button"
+                          onClick={handleClearSearch}
+                          initial={{ opacity: 0, scale: 0.8 }}
+                          animate={{ opacity: 1, scale: 1 }}
+                          exit={{ opacity: 0, scale: 0.8 }}
+                          transition={{ duration: 0.15 }}
+                          className="flex items-center gap-1 rounded-md px-2 py-0.5 text-xs text-muted transition-colors hover:bg-error/10 hover:text-error"
+                          aria-label="Clear search"
+                          title="Clear search result"
+                        >
+                          <TrashIcon className="h-3 w-3" />
+                          Clear
+                        </motion.button>
+                      )}
+                    </AnimatePresence>
+                  </div>
                 </div>
                 <input
                   id="meal-name-input"
@@ -529,7 +581,7 @@ function AddEntry({ onSubmit, isSaving: _isSaving }: AddEntryProps) {
             <NumberField
               label="Protein"
               value={protein}
-              onChange={handleManualMacroChange(setProtein)}
+              onChange={handleManualMacroChange(setProtein, "protein")}
               min={0}
               max={500}
               step={0.1}
@@ -538,7 +590,7 @@ function AddEntry({ onSubmit, isSaving: _isSaving }: AddEntryProps) {
             <NumberField
               label="Carbs"
               value={carbs}
-              onChange={handleManualMacroChange(setCarbs)}
+              onChange={handleManualMacroChange(setCarbs, "carbs")}
               min={0}
               max={500}
               step={0.1}
@@ -547,7 +599,7 @@ function AddEntry({ onSubmit, isSaving: _isSaving }: AddEntryProps) {
             <NumberField
               label="Fats"
               value={fats}
-              onChange={handleManualMacroChange(setFats)}
+              onChange={handleManualMacroChange(setFats, "fats")}
               min={0}
               max={500}
               step={0.1}

--- a/frontend/src/features/macroTracking/components/CalorieSearchForm.test.tsx
+++ b/frontend/src/features/macroTracking/components/CalorieSearchForm.test.tsx
@@ -89,4 +89,49 @@ describe("CalorieSearchForm", () => {
       }),
     );
   });
+
+  it("allows selecting a recent entry from Recents tab in search overlay", async () => {
+    const handleSelectSavedMeal = vi.fn();
+    const recentEntries = [
+      {
+        id: 1,
+        foodName: "Banana",
+        mealName: "Snack",
+        protein: 1.1,
+        carbs: 23,
+        fats: 0.3,
+        mealType: "snack" as const,
+        entryDate: "2026-08-10",
+        entryTime: "10:00",
+        createdAt: "2026-08-10T10:00:00Z",
+      },
+    ];
+
+    renderWithQueryClient(
+      <CalorieSearchForm
+        onResult={() => {}}
+        onSelectSavedMeal={handleSelectSavedMeal}
+        recentEntries={recentEntries}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Search for food" });
+    fireEvent.focus(input);
+
+    expect(screen.getByRole("tab", { name: "Recents" })).toBeInTheDocument();
+    expect(screen.getByText("Banana")).toBeInTheDocument();
+
+    const recentItemButton = screen.getByRole("button", { name: /Banana/i });
+    fireEvent.click(recentItemButton);
+
+    expect(handleSelectSavedMeal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Banana",
+        protein: 1.1,
+        carbs: 23,
+        fats: 0.3,
+        mealType: "snack",
+      }),
+    );
+  });
 });

--- a/frontend/src/features/macroTracking/components/CalorieSearchForm.tsx
+++ b/frontend/src/features/macroTracking/components/CalorieSearchForm.tsx
@@ -7,10 +7,12 @@ import {
   Button,
   ProgressiveBlur,
   SearchIcon,
+  TabBar,
 } from "@/components/ui";
 import StatusIndicator from "@/components/ui/StatusIndicator";
 import { useFoodSearch } from "@/hooks/queries/useFoodSearch";
-import type { Ingredient } from "@/types/macro";
+import { useMacroHistory } from "@/hooks/queries/useMacroQueries";
+import type { Ingredient, MacroEntry } from "@/types/macro";
 
 import { calculateCaloriesFromMacros } from "../calculations";
 import { UnitConverter, type UnitType } from "../utils/units";
@@ -35,25 +37,49 @@ interface CalorieSearchProps {
     mealType: string;
     ingredients?: Ingredient[];
   }) => void;
+  recentEntries?: MacroEntry[];
 }
 
 type ActivePanel = "results" | "savedMeals" | null;
+type ActiveTab = "recents" | "savedMeals";
 
 const CalorieSearch = memo(function CalorieSearch({
   onResult,
   onSelectSavedMeal,
+  recentEntries,
 }: CalorieSearchProps) {
   const [query, setQuery] = useState("");
   const [submittedQuery, setSubmittedQuery] = useState("");
   const [activePanel, setActivePanel] = useState<ActivePanel>(null);
+  const [activeTab, setActiveTab] = useState<ActiveTab>("recents");
   const [isAtBottom, setIsAtBottom] = useState(false);
   const wrapperReference = useRef<HTMLDivElement>(null);
+
+  const { data: historyData, isLoading: isHistoryLoading } = useMacroHistory(
+    15,
+    0,
+  );
+
   const {
     data: results = [],
     isFetching: isSearching,
     isFetched,
     error: searchError,
   } = useFoodSearch(submittedQuery);
+
+  const rawRecents = recentEntries ?? historyData?.entries ?? [];
+  const displayRecents = useMemo(() => {
+    const seen = new Set<string>();
+    const unique: MacroEntry[] = [];
+    for (const item of rawRecents) {
+      const name = (item.foodName ?? item.mealName)?.trim();
+      if (name && !seen.has(name.toLowerCase())) {
+        seen.add(name.toLowerCase());
+        unique.push(item);
+      }
+    }
+    return unique.slice(0, 10);
+  }, [rawRecents]);
 
   const trimmedQuery = query.trim();
 
@@ -367,14 +393,94 @@ const CalorieSearch = memo(function CalorieSearch({
 
       {activePanel === "savedMeals" && query.length === 0 && (
         <div className="absolute top-full left-0 z-50 mt-2 w-full overflow-hidden rounded-xl border border-border bg-surface p-4 shadow-xl">
-          <SavedMealsList
-            onSelectMeal={(meal) => {
-              onSelectSavedMeal(meal);
-              setSubmittedQuery("");
-              setQuery("");
-              setActivePanel(null);
-            }}
-          />
+          <div className="mb-3">
+            <TabBar
+              items={[
+                { key: "recents", label: "Recents" },
+                { key: "savedMeals", label: "Saved Meals" },
+              ]}
+              activeKey={activeTab}
+              onChange={(key) => setActiveTab(key as ActiveTab)}
+              size="sm"
+            />
+          </div>
+
+          {activeTab === "recents" && (
+            <div className="max-h-60 overflow-y-auto pr-1">
+              {isHistoryLoading && !recentEntries ? (
+                <div className="space-y-2 py-1">
+                  {[1, 2, 3].map((index) => (
+                    <div
+                      key={index}
+                      className="h-10 animate-pulse rounded-lg bg-surface-2"
+                    />
+                  ))}
+                </div>
+              ) : displayRecents.length === 0 ? (
+                <div className="py-4 text-center text-sm text-muted">
+                  No recent entries found.
+                </div>
+              ) : (
+                <div className="divide-y divide-border/40">
+                  {displayRecents.map((entry) => {
+                    const entryName = entry.foodName ?? entry.mealName;
+                    const cals = Math.round(
+                      calculateCaloriesFromMacros(
+                        entry.protein,
+                        entry.carbs,
+                        entry.fats,
+                      ),
+                    );
+
+                    return (
+                      <button
+                        key={entry.id}
+                        type="button"
+                        onClick={() => {
+                          onSelectSavedMeal({
+                            name: entryName,
+                            protein: entry.protein,
+                            carbs: entry.carbs,
+                            fats: entry.fats,
+                            mealType: entry.mealType,
+                            ingredients: entry.ingredients,
+                          });
+                          setSubmittedQuery("");
+                          setQuery("");
+                          setActivePanel(null);
+                        }}
+                        className="w-full rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-surface-2 focus:bg-surface-2 focus:outline-none"
+                      >
+                        <div className="flex items-center justify-between">
+                          <span className="font-medium text-foreground">
+                            {entryName}
+                          </span>
+                          <span className="text-xs text-muted capitalize">
+                            {entry.mealType}
+                          </span>
+                        </div>
+                        <div className="mt-0.5 text-xs text-muted">
+                          Calories: {cals} kcal | Protein: {entry.protein}g,
+                          Carbs: {entry.carbs}g, Fats: {entry.fats}g
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+
+          {activeTab === "savedMeals" && (
+            <SavedMealsList
+              onSelectMeal={(meal) => {
+                onSelectSavedMeal(meal);
+                setSubmittedQuery("");
+                setQuery("");
+                setActivePanel(null);
+              }}
+            />
+          )}
         </div>
       )}
 

--- a/frontend/src/features/macroTracking/pages/HomePage.tsx
+++ b/frontend/src/features/macroTracking/pages/HomePage.tsx
@@ -111,13 +111,6 @@ export default function HomePage() {
 
   const nutritionProfile = useNutritionProfile(nutritionProfileSource);
 
-  const handleAddEntry = useCallback(
-    async (entry: MacroEntryInput) => {
-      await addMacroEntryMutation.mutateAsync(entry);
-    },
-    [addMacroEntryMutation],
-  );
-
   const handleSaveMeal = useCallback(
     async (entry: MacroEntry) => {
       const entryName = entry.foodName ?? entry.mealName;
@@ -152,6 +145,24 @@ export default function HomePage() {
       });
     },
     [createSavedMealMutation],
+  );
+
+  const handleAddEntry = useCallback(
+    async (entry: MacroEntryInput) => {
+      const newEntry = await addMacroEntryMutation.mutateAsync(entry);
+      if (entry.saveAsMeal) {
+        await handleSaveMeal({
+          id: (newEntry as MacroEntry | undefined)?.id ?? 0,
+          protein: entry.protein,
+          carbs: entry.carbs,
+          fats: entry.fats,
+          mealType: entry.mealType,
+          mealName: entry.mealName,
+          ingredients: entry.ingredients,
+        } as MacroEntry);
+      }
+    },
+    [addMacroEntryMutation, handleSaveMeal],
   );
 
   const handleUnsaveMeal = useCallback(

--- a/frontend/src/features/macroTracking/types/macro.ts
+++ b/frontend/src/features/macroTracking/types/macro.ts
@@ -11,6 +11,7 @@ export interface MacroEntryInput {
   entryDate: string; // YYYY-MM-DD
   entryTime: string; // HH:mm
   ingredients?: Ingredient[];
+  saveAsMeal?: boolean;
 }
 
 export interface EditingEntry {


### PR DESCRIPTION
## Summary
- Enabled quantity and unit editing for custom entries with dynamic macro scaling per 100g/ml/unit base calculations.
- Auto-attach base macro metadata (`baseProtein`, `baseCarbs`, `baseFats`, `baseQuantity`, `baseUnit`) on custom entry submission.
- Replaced bottom "Save as Meal" checkbox with a star toggle button adjacent to Meal Name label.
- Added `Recents` and `Saved Meals` tab overlay in `CalorieSearchForm`.
- Comprehensive test coverage for custom entry quantity editing, scaling, and direct meal saving.

## Verification
- `npm run test` - All 677 tests passing.
- `npm run typecheck` - Clean compilation.