### PR TITLE
v2.6.0: Free Nutrition Calculators, /tools Hub & Docker Hub Mirror

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -27,11 +30,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Extract backend image metadata
         id: backend-meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/macrotrackr-backend
+          images: |
+            ghcr.io/${{ github.repository_owner }}/macrotrackr-backend
+            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/macrotrackr-backend
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,format=short,prefix=sha-
@@ -42,6 +53,7 @@ jobs:
         with:
           context: .
           file: backend/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.backend-meta.outputs.tags }}
           labels: ${{ steps.backend-meta.outputs.labels }}
@@ -51,6 +63,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -62,11 +77,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Extract frontend image metadata
         id: frontend-meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/macrotrackr-frontend
+          images: |
+            ghcr.io/${{ github.repository_owner }}/macrotrackr-frontend
+            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/macrotrackr-frontend
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,format=short,prefix=sha-
@@ -77,6 +100,7 @@ jobs:
         with:
           context: .
           file: frontend/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.frontend-meta.outputs.tags }}
           labels: ${{ steps.frontend-meta.outputs.labels }}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macrotrackr-backend",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Backend API for Macro Trackr application",
   "module": "src/index.ts",
   "type": "module",

--- a/docs/organic-discovery-submissions.md
+++ b/docs/organic-discovery-submissions.md
@@ -1,0 +1,69 @@
+# Organic Discovery — Submission Content
+
+Copy-paste-ready content for external directories. All URLs verified as of 2026-08-11.
+
+## 1. awesome-selfhosted — Nutrition list
+
+PR against `awesome-selfhosted/awesome-selfhosted`, in the **Nutrition** list section (alphabetical). Entry format follows their `[name](url) - description. license, platform` convention:
+
+```
+- [Macro Trackr](https://github.com/arogan178/macrotrackr) - Self-hosted calorie and macro tracker with meal logging, barcode search, habits, and reporting. AGPL-3.0, Docker, Node.js
+```
+
+Notes:
+- License line must say `AGPL-3.0` exactly (their linter checks license names).
+- Platform tags they accept: `Docker`, `Node.js`, `Go`, etc. Keep to what's in the README.
+- Link must be the GitHub repo, not the hosted site.
+
+## 2. AlternativeTo — MyFitnessPal alternative
+
+Listing at `https://alternativeto.net/software/macrotrackr/`:
+
+**Name:** MacroTrackr
+
+**Description (blurb):**
+> Open source macro and calorie tracker. Log meals by barcode or search, track protein/carbs/fat targets, habits, and weekly trends — self-host it or use the free hosted version. No ads, no data reselling, no paywalled basics.
+
+**Tags:** calorie counter, macro tracker, nutrition tracker, meal tracker, self-hosted, open source
+
+**Link:** https://github.com/arogan178/macrotrackr
+
+## 3. Docker Hub mirror
+
+Compose defaults to GHCR (`ghcr.io/arogan178/macrotrackr-backend:latest`, `ghcr.io/arogan178/macrotrackr-frontend:latest`). Mirror to Docker Hub for visibility:
+
+```bash
+# one-time login, then per release:
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -f backend/Dockerfile -t arogan178/macrotrackr-backend:latest . --push
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -f frontend/Dockerfile -t arogan178/macrotrackr-frontend:latest . --push
+```
+
+**Docker Hub repo description (README tab):**
+
+> # MacroTrackr
+>
+> Self-hosted calorie and macro tracker: meal logging with barcode search, macro targets, habits, and weekly reporting. AGPL-3.0, no telemetry required.
+>
+> Run with Docker Compose — see https://github.com/arogan178/macrotrackr#self-hosting-with-docker-compose
+>
+> Two images: `macrotrackr-backend` (API + SQLite) and `macrotrackr-frontend` (web UI). Hosted version: https://macrotrackr.com
+
+## 4. Open Food Facts — apps list
+
+Submit at https://world.openfoodfacts.org/apps (uses their GitHub form):
+
+**App name:** MacroTrackr
+**Platform:** Web (PWA) + Android/iOS via Capacitor
+**Description:** Open source macro tracker that logs foods by Open Food Facts barcode search. Free and self-hostable; no account needed for searching.
+**Link:** https://github.com/arogan178/macrotrackr
+**Source code:** https://github.com/arogan178/macrotrackr (AGPL-3.0)
+
+## Checklist
+
+- [ ] awesome-selfhosted PR merged → watch stars/link-referrers
+- [ ] AlternativeTo listing approved
+- [ ] Docker Hub org/repos created, images pushed, description set
+- [ ] OFF apps list entry live
+- [ ] Add badge to README when listing is live (e.g. "Listed on AlternativeTo")

--- a/docs/organic-discovery-submissions.md
+++ b/docs/organic-discovery-submissions.md
@@ -1,28 +1,57 @@
 # Organic Discovery — Submission Content
 
-Copy-paste-ready content for external directories. All URLs verified as of 2026-08-11.
+Copy-paste-ready content for external directories. Checked 2026-08-11.
 
-## 1. awesome-selfhosted — Nutrition list
+The five free calculators at `/tools` (TDEE, BMR, macro, weight loss, protein) are the
+only part of the product that needs no account, so they carry every submission blurb.
 
-PR against `awesome-selfhosted/awesome-selfhosted`, in the **Nutrition** list section (alphabetical). Entry format follows their `[name](url) - description. license, platform` convention:
+## 1. awesome-selfhosted — Health and Fitness
 
-```
-- [Macro Trackr](https://github.com/arogan178/macrotrackr) - Self-hosted calorie and macro tracker with meal logging, barcode search, habits, and reporting. AGPL-3.0, Docker, Node.js
+`awesome-selfhosted/awesome-selfhosted-data` takes one YAML file per project at
+`software/<kebab-case-name>.yml` — not a line in the README. Submitted as
+[PR #2886](https://github.com/awesome-selfhosted/awesome-selfhosted-data/pull/2886):
+
+```yaml
+name: MacroTrackr
+website_url: https://macrotrackr.com
+source_code_url: https://github.com/arogan178/macrotrackr
+description: Calorie and macro tracker with meal logging, barcode search, habits, and reporting (alternative to MyFitnessPal).
+licenses:
+  - AGPL-3.0
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Health and Fitness
 ```
 
 Notes:
-- License line must say `AGPL-3.0` exactly (their linter checks license names).
-- Platform tags they accept: `Docker`, `Node.js`, `Go`, etc. Keep to what's in the README.
-- Link must be the GitHub repo, not the hosted site.
+
+- `licenses`, `platforms`, and `tags` values must match an existing file in their
+  `licenses.yml`, `platforms/`, and `tags/` directories. `AGPL-3.0`, `Nodejs`,
+  `Docker`, and `Health and Fitness` all exist.
+- Their guidelines ban redundant words in descriptions (_open-source_, _free_,
+  _self-hosted_) — the list already implies all three.
+- Comparisons belong in the description as `(alternative to $PRODUCT)`.
+- `website_url` is the project's own site; `source_code_url` is the repo. The PR as
+  submitted has the repo in both — worth a follow-up commit.
+- **Release-age risk:** they require the first release to be more than 4 months old.
+  Our GitHub releases were all backfilled on 2026-04-28, which is only ~3.5 months
+  ago, so the PR may draw their "no tagged releases" canned reply. The underlying git
+  tags go back to v1.0.0 on 2025-04-16 — say so in a PR comment if it comes up.
 
 ## 2. AlternativeTo — MyFitnessPal alternative
 
-Listing at `https://alternativeto.net/software/macrotrackr/`:
+Listing at `https://alternativeto.net/software/macrotrackr/` (live once approved):
 
 **Name:** MacroTrackr
 
 **Description (blurb):**
-> Open source macro and calorie tracker. Log meals by barcode or search, track protein/carbs/fat targets, habits, and weekly trends — self-host it or use the free hosted version. No ads, no data reselling, no paywalled basics.
+
+> Open source macro and calorie tracker. Log meals by barcode or search, track
+> protein/carbs/fat targets, habits, and weekly trends — self-host it or use the free
+> hosted version. Free TDEE, BMR, macro, and protein calculators run without an
+> account. No ads, no data reselling, no paywalled basics.
 
 **Tags:** calorie counter, macro tracker, nutrition tracker, meal tracker, self-hosted, open source
 
@@ -30,21 +59,25 @@ Listing at `https://alternativeto.net/software/macrotrackr/`:
 
 ## 3. Docker Hub mirror
 
-Compose defaults to GHCR (`ghcr.io/arogan178/macrotrackr-backend:latest`, `ghcr.io/arogan178/macrotrackr-frontend:latest`). Mirror to Docker Hub for visibility:
+Compose defaults to GHCR (`ghcr.io/arogan178/macrotrackr-backend:latest`,
+`ghcr.io/arogan178/macrotrackr-frontend:latest`). Mirror to Docker Hub for visibility.
 
-```bash
-# one-time login, then per release:
-docker buildx build --platform linux/amd64,linux/arm64 \
-  -f backend/Dockerfile -t arogan178/macrotrackr-backend:latest . --push
-docker buildx build --platform linux/amd64,linux/arm64 \
-  -f frontend/Dockerfile -t arogan178/macrotrackr-frontend:latest . --push
-```
+Do this in `.github/workflows/publish-images.yml` rather than by hand, so the mirror
+cannot drift from releases: add a second `docker/login-action` for `docker.io`, a
+second `images:` line to each `docker/metadata-action`, and
+`platforms: linux/amd64,linux/arm64` to both build steps. Needs `DOCKERHUB_USERNAME`
+and `DOCKERHUB_TOKEN` repo secrets.
+
+Note the images we publish today are **amd64 only** — the workflow sets no
+`platforms:`. arm64 matters here, since Raspberry Pi and NAS users are most of the
+traffic awesome-selfhosted sends. Fix that in the same change.
 
 **Docker Hub repo description (README tab):**
 
 > # MacroTrackr
 >
-> Self-hosted calorie and macro tracker: meal logging with barcode search, macro targets, habits, and weekly reporting. AGPL-3.0, no telemetry required.
+> Self-hosted calorie and macro tracker: meal logging with barcode search, macro
+> targets, habits, and weekly reporting. AGPL-3.0, no telemetry required.
 >
 > Run with Docker Compose — see https://github.com/arogan178/macrotrackr#self-hosting-with-docker-compose
 >
@@ -52,18 +85,30 @@ docker buildx build --platform linux/amd64,linux/arm64 \
 
 ## 4. Open Food Facts — apps list
 
-Submit at https://world.openfoodfacts.org/apps (uses their GitHub form):
+`https://world.openfoodfacts.org/apps` now 404s. The reusers/apps list lives on their
+wiki (https://wiki.openfoodfacts.org, behind Anubis bot protection, so open it in a
+real browser), and the practical route to getting listed is their Slack at
+https://slack.openfoodfacts.org — introduce the app in the relevant channel and ask
+where reusers are catalogued now.
 
 **App name:** MacroTrackr
 **Platform:** Web (PWA) + Android/iOS via Capacitor
-**Description:** Open source macro tracker that logs foods by Open Food Facts barcode search. Free and self-hostable; no account needed for searching.
+**Description:** Macro tracker that logs foods by Open Food Facts barcode search, with free nutrition calculators that need no account.
 **Link:** https://github.com/arogan178/macrotrackr
 **Source code:** https://github.com/arogan178/macrotrackr (AGPL-3.0)
 
+Do not claim food search works without an account — `/api/macros/search` sits behind
+the auth middleware (`backend/src/app.ts`), and it is not in `AUTH_EXEMPT_PATHS`
+(`backend/src/middleware/clerk-auth.ts`). The `/tools` calculators are the
+account-free surface.
+
 ## Checklist
 
-- [ ] awesome-selfhosted PR merged → watch stars/link-referrers
-- [ ] AlternativeTo listing approved
-- [ ] Docker Hub org/repos created, images pushed, description set
+- [x] awesome-selfhosted PR submitted (PR #2886: https://github.com/awesome-selfhosted/awesome-selfhosted-data/pull/2886) → watch stars/link-referrers when merged
+- [ ] Follow up on PR #2886: point `website_url` at https://macrotrackr.com, add the MyFitnessPal comparison to the description
+- [x] AlternativeTo listing submitted (pending review/approval)
+- [x] Docker Hub repos created (public), `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets added under Actions, `publish-images.yml` mirrors GHCR + Docker Hub for `linux/amd64,linux/arm64`
+- [ ] Docker Hub short descriptions + README tab filled in (see blurb above)
+- [ ] First `master` push verified: both registries tagged, `docker manifest inspect` shows two architectures
 - [ ] OFF apps list entry live
 - [ ] Add badge to README when listing is live (e.g. "Listed on AlternativeTo")

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "macrotrackr-frontend",
   "private": true,
-  "version": "2.5.0",
+  "version": "2.6.0",
   "type": "module",
   "scripts": {
     "dev": "bunx vite",

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -2,85 +2,133 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://macrotrackr.com/</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/blog</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://macrotrackr.com/tools</loc>
+    <lastmod>2026-08-11</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://macrotrackr.com/tools/tdee-calculator</loc>
+    <lastmod>2026-08-11</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://macrotrackr.com/tools/bmr-calculator</loc>
+    <lastmod>2026-08-11</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://macrotrackr.com/tools/macro-calculator</loc>
+    <lastmod>2026-08-11</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://macrotrackr.com/tools/weight-loss-calculator</loc>
+    <lastmod>2026-08-11</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://macrotrackr.com/tools/protein-calculator</loc>
+    <lastmod>2026-08-11</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://macrotrackr.com/pricing</loc>
+    <lastmod>2026-08-11</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://macrotrackr.com/login</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/register</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/reset-password</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/privacy</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/terms</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>
   </url>
   <url>
+    <loc>https://macrotrackr.com/blog/v2-5-mobile-ux-polish-and-responsive-density</loc>
+    <lastmod>2026-08-11</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://macrotrackr.com/blog/v2-launch-complete-ui-overhaul</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-03-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/blog/how-to-estimate-restaurant-meals-without-guessing-blind</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-02-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/blog/why-weekly-averages-beat-perfect-days</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/blog/macro-tracking-tips-for-beginners</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-02-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/blog/understanding-protein-intake</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-01-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/blog/meal-prep-for-macro-tracking</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-01-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/blog/carbs-fats-balance</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2025-12-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/frontend/scripts/generate-sitemap.js
+++ b/frontend/scripts/generate-sitemap.js
@@ -7,6 +7,13 @@ import path from "path";
 const routes = [
   { path: "/", changefreq: "weekly", priority: 0.8 },
   { path: "/blog", changefreq: "weekly", priority: 0.7 },
+  { path: "/tools", changefreq: "monthly", priority: 0.7 },
+  { path: "/tools/tdee-calculator", changefreq: "monthly", priority: 0.6 },
+  { path: "/tools/bmr-calculator", changefreq: "monthly", priority: 0.6 },
+  { path: "/tools/macro-calculator", changefreq: "monthly", priority: 0.6 },
+  { path: "/tools/weight-loss-calculator", changefreq: "monthly", priority: 0.6 },
+  { path: "/tools/protein-calculator", changefreq: "monthly", priority: 0.6 },
+  { path: "/pricing", changefreq: "monthly", priority: 0.6 },
   { path: "/login", changefreq: "monthly", priority: 0.5 },
   { path: "/register", changefreq: "monthly", priority: 0.5 },
   { path: "/reset-password", changefreq: "monthly", priority: 0.5 },
@@ -14,14 +21,7 @@ const routes = [
   { path: "/terms", changefreq: "yearly", priority: 0.2 },
 ];
 
-function formatDate(date) {
-  return date.toISOString().split("T")[0];
-}
-
 function buildSitemap(hostname) {
-  const lastmod = formatDate(new Date());
-
-  // Dynamically resolve and read blog posts
   const blogPostsPath = path.resolve(
     new URL("../src/data/blog-posts.json", import.meta.url).pathname,
   );
@@ -33,17 +33,24 @@ function buildSitemap(hostname) {
     console.error("Warning: Could not read blog-posts.json:", err.message);
   }
 
-  const dynamicRoutes = blogPosts.map((post) => ({
-    path: `/blog/${post.slug}`,
-    changefreq: "weekly",
-    priority: 0.6,
-  }));
+  // Static pages share the newest post date as their lastmod (content freshness).
+  const newestPostDate =
+    blogPosts.map((post) => post.date).sort().at(-1) ??
+    new Date().toISOString().slice(0, 10);
 
-  const allRoutes = [...routes, ...dynamicRoutes];
+  const allRoutes = [
+    ...routes.map((r) => ({ ...r, lastmod: newestPostDate })),
+    ...blogPosts.map((post) => ({
+      path: `/blog/${post.slug}`,
+      changefreq: "weekly",
+      priority: 0.6,
+      lastmod: post.date || newestPostDate,
+    })),
+  ];
 
   const urls = allRoutes
     .map((r) => {
-      return `  <url>\n    <loc>${hostname}${r.path}</loc>\n    <lastmod>${lastmod}</lastmod>\n    <changefreq>${r.changefreq}</changefreq>\n    <priority>${r.priority}</priority>\n  </url>`;
+      return `  <url>\n    <loc>${hostname}${r.path}</loc>\n    <lastmod>${r.lastmod}</lastmod>\n    <changefreq>${r.changefreq}</changefreq>\n    <priority>${r.priority}</priority>\n  </url>`;
     })
     .join("\n");
 

--- a/frontend/src/data/release-notes.json
+++ b/frontend/src/data/release-notes.json
@@ -1,5 +1,18 @@
 [
   {
+    "version": "2.6.0",
+    "date": "2026-08-11",
+    "title": "Free Nutrition Calculators & Organic Discovery",
+    "type": "release",
+    "highlights": [
+      "Five free calculators at /tools: TDEE, BMR, macro split, weight loss timeline, and protein intake",
+      "No account required \u2014 every calculator runs entirely in the browser",
+      "New Tools menu in the header and a calculator hub with cross-linking",
+      "Structured data and sitemap coverage so the calculators are discoverable in search",
+      "Container images now published to Docker Hub alongside GHCR, for both amd64 and arm64"
+    ]
+  },
+  {
     "version": "2.5.0",
     "date": "2026-08-11",
     "title": "Mobile Layout Polish & Compact UX",

--- a/frontend/src/features/landing/components/Footer.tsx
+++ b/frontend/src/features/landing/components/Footer.tsx
@@ -57,6 +57,11 @@ const Footer: React.FC = () => {
                   Blog
                 </Link>
               </li>
+              <li>
+                <Link to="/tools" className={footerLinkClasses}>
+                  Free Calculators
+                </Link>
+              </li>
             </ul>
           </div>
 

--- a/frontend/src/features/landing/components/Header.tsx
+++ b/frontend/src/features/landing/components/Header.tsx
@@ -1,10 +1,14 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
 import { usePostHog } from "posthog-js/react";
 
 import LogoButton from "@/components/layout/LogoButton";
-import { ExternalLinkIcon, GithubIcon } from "@/components/ui";
+import { ChevronDownIcon, ExternalLinkIcon, GithubIcon } from "@/components/ui";
 import { getButtonClasses } from "@/components/ui/Button";
+import {
+  CALCULATOR_TOOLS,
+  TOOLS_HUB_PATH,
+} from "@/features/landing/tools/toolsCatalog";
 import { DOCS_URL, GITHUB_REPO_URL } from "@/utils/appConstants";
 
 const navLinkClasses =
@@ -13,12 +17,102 @@ const navLinkClasses =
 const externalLinkClasses =
   "inline-flex min-h-11 items-center gap-1.5 rounded-full px-4 py-2 text-sm font-medium text-muted transition-colors duration-200 hover:bg-surface hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none";
 
+const toolsPopoverItems = [
+  {
+    to: TOOLS_HUB_PATH,
+    label: "All free calculators",
+    description: "Browse the complete suite of nutrition tools",
+  },
+  ...CALCULATOR_TOOLS.map((tool) => ({
+    to: tool.path,
+    label: tool.navLabel ?? tool.title,
+    description: tool.tagline,
+  })),
+];
+
+interface ToolsDropdownProps {
+  isActive: boolean;
+  currentPath: string;
+}
+
+const ToolsDropdown: React.FC<ToolsDropdownProps> = ({
+  isActive,
+  currentPath,
+}) => {
+  const [open, setOpen] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  // Close when the route changes, including on browser back/forward.
+  // jsdom has no popover API, hence the optional call.
+  const closePopover = () => popoverRef.current?.hidePopover?.();
+  useEffect(closePopover, [currentPath]);
+
+  return (
+    <>
+      {/* Light dismiss, Escape, and focus restoration come from the popover API. */}
+      <button
+        type="button"
+        popoverTarget="tools-popover"
+        className={`${navLinkClasses} gap-1.5 [anchor-name:--tools-trigger] ${isActive ? "bg-surface-2 text-foreground" : ""}`}
+      >
+        Tools
+        <ChevronDownIcon
+          className={`h-3.5 w-3.5 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+          aria-hidden="true"
+        />
+      </button>
+      <div
+        ref={popoverRef}
+        id="tools-popover"
+        popover="auto"
+        onToggle={(event) => setOpen(event.newState === "open")}
+        className="w-80 rounded-2xl border border-border bg-surface p-2 shadow-modal [margin:0.5rem_0_0_0] [position-anchor:--tools-trigger] [position-area:bottom_span-right]"
+      >
+        <p
+          id="tools-popover-heading"
+          className="px-3 pt-1 pb-2 text-xs font-semibold uppercase tracking-wider text-muted"
+        >
+          Free calculators
+        </p>
+        <ul aria-labelledby="tools-popover-heading">
+          {toolsPopoverItems.map((tool) => {
+            const isCurrent = tool.to === currentPath;
+
+            return (
+              <li key={tool.to}>
+                <Link
+                  to={tool.to}
+                  onClick={closePopover}
+                  aria-current={isCurrent ? "page" : undefined}
+                  className={`block rounded-xl px-3 py-2.5 transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none ${
+                    isCurrent ? "bg-surface-2" : "hover:bg-surface-2"
+                  }`}
+                >
+                  <span
+                    className={`block text-sm font-medium ${isCurrent ? "text-primary" : "text-foreground"}`}
+                  >
+                    {tool.label}
+                  </span>
+                  <span className="block text-xs text-muted">
+                    {tool.description}
+                  </span>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </>
+  );
+};
+
 const Header: React.FC = () => {
   const posthog = usePostHog();
   const location = useLocation();
   const navigate = useNavigate();
   const isLandingPage = location.pathname === "/";
   const isBlogPage = location.pathname.startsWith("/blog");
+  const isToolsPage = location.pathname.startsWith("/tools");
 
   const captureNavigation = (source: string) => {
     posthog.capture("clicked_pricing_nav", {
@@ -76,6 +170,10 @@ const Header: React.FC = () => {
               </a>
             </>
           ) : null}
+          <ToolsDropdown
+            isActive={isToolsPage}
+            currentPath={location.pathname}
+          />
           <a
             href={DOCS_URL}
             target="_blank"

--- a/frontend/src/features/landing/pages/BmrCalculatorPage.tsx
+++ b/frontend/src/features/landing/pages/BmrCalculatorPage.tsx
@@ -1,0 +1,119 @@
+import { useState } from "react";
+import { Link } from "@tanstack/react-router";
+
+import { ArrowRightIcon } from "@/components/ui";
+import { calculateBMR } from "@/utils/nutritionCalculations";
+import { ACTIVITY_LEVELS } from "@/utils/userConstants";
+
+import BodyStatsForm from "../tools/BodyStatsForm";
+import CalculatorLayout from "../tools/CalculatorLayout";
+import {
+  calculatorCardClass,
+  calculatorResultCardClass,
+  calculatorResultColumnClass,
+  calculatorSectionDescriptionClass,
+  calculatorSectionTitleClass,
+} from "../tools/calculatorStyles";
+import ResultHeadline from "../tools/ResultHeadline";
+import { useBodyStats } from "../tools/useBodyStats";
+
+const FAQS = [
+  {
+    question: "What is Basal Metabolic Rate (BMR)?",
+    answer:
+      "BMR is the number of calories your body burns at rest to maintain essential life functions like breathing, circulation, cell production, and temperature regulation.",
+  },
+  {
+    question: "What is the difference between BMR and TDEE?",
+    answer:
+      "BMR is your baseline resting energy burn. TDEE (Total Daily Energy Expenditure) includes your BMR plus the calories burned through movement, exercise, and digesting food.",
+  },
+  {
+    question: "Which formula does this calculator use?",
+    answer:
+      "This calculator uses the Mifflin-St Jeor equation, widely recognized in clinical research as the most accurate formula for estimating resting metabolic rate.",
+  },
+  {
+    question: "Should I eat less than my BMR?",
+    answer:
+      "Generally no. Eating below your BMR for extended periods can cause muscle loss, nutrient deficiencies, low energy levels, and hormonal disruption. Aim to eat between your BMR and TDEE for weight loss.",
+  },
+];
+
+export default function BmrCalculatorPage() {
+  const stats = useBodyStats();
+  const { weightKg, heightCm, age, gender } = stats;
+  const statsReady = stats.ready;
+
+  const bmr = statsReady ? calculateBMR(weightKg, heightCm, age, gender) : 0;
+
+  return (
+    <CalculatorLayout
+      title="BMR Calculator"
+      subtitle="Estimate the calories your body uses at complete rest to keep essential functions running."
+      canonicalPath="/tools/bmr-calculator"
+      description="Free Basal Metabolic Rate (BMR) calculator using the Mifflin-St Jeor equation. Calculate your baseline calories burned at rest."
+      faqs={FAQS}
+    >
+      <div className="grid grid-cols-1 gap-8 lg:grid-cols-12">
+        {/* Form Inputs */}
+        <div className={`lg:col-span-7 ${calculatorCardClass}`}>
+          <h2 className={calculatorSectionTitleClass}>Your Body Stats</h2>
+          <p className={`${calculatorSectionDescriptionClass} mb-5`}>
+            We use the Mifflin-St Jeor equation for this estimate.
+          </p>
+          <BodyStatsForm stats={stats} />
+        </div>
+
+        {/* BMR Output Card */}
+        <div
+          className={`${calculatorResultColumnClass} ${calculatorResultCardClass}`}
+        >
+          <ResultHeadline
+            label="Your Resting Burn"
+            value={bmr}
+            unit="kcal / day"
+            ready={statsReady}
+          />
+          {statsReady ? (
+            <p className="mt-3 text-sm leading-relaxed text-muted">
+              This is the energy your body uses for essential functions before
+              movement, exercise, and digestion.
+            </p>
+          ) : null}
+
+          <div className="mt-8 border-t border-border pt-6">
+            <h3 className="text-xs font-bold uppercase tracking-wider text-foreground">
+              Estimated Burn by Activity
+            </h3>
+            <p className="mt-1 mb-3 text-xs leading-relaxed text-muted">
+              Layer daily movement on top to approximate a full day of burn.
+            </p>
+            <ul className="space-y-2">
+              {Object.values(ACTIVITY_LEVELS).map((level) => (
+                <li
+                  key={level.value}
+                  className="flex items-center justify-between gap-3 rounded-xl border border-border bg-surface-2/50 px-3 py-2.5 text-xs"
+                >
+                  <span className="truncate font-medium text-muted">
+                    {level.label}
+                  </span>
+                  <span className="whitespace-nowrap rounded-lg border border-border bg-surface px-2 py-1 font-semibold text-foreground tabular-nums">
+                    {Math.round(bmr * level.multiplier)} kcal
+                  </span>
+                </li>
+              ))}
+            </ul>
+            <Link
+              to="/tools/tdee-calculator"
+              className="mt-4 inline-flex min-h-11 items-center gap-1.5 rounded-lg text-xs font-semibold text-primary transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none"
+            >
+              Get a full TDEE breakdown
+              <ArrowRightIcon className="h-3.5 w-3.5" aria-hidden="true" />
+            </Link>
+          </div>
+        </div>
+      </div>
+    </CalculatorLayout>
+  );
+}

--- a/frontend/src/features/landing/pages/MacroCalculatorPage.tsx
+++ b/frontend/src/features/landing/pages/MacroCalculatorPage.tsx
@@ -1,0 +1,269 @@
+import { useState } from "react";
+
+import Dropdown from "@/components/form/Dropdown";
+import NumberField from "@/components/form/NumberField";
+import MacroSlider from "@/components/macros/MacroSlider";
+import { COLOR_MAP } from "@/components/utils/UiConstants";
+import type { MacroType } from "@/types/macro";
+import {
+  calculateBMR,
+  calculateMacroTarget,
+  calculateTDEE,
+} from "@/utils/nutritionCalculations";
+import {
+  getActivityLevelFromString,
+  getActivityLevelMultiplier,
+} from "@/utils/userConstants";
+
+import BodyStatsForm from "../tools/BodyStatsForm";
+import { toNumericInput } from "../tools/calculatorInputs";
+import CalculatorLayout from "../tools/CalculatorLayout";
+import {
+  calculatorCardClass,
+  calculatorResultCardClass,
+  calculatorResultColumnClass,
+  calculatorSectionDescriptionClass,
+  calculatorSectionTitleClass,
+} from "../tools/calculatorStyles";
+import { redistributeMacroPercentages } from "../tools/macroRedistribution";
+import ResultHeadline from "../tools/ResultHeadline";
+import { useBodyStats } from "../tools/useBodyStats";
+
+const FAQS = [
+  {
+    question: "What is a macro split?",
+    answer:
+      "A macro split is the percentage breakdown of daily calories coming from Protein (4 kcal/g), Carbohydrates (4 kcal/g), and Fats (9 kcal/g).",
+  },
+  {
+    question: "What is the best macro split for fat loss?",
+    answer:
+      "A common high-protein split for fat loss is 35% Protein / 35% Carbs / 30% Fats. High protein preserves lean muscle tissue while in a calorie deficit.",
+  },
+  {
+    question: "What is the best macro split for muscle building?",
+    answer:
+      "For lean muscle gain, 30% Protein / 45% Carbs / 25% Fats works well. Higher carbs replenish glycogen stores and fuel intense workout performance.",
+  },
+];
+
+const GOAL_OPTIONS = [
+  { value: "lose", label: "Fat Loss (-500 kcal)" },
+  { value: "maintain", label: "Maintenance (TDEE)" },
+  { value: "gain", label: "Muscle Gain (+300 kcal)" },
+  { value: "custom", label: "Custom Calorie Target" },
+];
+
+export default function MacroCalculatorPage() {
+  const stats = useBodyStats();
+  const { weightKg, heightCm, age, gender, activityLevel } = stats;
+  const statsReady = stats.ready;
+
+  const [goal, setGoal] = useState<"lose" | "maintain" | "gain" | "custom">(
+    "lose",
+  );
+  const [customCalories, setCustomCalories] = useState(2000);
+
+  const [percentages, setPercentages] = useState({
+    proteinPercentage: 30,
+    carbsPercentage: 40,
+    fatsPercentage: 30,
+  });
+  const [lockedMacros, setLockedMacros] = useState<MacroType[]>([]);
+
+  const bmr = statsReady ? calculateBMR(weightKg, heightCm, age, gender) : 0;
+  const activityNumber = getActivityLevelFromString(activityLevel);
+  const multiplier = getActivityLevelMultiplier(activityNumber);
+  const tdee = calculateTDEE(bmr, multiplier);
+
+  const totalCalories =
+    goal === "custom"
+      ? customCalories
+      : goal === "lose"
+        ? Math.max(1200, tdee - 500)
+        : goal === "gain"
+          ? tdee + 300
+          : tdee;
+
+  const macroGrams = calculateMacroTarget(
+    totalCalories,
+    percentages.proteinPercentage,
+    percentages.carbsPercentage,
+    percentages.fatsPercentage,
+  );
+
+  // A custom calorie target does not depend on the body stats above it.
+  const resultReady = goal === "custom" || statsReady;
+
+  const macroRows = [
+    {
+      macro: "protein" as MacroType,
+      label: "Protein",
+      grams: macroGrams.proteinTarget,
+      percentage: percentages.proteinPercentage,
+      calories: macroGrams.proteinTarget * 4,
+    },
+    {
+      macro: "carbs" as MacroType,
+      label: "Carbs",
+      grams: macroGrams.carbsTarget,
+      percentage: percentages.carbsPercentage,
+      calories: macroGrams.carbsTarget * 4,
+    },
+    {
+      macro: "fats" as MacroType,
+      label: "Fats",
+      grams: macroGrams.fatsTarget,
+      percentage: percentages.fatsPercentage,
+      calories: macroGrams.fatsTarget * 9,
+    },
+  ];
+
+  const handleSliderChange = (macro: MacroType, newValue: number) => {
+    setPercentages((prev) =>
+      redistributeMacroPercentages(macro, newValue, prev, lockedMacros),
+    );
+  };
+
+  const toggleLock = (macro: MacroType) => {
+    setLockedMacros((prev) =>
+      prev.includes(macro) ? prev.filter((m) => m !== macro) : [...prev, macro],
+    );
+  };
+
+  return (
+    <CalculatorLayout
+      title="Macro Calculator"
+      subtitle="Build a daily macronutrient target with adjustable protein, carbohydrate, and fat ratios."
+      canonicalPath="/tools/macro-calculator"
+      description="Free Flexible Macro Calculator. Customize your protein, carbohydrate, and fat percentage splits to hit your fitness goals."
+      faqs={FAQS}
+    >
+      <div className="grid grid-cols-1 gap-8 lg:grid-cols-12">
+        {/* Left Inputs */}
+        <div className="lg:col-span-7 space-y-6">
+          <div className={calculatorCardClass}>
+            <h2 className={calculatorSectionTitleClass}>Body Stats & Goal</h2>
+            <p className={`${calculatorSectionDescriptionClass} mb-5`}>
+              Choose a goal to set calories, then fine-tune your split below.
+            </p>
+            <BodyStatsForm stats={stats} showActivity />
+
+            <div className="mt-4 grid grid-cols-1 items-end gap-4 sm:grid-cols-2">
+              <Dropdown
+                label="Goal Preset"
+                value={goal}
+                onChange={(v) =>
+                  setGoal(v as "lose" | "maintain" | "gain" | "custom")
+                }
+                options={GOAL_OPTIONS}
+              />
+              {goal === "custom" ? (
+                <NumberField
+                  label="Custom Daily Calories"
+                  value={customCalories || ""}
+                  onChange={(v) => setCustomCalories(toNumericInput(v, 10000))}
+                  min={800}
+                  max={10000}
+                  unit="kcal"
+                  maxDigits={5}
+                />
+              ) : (
+                <p className="rounded-xl border border-border bg-surface-2/50 px-3 py-2.5 text-xs leading-relaxed text-muted">
+                  Based on your maintenance estimate of{" "}
+                  <strong className="font-semibold text-foreground tabular-nums">
+                    {tdee} kcal
+                  </strong>
+                  . Switch to a custom target to set calories yourself.
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* Macro Sliders */}
+          <div className={calculatorCardClass}>
+            <div className="flex flex-wrap items-baseline justify-between gap-2">
+              <h2 className={calculatorSectionTitleClass}>
+                Macro Distribution Split
+              </h2>
+              <span className="rounded-full border border-border bg-surface-2/60 px-2.5 py-1 text-xs font-medium text-muted tabular-nums">
+                Total 100%
+              </span>
+            </div>
+            <p className={`${calculatorSectionDescriptionClass} mb-6`}>
+              Moving one slider rebalances the others. Lock a macro to hold it
+              in place.
+            </p>
+            <div className="space-y-6">
+              <MacroSlider
+                name="Protein"
+                color="protein"
+                value={percentages.proteinPercentage}
+                onChange={(val) => handleSliderChange("protein", val)}
+                isLocked={lockedMacros.includes("protein")}
+                onToggleLock={() => toggleLock("protein")}
+              />
+              <MacroSlider
+                name="Carbs"
+                color="carbs"
+                value={percentages.carbsPercentage}
+                onChange={(val) => handleSliderChange("carbs", val)}
+                isLocked={lockedMacros.includes("carbs")}
+                onToggleLock={() => toggleLock("carbs")}
+              />
+              <MacroSlider
+                name="Fats"
+                color="fats"
+                value={percentages.fatsPercentage}
+                onChange={(val) => handleSliderChange("fats", val)}
+                isLocked={lockedMacros.includes("fats")}
+                onToggleLock={() => toggleLock("fats")}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Right Output Card */}
+        <div
+          className={`${calculatorResultColumnClass} ${calculatorResultCardClass}`}
+        >
+          <ResultHeadline
+            label="Daily Target Summary"
+            value={totalCalories}
+            unit="kcal / day"
+            ready={resultReady}
+          />
+
+          <ul className="mt-8 space-y-3 border-t border-border pt-6">
+            {macroRows.map((row) => (
+              <li
+                key={row.macro}
+                className="rounded-xl border border-border bg-surface-2/50 p-3"
+              >
+                <div className="mb-1 flex items-center justify-between gap-2 text-xs">
+                  <span className="flex items-center gap-2 font-bold text-foreground">
+                    <span
+                      className={`h-2 w-2 rounded-full ${COLOR_MAP[row.macro].dot}`}
+                      aria-hidden="true"
+                    />
+                    {row.label}
+                  </span>
+                  <span className="text-muted tabular-nums">
+                    {row.percentage}% · {row.calories} kcal
+                  </span>
+                </div>
+                <div className="text-xl font-extrabold text-foreground tabular-nums">
+                  {row.grams}g
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          <p className="mt-6 text-sm leading-relaxed text-muted">
+            Protein and carbs provide 4 calories per gram. Fat provides 9.
+          </p>
+        </div>
+      </div>
+    </CalculatorLayout>
+  );
+}

--- a/frontend/src/features/landing/pages/ProteinCalculatorPage.tsx
+++ b/frontend/src/features/landing/pages/ProteinCalculatorPage.tsx
@@ -1,0 +1,246 @@
+import { useState } from "react";
+
+import Dropdown from "@/components/form/Dropdown";
+import NumberField from "@/components/form/NumberField";
+import { kgToLb } from "@/utils/unitConversion";
+
+import BodyStatsForm from "../tools/BodyStatsForm";
+import { toNumericInput } from "../tools/calculatorInputs";
+import CalculatorLayout from "../tools/CalculatorLayout";
+import {
+  calculatorCardClass,
+  calculatorResultCardClass,
+  calculatorResultColumnClass,
+  calculatorSectionDescriptionClass,
+  calculatorSectionTitleClass,
+  calculatorStatLabelClass,
+  calculatorStatRowClass,
+  calculatorStatValueClass,
+} from "../tools/calculatorStyles";
+import ResultHeadline from "../tools/ResultHeadline";
+import { useBodyStats } from "../tools/useBodyStats";
+
+const FAQS = [
+  {
+    question: "How much protein do I need per day?",
+    answer:
+      "General healthy adults need 1.2–1.6g per kg of body weight. Active individuals training with resistance or in a calorie deficit benefit from 1.6–2.4g per kg (0.8–1.1g per lb) to build and retain muscle.",
+  },
+  {
+    question: "Is high protein intake safe for healthy kidneys?",
+    answer:
+      "Yes. Research consistently shows high protein diets (up to 3.3g/kg per day) are completely safe for healthy adults without pre-existing kidney conditions.",
+  },
+  {
+    question: "How much protein can the body absorb in one meal?",
+    answer:
+      "Your digestive system can absorb virtually all protein eaten in a meal. However, muscle protein synthesis peaks around 30–50g of high-quality protein per meal.",
+  },
+];
+
+const TRAINING_GOAL_OPTIONS = [
+  {
+    value: "1.2",
+    label: "Sedentary / Maintenance (1.2g per kg / ~0.55g per lb)",
+  },
+  {
+    value: "1.6",
+    label: "Active / Endurance (1.6g per kg / ~0.73g per lb)",
+  },
+  {
+    value: "2.2",
+    label: "Strength / Muscle Building (2.2g per kg / ~1.00g per lb)",
+  },
+  {
+    value: "2.4",
+    label: "Fat Loss Deficit / Cut (2.4g per kg / ~1.10g per lb)",
+  },
+];
+
+const HIGH_PROTEIN_FOODS = [
+  {
+    name: "Chicken Breast (Cooked)",
+    serving: "100g",
+    protein: "31g",
+    cals: "165",
+  },
+  {
+    name: "Greek Yogurt (Non-fat)",
+    serving: "200g",
+    protein: "20g",
+    cals: "120",
+  },
+  { name: "Salmon (Cooked)", serving: "100g", protein: "25g", cals: "206" },
+  { name: "Whey Protein Scoop", serving: "30g", protein: "24g", cals: "120" },
+  {
+    name: "Cottage Cheese (Low-fat)",
+    serving: "150g",
+    protein: "18g",
+    cals: "125",
+  },
+  { name: "Whole Eggs", serving: "3 large", protein: "18g", cals: "210" },
+  { name: "Extra Firm Tofu", serving: "150g", protein: "15g", cals: "120" },
+  { name: "Cooked Lentils", serving: "200g", protein: "18g", cals: "230" },
+];
+
+export default function ProteinCalculatorPage() {
+  const stats = useBodyStats();
+  const { weightKg } = stats;
+
+  const [proteinRatio, setProteinRatio] = useState(2.2);
+  const [mealsPerDay, setMealsPerDay] = useState(4);
+
+  const weightReady = weightKg > 0;
+  const totalProteinGrams = Math.round(weightKg * proteinRatio);
+  const safeMealsPerDay = Math.max(1, mealsPerDay);
+  const perMealGrams = Math.round(totalProteinGrams / safeMealsPerDay);
+  const gramsPerLb = weightReady
+    ? (totalProteinGrams / kgToLb(weightKg)).toFixed(2)
+    : "0.00";
+
+  return (
+    <CalculatorLayout
+      title="Protein Intake Calculator"
+      subtitle="Estimate a practical daily protein target for muscle building, fat loss, or endurance training."
+      canonicalPath="/tools/protein-calculator"
+      description="Free Protein Intake Calculator. Calculate exact daily grams of protein and per-meal targets tailored to your weight and fitness goals."
+      faqs={FAQS}
+    >
+      <div className="grid grid-cols-1 gap-8 lg:grid-cols-12">
+        {/* Form Inputs */}
+        <div className="lg:col-span-7 space-y-6">
+          <div className={calculatorCardClass}>
+            <h2 className={calculatorSectionTitleClass}>
+              Body Stats & Fitness Goal
+            </h2>
+            <p className={`${calculatorSectionDescriptionClass} mb-5`}>
+              Pick the training context that best matches your current routine.
+            </p>
+            <BodyStatsForm stats={stats} />
+
+            <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <Dropdown
+                label="Training & Activity Goal"
+                value={String(proteinRatio)}
+                onChange={(v) => setProteinRatio(Number(v))}
+                options={TRAINING_GOAL_OPTIONS}
+              />
+
+              <NumberField
+                label="Meals per Day"
+                value={mealsPerDay || ""}
+                onChange={(v) => setMealsPerDay(toNumericInput(v, 8))}
+                min={1}
+                max={8}
+                unit="meals"
+                maxDigits={1}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Output Card */}
+        <div
+          className={`${calculatorResultColumnClass} ${calculatorResultCardClass}`}
+        >
+          <ResultHeadline
+            label="Recommended Daily Protein"
+            value={totalProteinGrams}
+            unit="grams / day"
+            ready={weightReady}
+            hint="Add your weight to see your protein target."
+          />
+
+          <dl className="mt-8 space-y-3 border-t border-border pt-6 text-sm">
+            <div className={calculatorStatRowClass}>
+              <dt className={calculatorStatLabelClass}>Target per meal</dt>
+              <dd className={calculatorStatValueClass}>~{perMealGrams}g</dd>
+            </div>
+            <div className={calculatorStatRowClass}>
+              <dt className={calculatorStatLabelClass}>
+                Protein per body weight
+              </dt>
+              <dd className={calculatorStatValueClass}>
+                {proteinRatio} g/kg ({gramsPerLb} g/lb)
+              </dd>
+            </div>
+            <div className={calculatorStatRowClass}>
+              <dt className={calculatorStatLabelClass}>
+                Total calories from protein
+              </dt>
+              <dd className={calculatorStatValueClass}>
+                {totalProteinGrams * 4} kcal
+              </dd>
+            </div>
+          </dl>
+
+          <p className="mt-6 text-sm leading-relaxed text-muted">
+            Spread across {safeMealsPerDay}{" "}
+            {safeMealsPerDay === 1 ? "meal" : "meals"}, that is roughly{" "}
+            {perMealGrams}g of protein each time you eat.
+          </p>
+        </div>
+      </div>
+
+      {/* Protein Source Reference Table */}
+      <div className={`mt-12 ${calculatorCardClass}`}>
+        <h2 className="mb-1 text-xl font-bold tracking-tight text-foreground">
+          High-Protein Food Ideas
+        </h2>
+        <p className="mb-4 text-sm text-muted">
+          Use these as quick reference points when planning meals.
+        </p>
+        <div className="-mx-1 overflow-x-auto px-1">
+          <table className="w-full min-w-100 text-left text-xs text-muted">
+            <thead className="border-b border-border/60 uppercase tracking-wider text-foreground">
+              <tr>
+                <th scope="col" className="px-3 py-2.5 font-semibold">
+                  Food item
+                </th>
+                <th scope="col" className="px-3 py-2.5 font-semibold">
+                  Serving
+                </th>
+                <th
+                  scope="col"
+                  className="px-3 py-2.5 text-right font-semibold"
+                >
+                  Protein
+                </th>
+                <th
+                  scope="col"
+                  className="px-3 py-2.5 text-right font-semibold"
+                >
+                  Calories
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border/40">
+              {HIGH_PROTEIN_FOODS.map((item) => (
+                <tr
+                  key={item.name}
+                  className="transition-colors hover:bg-surface-2/40"
+                >
+                  <th
+                    scope="row"
+                    className="px-3 py-2.5 text-left font-semibold text-foreground"
+                  >
+                    {item.name}
+                  </th>
+                  <td className="px-3 py-2.5 whitespace-nowrap">
+                    {item.serving}
+                  </td>
+                  <td className="px-3 py-2.5 text-right font-semibold text-foreground tabular-nums">
+                    {item.protein}
+                  </td>
+                  <td className="px-3 py-2.5 text-right whitespace-nowrap tabular-nums">
+                    {item.cals} kcal
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </CalculatorLayout>
+  );
+}

--- a/frontend/src/features/landing/pages/TdeeCalculatorPage.tsx
+++ b/frontend/src/features/landing/pages/TdeeCalculatorPage.tsx
@@ -1,0 +1,231 @@
+import AnimatedNumber from "@/components/animation/AnimatedNumber";
+import {
+  calculateBMR,
+  calculateMacroTarget,
+  calculateTDEE,
+} from "@/utils/nutritionCalculations";
+import {
+  ACTIVITY_LEVELS,
+  getActivityLevelFromString,
+  getActivityLevelMultiplier,
+} from "@/utils/userConstants";
+
+import BodyStatsForm from "../tools/BodyStatsForm";
+import CalculatorLayout from "../tools/CalculatorLayout";
+import {
+  calculatorCardClass,
+  calculatorResultCardClass,
+  calculatorResultColumnClass,
+  calculatorSectionDescriptionClass,
+  calculatorSectionTitleClass,
+  calculatorStatLabelClass,
+  calculatorStatRowClass,
+  calculatorStatValueClass,
+} from "../tools/calculatorStyles";
+import ResultHeadline from "../tools/ResultHeadline";
+import { useBodyStats } from "../tools/useBodyStats";
+
+const FAQS = [
+  {
+    question: "What is Total Daily Energy Expenditure (TDEE)?",
+    answer:
+      "TDEE is the total number of calories you burn each day through resting metabolism, daily movement, physical activity, and food digestion.",
+  },
+  {
+    question: "How should I use my TDEE to lose weight?",
+    answer:
+      "To lose fat, consume 300–500 calories below your TDEE daily. This creates a sustainable deficit resulting in about 0.5–1 lb (0.25–0.5 kg) of fat loss per week.",
+  },
+  {
+    question: "Which activity level should I select?",
+    answer:
+      "If you work a desk job and do not exercise, select Sedentary. If you work a desk job but work out 3-4 times a week, select Lightly Active or Moderately Active. Most people overestimate physical activity, so err on the conservative side.",
+  },
+];
+
+const GOAL_SPLIT = { protein: 30, carbs: 40, fats: 30 } as const;
+
+export default function TdeeCalculatorPage() {
+  const stats = useBodyStats();
+  const { weightKg, heightCm, age, gender, activityLevel, setActivityLevel } =
+    stats;
+  const statsReady = stats.ready;
+
+  const bmr = statsReady ? calculateBMR(weightKg, heightCm, age, gender) : 0;
+  const activityNumber = getActivityLevelFromString(activityLevel);
+  const multiplier = getActivityLevelMultiplier(activityNumber);
+  const tdee = calculateTDEE(bmr, multiplier);
+
+  const goalCards = [
+    {
+      key: "lose",
+      label: "Fat Loss",
+      accentClass: "text-vibrant-accent",
+      delta: "-500 kcal/day",
+      calories: Math.max(1200, tdee - 500),
+    },
+    {
+      key: "maintain",
+      label: "Maintenance",
+      accentClass: "text-primary",
+      delta: "Match your burn",
+      calories: tdee,
+      highlighted: true,
+    },
+    {
+      key: "gain",
+      label: "Muscle Gain",
+      accentClass: "text-success",
+      delta: "+300 kcal/day",
+      calories: tdee + 300,
+    },
+  ].map((goal) => ({
+    ...goal,
+    macros: calculateMacroTarget(
+      goal.calories,
+      GOAL_SPLIT.protein,
+      GOAL_SPLIT.carbs,
+      GOAL_SPLIT.fats,
+    ),
+  }));
+
+  return (
+    <CalculatorLayout
+      title="TDEE Calculator"
+      subtitle="Estimate your Total Daily Energy Expenditure and explore calorie targets for fat loss, maintenance, or muscle gain."
+      canonicalPath="/tools/tdee-calculator"
+      description="Free TDEE Calculator (Total Daily Energy Expenditure). Estimate your daily maintenance calories and macro splits accurately."
+      faqs={FAQS}
+    >
+      <div className="grid grid-cols-1 gap-8 lg:grid-cols-12">
+        {/* Form Inputs */}
+        <div className={`lg:col-span-7 ${calculatorCardClass}`}>
+          <h2 className={calculatorSectionTitleClass}>
+            Your Body Stats & Activity
+          </h2>
+          <p className={`${calculatorSectionDescriptionClass} mb-5`}>
+            Your maintenance estimate updates as you adjust these details.
+          </p>
+          <BodyStatsForm stats={stats} showActivity />
+        </div>
+
+        {/* TDEE Summary Card */}
+        <div
+          className={`${calculatorResultColumnClass} ${calculatorResultCardClass}`}
+        >
+          <ResultHeadline
+            label="Maintenance Calories (TDEE)"
+            value={tdee}
+            unit="kcal / day"
+            ready={statsReady}
+          />
+          {statsReady ? (
+            <p className="mt-3 text-xs leading-relaxed text-muted">
+              Your Basal Metabolic Rate (BMR) is{" "}
+              <strong className="text-foreground">{bmr} kcal</strong>. Activity
+              adds{" "}
+              <strong className="text-foreground">{tdee - bmr} kcal</strong>.
+            </p>
+          ) : null}
+
+          <div className="mt-8 border-t border-border pt-6">
+            <h3 className="text-xs font-bold uppercase tracking-wider text-foreground">
+              Activity Breakdown
+            </h3>
+            <p className="mt-1 mb-3 text-xs leading-relaxed text-muted">
+              Tap a level to see how it changes your maintenance calories.
+            </p>
+            <ul className="space-y-2">
+              {Object.values(ACTIVITY_LEVELS).map((level) => {
+                const isSelected = level.value === activityLevel;
+
+                return (
+                  <li key={level.value}>
+                    <button
+                      type="button"
+                      onClick={() => setActivityLevel(level.value)}
+                      aria-pressed={isSelected}
+                      className={`grid w-full cursor-pointer grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded-xl border px-3 py-2.5 text-left text-xs transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none ${
+                        isSelected
+                          ? "border-primary/30 bg-primary/10 font-semibold text-foreground"
+                          : "border-transparent text-muted hover:bg-surface-2/70 hover:text-foreground"
+                      }`}
+                    >
+                      <span className="leading-snug">{level.label}</span>
+                      <span className="whitespace-nowrap font-medium tabular-nums">
+                        {Math.round(bmr * level.multiplier)} kcal
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      {/* Goal Targets */}
+      <div>
+        <h2 className="text-center text-2xl font-bold tracking-tight text-foreground">
+          Calorie & Macro Targets by Goal
+        </h2>
+        <p className="mx-auto mt-2 mb-6 max-w-xl text-center text-sm leading-relaxed text-muted">
+          Each target uses a balanced {GOAL_SPLIT.protein}/{GOAL_SPLIT.carbs}/
+          {GOAL_SPLIT.fats} protein, carb, and fat split.
+        </p>
+
+        <ul className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          {goalCards.map((goal) => (
+            <li
+              key={goal.key}
+              className={`${calculatorCardClass} ${
+                goal.highlighted ? "border-primary/30 bg-primary/[0.06]" : ""
+              }`}
+            >
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <span
+                  className={`text-xs font-bold uppercase tracking-wider ${goal.accentClass}`}
+                >
+                  {goal.label}
+                </span>
+                <span className="text-xs whitespace-nowrap text-muted">
+                  {goal.delta}
+                </span>
+              </div>
+              <div className="mb-4 text-3xl font-extrabold text-foreground tabular-nums">
+                <AnimatedNumber value={goal.calories} />{" "}
+                <span className="text-sm font-normal text-muted">kcal</span>
+              </div>
+              <dl className="space-y-2 border-t border-border/60 pt-4 text-xs">
+                <div className={calculatorStatRowClass}>
+                  <dt className={calculatorStatLabelClass}>
+                    Protein · {GOAL_SPLIT.protein}%
+                  </dt>
+                  <dd className={calculatorStatValueClass}>
+                    {goal.macros.proteinTarget}g
+                  </dd>
+                </div>
+                <div className={calculatorStatRowClass}>
+                  <dt className={calculatorStatLabelClass}>
+                    Carbs · {GOAL_SPLIT.carbs}%
+                  </dt>
+                  <dd className={calculatorStatValueClass}>
+                    {goal.macros.carbsTarget}g
+                  </dd>
+                </div>
+                <div className={calculatorStatRowClass}>
+                  <dt className={calculatorStatLabelClass}>
+                    Fats · {GOAL_SPLIT.fats}%
+                  </dt>
+                  <dd className={calculatorStatValueClass}>
+                    {goal.macros.fatsTarget}g
+                  </dd>
+                </div>
+              </dl>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </CalculatorLayout>
+  );
+}

--- a/frontend/src/features/landing/pages/ToolsHubPage.tsx
+++ b/frontend/src/features/landing/pages/ToolsHubPage.tsx
@@ -1,0 +1,116 @@
+import { Link } from "@tanstack/react-router";
+
+import PageBackground from "@/components/layout/PageBackground";
+import { ArrowRightIcon } from "@/components/ui";
+import BackToTopButton from "@/features/landing/components/BackToTopButton";
+import Footer from "@/features/landing/components/Footer";
+import Header from "@/features/landing/components/Header";
+import { usePageMetadata } from "@/hooks";
+import { buildCanonicalUrl } from "@/utils/appConstants";
+
+import { buildToolSchema } from "../tools/buildToolSchema";
+import { calculatorCardClass } from "../tools/calculatorStyles";
+import { CALCULATOR_TOOLS } from "../tools/toolsCatalog";
+import ToolsCtaBanner from "../tools/ToolsCtaBanner";
+
+export default function ToolsHubPage() {
+  const canonicalUrl = buildCanonicalUrl("/tools");
+
+  usePageMetadata({
+    title: "Free Nutrition & Macro Calculators",
+    description:
+      "Free nutrition, TDEE, BMR, macro, weight loss, and protein calculators. Accurate fitness tools with privacy-first design.",
+    canonical: canonicalUrl,
+  });
+
+  const schemaScript = buildToolSchema({
+    name: "Free Nutrition Tools & Calculators",
+    description:
+      "Collection of free nutrition, TDEE, BMR, macro, weight loss, and protein calculators.",
+    url: canonicalUrl,
+  });
+
+  return (
+    <div className="relative min-h-screen bg-background text-foreground antialiased selection:bg-foreground selection:text-background">
+      <PageBackground />
+      {schemaScript && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: schemaScript }}
+        />
+      )}
+
+      <Header />
+
+      <main className="relative z-10 pt-24 pb-16 sm:pt-28">
+        <div className="mx-auto max-w-5xl px-4 sm:px-6">
+          <div className="mb-10 text-center sm:mb-12">
+            <span className="mb-3 inline-flex items-center gap-1.5 rounded-full border border-border bg-surface px-3 py-1 text-xs font-medium text-foreground">
+              <span className="h-1.5 w-1.5 rounded-full bg-vibrant-accent" />
+              100% Free & No Sign-up Required
+            </span>
+            <h1 className="text-3xl font-bold tracking-tight sm:text-4xl lg:text-5xl">
+              Free Nutrition & Macro Calculators
+            </h1>
+            <p className="mx-auto mt-3 max-w-2xl text-base leading-relaxed text-muted sm:text-lg">
+              Start with the number that matters, then turn it into a practical
+              nutrition plan. Every calculator works without an account.
+            </p>
+          </div>
+
+          <ul className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {CALCULATOR_TOOLS.map((tool) => (
+              <li
+                key={tool.path}
+                className={tool.featured ? "md:col-span-2" : ""}
+              >
+                <Link
+                  to={tool.path}
+                  className={`group relative flex h-full min-h-44 flex-col justify-between overflow-hidden ${calculatorCardClass} transition-[border-color,background-color,transform] duration-200 hover:-translate-y-0.5 hover:border-primary/50 hover:bg-surface-2 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none ${
+                    tool.featured ? "md:min-h-0 md:flex-row md:items-center" : ""
+                  }`}
+                >
+                  <div className={tool.featured ? "md:max-w-xl md:flex-1" : ""}>
+                    {tool.featured ? (
+                      <span className="mb-2 inline-flex items-center gap-1.5 rounded-full border border-primary/30 bg-primary/10 px-2.5 py-0.5 text-[11px] font-semibold tracking-wide text-primary uppercase">
+                        Start here
+                      </span>
+                    ) : null}
+                    <h2 className="text-xl font-bold tracking-tight text-foreground transition-colors group-hover:text-primary sm:text-2xl">
+                      {tool.title}
+                    </h2>
+                    <p className="mt-2 text-sm leading-relaxed text-muted">
+                      {tool.description}
+                    </p>
+                  </div>
+
+                  <div
+                    className={`mt-6 flex items-center justify-end ${
+                      tool.featured ? "md:mt-0 md:ml-8 md:shrink-0" : ""
+                    }`}
+                  >
+                    <span className="inline-flex items-center gap-1 text-xs font-medium text-muted transition-colors group-hover:text-foreground">
+                      Open
+                      <ArrowRightIcon
+                        className="h-3.5 w-3.5 transition-transform duration-200 group-hover:translate-x-0.5"
+                        aria-hidden="true"
+                      />
+                    </span>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+
+          <ToolsCtaBanner
+            heading="Know your target? Make it a habit."
+            body="MacroTrackr brings food logging, custom goals, and privacy-first tracking into one calm daily routine."
+          />
+        </div>
+      </main>
+
+      <Footer />
+      <BackToTopButton label="Back to top" />
+    </div>
+  );
+}

--- a/frontend/src/features/landing/pages/WeightLossCalculatorPage.tsx
+++ b/frontend/src/features/landing/pages/WeightLossCalculatorPage.tsx
@@ -1,0 +1,237 @@
+import { useState } from "react";
+
+import Dropdown from "@/components/form/Dropdown";
+import NumberField from "@/components/form/NumberField";
+import { calculateBMR, calculateTDEE } from "@/utils/nutritionCalculations";
+import { kgToLb, lbToKg } from "@/utils/unitConversion";
+import {
+  getActivityLevelFromString,
+  getActivityLevelMultiplier,
+} from "@/utils/userConstants";
+
+import BodyStatsForm from "../tools/BodyStatsForm";
+import { toNumericInput } from "../tools/calculatorInputs";
+import CalculatorLayout from "../tools/CalculatorLayout";
+import {
+  calculatorCardClass,
+  calculatorResultCardClass,
+  calculatorResultColumnClass,
+  calculatorSectionDescriptionClass,
+  calculatorSectionTitleClass,
+  calculatorStatLabelClass,
+  calculatorStatRowClass,
+  calculatorStatValueClass,
+} from "../tools/calculatorStyles";
+import ResultHeadline from "../tools/ResultHeadline";
+import { useBodyStats } from "../tools/useBodyStats";
+
+const FAQS = [
+  {
+    question: "How fast should I safely lose weight?",
+    answer:
+      "A safe and sustainable rate of fat loss is 0.5 to 1.0 kg (1 to 2 lbs) per week, which corresponds to a daily deficit of 500 to 1,000 calories.",
+  },
+  {
+    question: "How many calories are in 1 kg of body fat?",
+    answer:
+      "1 kg of body fat contains approximately 7,700 calories (or ~3,500 calories per pound). A daily deficit of 500 calories creates a 3,500 calorie weekly deficit, yielding ~0.45 kg (1 lb) of fat loss per week.",
+  },
+  {
+    question: "Why is eating too few calories counterproductive?",
+    answer:
+      "Severe calorie deficits trigger metabolic adaptation, extreme hunger, fatigue, and muscle degradation. Moderation preserves muscle tissue and metabolic rate.",
+  },
+];
+
+// ~7,700 kcal per kg of body fat, spread across seven days.
+const CALORIES_PER_KG_OF_FAT_PER_DAY = 1100;
+
+const PACE_OPTIONS = [
+  { value: "0.25", label: "Slow & Easy (0.25 kg / 0.55 lbs per week)" },
+  { value: "0.5", label: "Recommended (0.5 kg / 1.1 lbs per week)" },
+  { value: "0.75", label: "Faster Pace (0.75 kg / 1.65 lbs per week)" },
+  { value: "1.0", label: "Aggressive (1.0 kg / 2.2 lbs per week)" },
+];
+
+export default function WeightLossCalculatorPage() {
+  const stats = useBodyStats(85);
+  const { weightKg, heightCm, age, gender, activityLevel, unitSystem } = stats;
+  const statsReady = stats.ready;
+
+  const [targetWeightKg, setTargetWeightKg] = useState(75);
+  const [weeklyPaceKg, setWeeklyPaceKg] = useState(0.5);
+
+  const bmr = statsReady ? calculateBMR(weightKg, heightCm, age, gender) : 0;
+  const activityNumber = getActivityLevelFromString(activityLevel);
+  const multiplier = getActivityLevelMultiplier(activityNumber);
+  const tdee = calculateTDEE(bmr, multiplier);
+
+  const hasTargetWeight = targetWeightKg > 0;
+  const isLoss = hasTargetWeight && targetWeightKg < weightKg;
+  const isGain = hasTargetWeight && targetWeightKg > weightKg;
+  const isAtGoal = hasTargetWeight && !isLoss && !isGain;
+  // Imperial input rounds to one decimal, so subtraction can leave float noise.
+  const weightChangeKg =
+    Math.round(Math.abs(weightKg - targetWeightKg) * 10) / 10;
+
+  const dailyCalorieAdjustment = isAtGoal
+    ? 0
+    : Math.round(weeklyPaceKg * CALORIES_PER_KG_OF_FAT_PER_DAY);
+  const targetCalories = isLoss
+    ? Math.max(800, tdee - dailyCalorieAdjustment)
+    : isGain
+      ? tdee + dailyCalorieAdjustment
+      : tdee;
+
+  const estimatedWeeks =
+    weeklyPaceKg > 0 && weightChangeKg > 0
+      ? Math.ceil(weightChangeKg / weeklyPaceKg)
+      : 0;
+
+  const targetDate = new Date();
+  targetDate.setDate(targetDate.getDate() + estimatedWeeks * 7);
+  const formattedDate = targetDate.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  const minSafeCalories = gender === "female" ? 1200 : 1500;
+  const isTooAggressive =
+    statsReady && isLoss && targetCalories < minSafeCalories;
+
+  return (
+    <CalculatorLayout
+      title="Weight Loss & Timeline Calculator"
+      subtitle="Estimate a daily calorie target, a realistic pace, and a projected date for your goal weight."
+      canonicalPath="/tools/weight-loss-calculator"
+      description="Free Weight Loss Timeline Calculator. Estimate daily calorie deficit, weekly progress, and completion date for your target weight."
+      faqs={FAQS}
+    >
+      <div className="grid grid-cols-1 gap-8 lg:grid-cols-12">
+        {/* Form Inputs */}
+        <div className="lg:col-span-7 space-y-6">
+          <div className={calculatorCardClass}>
+            <h2 className={calculatorSectionTitleClass}>
+              Current Stats & Activity
+            </h2>
+            <p className={`${calculatorSectionDescriptionClass} mb-5`}>
+              Start with your current routine so the estimate has a useful
+              baseline.
+            </p>
+            <BodyStatsForm stats={stats} showActivity />
+          </div>
+
+          <div className={`${calculatorCardClass} space-y-4`}>
+            <h2 className={calculatorSectionTitleClass}>Goal & Pace</h2>
+            <p className={calculatorSectionDescriptionClass}>
+              A slower pace is usually easier to sustain and protect your
+              energy.
+            </p>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              {unitSystem === "imperial" ? (
+                <NumberField
+                  label="Target Weight"
+                  value={kgToLb(targetWeightKg) || ""}
+                  onChange={(v) =>
+                    setTargetWeightKg(lbToKg(toNumericInput(v, 1000)))
+                  }
+                  min={30}
+                  max={1000}
+                  unit="lbs"
+                />
+              ) : (
+                <NumberField
+                  label="Target Weight"
+                  value={targetWeightKg || ""}
+                  onChange={(v) => setTargetWeightKg(toNumericInput(v, 500))}
+                  min={15}
+                  max={500}
+                  unit="kg"
+                />
+              )}
+
+              <Dropdown
+                label="Weekly Pace"
+                value={String(weeklyPaceKg)}
+                onChange={(v) => setWeeklyPaceKg(Number(v))}
+                options={PACE_OPTIONS}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Output Card */}
+        <div
+          className={`${calculatorResultColumnClass} ${calculatorResultCardClass}`}
+        >
+          <ResultHeadline
+            label="Target Daily Calories"
+            value={targetCalories}
+            unit="kcal / day"
+            ready={statsReady}
+          />
+
+          {isTooAggressive && (
+            <p
+              role="status"
+              className="mt-4 rounded-xl border border-error/30 bg-error/10 p-3 text-sm leading-relaxed text-error"
+            >
+              This target is below the usual minimum of {minSafeCalories}{" "}
+              kcal/day. Consider choosing a slower weekly pace.
+            </p>
+          )}
+
+          <dl className="mt-8 space-y-3 border-t border-border pt-6 text-sm">
+            <div className={calculatorStatRowClass}>
+              <dt className={calculatorStatLabelClass}>
+                Maintenance burn (TDEE)
+              </dt>
+              <dd className={calculatorStatValueClass}>{tdee} kcal</dd>
+            </div>
+            <div className={calculatorStatRowClass}>
+              <dt className={calculatorStatLabelClass}>
+                Daily calorie {isGain ? "surplus" : "deficit"}
+              </dt>
+              <dd className={calculatorStatValueClass}>
+                {isAtGoal
+                  ? "0"
+                  : `${isGain ? "+" : "-"}${dailyCalorieAdjustment}`}{" "}
+                kcal
+              </dd>
+            </div>
+            <div className={calculatorStatRowClass}>
+              <dt className={calculatorStatLabelClass}>Total weight change</dt>
+              <dd className={calculatorStatValueClass}>
+                {unitSystem === "imperial"
+                  ? `${kgToLb(weightChangeKg)} lbs`
+                  : `${weightChangeKg} kg`}
+              </dd>
+            </div>
+            <div className={calculatorStatRowClass}>
+              <dt className={calculatorStatLabelClass}>Estimated duration</dt>
+              <dd className={calculatorStatValueClass}>
+                {estimatedWeeks === 0
+                  ? "—"
+                  : `${estimatedWeeks} ${estimatedWeeks === 1 ? "week" : "weeks"}`}
+              </dd>
+            </div>
+          </dl>
+
+          <div className="mt-6 rounded-xl border border-primary/25 bg-primary/10 p-4 text-center">
+            <span className="block text-xs font-medium text-muted">
+              {estimatedWeeks > 0 ? "Estimated goal date" : "Goal status"}
+            </span>
+            <span className="mt-1 block text-lg font-bold text-foreground">
+              {estimatedWeeks > 0
+                ? formattedDate
+                : isAtGoal
+                  ? "You're at your goal weight"
+                  : "Set a target weight"}
+            </span>
+          </div>
+        </div>
+      </div>
+    </CalculatorLayout>
+  );
+}

--- a/frontend/src/features/landing/tools/BodyStatsForm.tsx
+++ b/frontend/src/features/landing/tools/BodyStatsForm.tsx
@@ -1,0 +1,175 @@
+import { useId } from "react";
+
+import Dropdown from "@/components/form/Dropdown";
+import NumberField from "@/components/form/NumberField";
+import type { ActivityLevel, Gender } from "@/types/activity";
+import { cmToFtIn, ftInToCm, kgToLb, lbToKg } from "@/utils/unitConversion";
+import { ACTIVITY_LEVELS, GENDER_OPTIONS } from "@/utils/userConstants";
+
+import { toNumericInput } from "./calculatorInputs";
+import type { BodyStatsControls } from "./useBodyStats";
+
+interface BodyStatsFormProps {
+  stats: BodyStatsControls;
+  showActivity?: boolean;
+}
+
+const activityOptions = Object.values(ACTIVITY_LEVELS).map((item) => ({
+  value: item.value,
+  label: `${item.label} (x${item.multiplier})`,
+}));
+
+// The shared constant leads with a "Select gender" placeholder; the
+// calculators always start from a real value, so it is filtered out here.
+const genderDropdownOptions = GENDER_OPTIONS.filter(
+  (item) => item.value !== "",
+).map((item) => ({
+  value: item.value,
+  label: item.label,
+}));
+
+export default function BodyStatsForm({
+  stats,
+  showActivity = false,
+}: BodyStatsFormProps) {
+  const {
+    weightKg,
+    setWeightKg,
+    heightCm,
+    setHeightCm,
+    age,
+    setAge,
+    gender,
+    setGender,
+    activityLevel,
+    setActivityLevel,
+    unitSystem,
+    setUnitSystem,
+  } = stats;
+  const { feet, inches } = cmToFtIn(heightCm);
+  const weightLb = kgToLb(weightKg);
+  const unitSystemLabelId = useId();
+
+  return (
+    <div className="space-y-4">
+      {/* Unit System Toggle */}
+      <div className="flex items-center justify-between gap-3 rounded-xl border border-border bg-surface-2/60 p-2 text-xs">
+        <span id={unitSystemLabelId} className="pl-1 font-medium text-muted">
+          Units
+        </span>
+        <div
+          role="group"
+          aria-labelledby={unitSystemLabelId}
+          className="flex items-center gap-1 rounded-lg bg-surface p-1"
+        >
+          <button
+            type="button"
+            onClick={() => setUnitSystem("imperial")}
+            aria-pressed={unitSystem === "imperial"}
+            className={`min-h-8 cursor-pointer rounded-md px-2.5 py-1 font-medium transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface focus-visible:outline-none ${
+              unitSystem === "imperial"
+                ? "bg-primary font-semibold text-black"
+                : "text-muted hover:text-foreground"
+            }`}
+          >
+            Imperial<span className="hidden sm:inline"> (lb, ft)</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => setUnitSystem("metric")}
+            aria-pressed={unitSystem === "metric"}
+            className={`min-h-8 cursor-pointer rounded-md px-2.5 py-1 font-medium transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface focus-visible:outline-none ${
+              unitSystem === "metric"
+                ? "bg-primary font-semibold text-black"
+                : "text-muted hover:text-foreground"
+            }`}
+          >
+            Metric<span className="hidden sm:inline"> (kg, cm)</span>
+          </button>
+        </div>
+      </div>
+
+      {/* Two up even on phones: the whole form stays above the fold. */}
+      <div className="grid grid-cols-2 gap-3 sm:gap-4">
+        <Dropdown
+          label="Gender"
+          value={gender}
+          onChange={(v) => setGender(v as Gender)}
+          options={genderDropdownOptions}
+        />
+
+        <NumberField
+          label="Age"
+          value={age || ""}
+          onChange={(v) => setAge(toNumericInput(v, 120))}
+          min={1}
+          max={120}
+          unit="years"
+        />
+
+        {unitSystem === "imperial" ? (
+          <NumberField
+            label="Weight"
+            value={weightLb || ""}
+            onChange={(v) => setWeightKg(lbToKg(toNumericInput(v, 1000)))}
+            min={30}
+            max={1000}
+            unit="lbs"
+          />
+        ) : (
+          <NumberField
+            label="Weight"
+            value={weightKg || ""}
+            onChange={(v) => setWeightKg(toNumericInput(v, 500))}
+            min={15}
+            max={500}
+            unit="kg"
+          />
+        )}
+
+        {unitSystem === "imperial" ? (
+          <div className="col-span-2 grid grid-cols-2 gap-2 sm:col-span-1">
+            <NumberField
+              label="Height (ft)"
+              value={feet || ""}
+              onChange={(v) =>
+                setHeightCm(ftInToCm(toNumericInput(v, 8), inches))
+              }
+              min={1}
+              max={8}
+              unit="ft"
+            />
+            <NumberField
+              label="Height (in)"
+              value={inches || ""}
+              onChange={(v) =>
+                setHeightCm(ftInToCm(feet, toNumericInput(v, 11)))
+              }
+              min={0}
+              max={11}
+              unit="in"
+            />
+          </div>
+        ) : (
+          <NumberField
+            label="Height"
+            value={heightCm || ""}
+            onChange={(v) => setHeightCm(toNumericInput(v, 250))}
+            min={50}
+            max={250}
+            unit="cm"
+          />
+        )}
+      </div>
+
+      {showActivity ? (
+        <Dropdown
+          label="Activity Level"
+          value={activityLevel}
+          onChange={(v) => setActivityLevel(v as ActivityLevel)}
+          options={activityOptions}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/features/landing/tools/CalculatorLayout.tsx
+++ b/frontend/src/features/landing/tools/CalculatorLayout.tsx
@@ -1,0 +1,145 @@
+import React from "react";
+import { Link } from "@tanstack/react-router";
+
+import PageBackground from "@/components/layout/PageBackground";
+import { ChevronDownIcon, ChevronRightIcon } from "@/components/ui";
+import BackToTopButton from "@/features/landing/components/BackToTopButton";
+import Footer from "@/features/landing/components/Footer";
+import Header from "@/features/landing/components/Header";
+import { usePageMetadata } from "@/hooks";
+import { buildCanonicalUrl } from "@/utils/appConstants";
+
+import { buildToolSchema, type FaqItem } from "./buildToolSchema";
+import { calculatorCardClass } from "./calculatorStyles";
+import RelatedTools from "./RelatedTools";
+import { TOOLS_HUB_PATH } from "./toolsCatalog";
+import ToolsCtaBanner from "./ToolsCtaBanner";
+
+interface CalculatorLayoutProps {
+  title: string;
+  subtitle: string;
+  canonicalPath: string;
+  description: string;
+  /** Overrides the browser tab title when the default reads redundantly. */
+  metaTitle?: string;
+  badge?: string;
+  faqs?: FaqItem[];
+  children: React.ReactNode;
+}
+
+export default function CalculatorLayout({
+  title,
+  subtitle,
+  canonicalPath,
+  description,
+  metaTitle,
+  badge,
+  faqs = [],
+  children,
+}: CalculatorLayoutProps) {
+  const canonicalUrl = buildCanonicalUrl(canonicalPath);
+
+  usePageMetadata({
+    title: metaTitle ?? `${title} - Free Calculator`,
+    description,
+    canonical: canonicalUrl,
+  });
+
+  const schemaScript = buildToolSchema({
+    name: title,
+    description,
+    url: canonicalUrl,
+    faqs,
+  });
+
+  return (
+    <div className="relative min-h-screen bg-background text-foreground antialiased selection:bg-foreground selection:text-background">
+      <PageBackground />
+      {schemaScript && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: schemaScript }}
+        />
+      )}
+
+      <Header />
+
+      <main className="relative z-10 pt-24 pb-16 sm:pt-28">
+        <div className="mx-auto max-w-5xl px-4 sm:px-6">
+          <nav aria-label="Breadcrumb" className="mb-6">
+            <ol className="flex items-center gap-1 text-xs text-muted">
+              <li>
+                <Link
+                  to={TOOLS_HUB_PATH}
+                  className="inline-flex min-h-8 items-center rounded-lg px-1 font-medium transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none"
+                >
+                  Free calculators
+                </Link>
+              </li>
+              <li aria-hidden="true" className="flex items-center">
+                <ChevronRightIcon className="h-3.5 w-3.5" />
+              </li>
+              <li aria-current="page" className="truncate px-1 text-foreground">
+                {title}
+              </li>
+            </ol>
+          </nav>
+
+          {/* Hero Header */}
+          <div className="mb-8 text-center sm:mb-10">
+            {badge ? (
+              <span className="mb-3 inline-flex items-center gap-1.5 rounded-full border border-border bg-surface px-3 py-1 text-xs font-medium text-foreground">
+                <span className="h-1.5 w-1.5 rounded-full bg-vibrant-accent" />
+                {badge}
+              </span>
+            ) : null}
+            <h1 className="text-3xl font-bold tracking-tight sm:text-4xl lg:text-5xl">
+              {title}
+            </h1>
+            <p className="mx-auto mt-3 max-w-2xl text-base leading-relaxed text-muted sm:text-lg">
+              {subtitle}
+            </p>
+          </div>
+
+          {/* Calculator main content */}
+          <div className="space-y-8">{children}</div>
+
+          {/* FAQ Section if present */}
+          {faqs.length > 0 && (
+            <div className={`mt-12 ${calculatorCardClass}`}>
+              <h2 className="mb-6 text-xl font-bold tracking-tight text-foreground sm:text-2xl">
+                Frequently Asked Questions
+              </h2>
+              <div className="space-y-3">
+                {faqs.map((faq) => (
+                  <details
+                    key={faq.question}
+                    className="group rounded-xl border border-border bg-surface-2/50 transition-colors hover:bg-surface-2"
+                  >
+                    <summary className="flex min-h-14 cursor-pointer list-none items-center justify-between gap-4 px-4 py-3 text-sm font-semibold text-foreground select-none">
+                      <span>{faq.question}</span>
+                      <ChevronDownIcon className="h-4 w-4 shrink-0 text-muted transition-transform duration-200 group-open:rotate-180" />
+                    </summary>
+                    <div className="border-t border-border px-4 pt-3 pb-4 text-sm leading-relaxed text-muted">
+                      {faq.answer}
+                    </div>
+                  </details>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <RelatedTools currentPath={canonicalPath} />
+
+          <ToolsCtaBanner
+            heading="Ready to put your target into practice?"
+            body="Log meals against this target, see your progress, and adjust your plan as real life changes."
+          />
+        </div>
+      </main>
+
+      <Footer />
+      <BackToTopButton label="Back to top" />
+    </div>
+  );
+}

--- a/frontend/src/features/landing/tools/Calculators.test.tsx
+++ b/frontend/src/features/landing/tools/Calculators.test.tsx
@@ -1,0 +1,222 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import BmrCalculatorPage from "../pages/BmrCalculatorPage";
+import MacroCalculatorPage from "../pages/MacroCalculatorPage";
+import ProteinCalculatorPage from "../pages/ProteinCalculatorPage";
+import TdeeCalculatorPage from "../pages/TdeeCalculatorPage";
+import ToolsHubPage from "../pages/ToolsHubPage";
+import WeightLossCalculatorPage from "../pages/WeightLossCalculatorPage";
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@tanstack/react-router")>();
+
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+    useLocation: () => ({ pathname: "/" }),
+    Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+      <a href={to}>{children}</a>
+    ),
+  };
+});
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: vi.fn() }),
+}));
+
+vi.mock("@/hooks/auth/useAuthState", () => ({
+  useAppAuthState: () => ({ isLoaded: true, isSignedIn: false }),
+}));
+
+vi.mock("@/hooks/usePageMetadata", () => ({
+  usePageMetadata: vi.fn(),
+}));
+
+describe("Free Calculators", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("BMR Calculator Page", () => {
+    it("renders BMR page with default metric units and non-zero BMR burn", () => {
+      render(<BmrCalculatorPage />);
+
+      expect(
+        screen.getByRole("heading", { name: /bmr calculator/i }),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/your resting burn/i)).toBeInTheDocument();
+      // Should show metric weight input by default
+      expect(screen.getByLabelText(/weight/i)).toBeInTheDocument();
+      expect(screen.getAllByText(/kg/i).length).toBeGreaterThan(0);
+      // Should show Estimated Burn by Activity
+      expect(
+        screen.getByText(/estimated burn by activity/i),
+      ).toBeInTheDocument();
+    });
+
+    it("falls back to a placeholder instead of NaN when a stat is cleared", () => {
+      render(<BmrCalculatorPage />);
+
+      fireEvent.change(screen.getByLabelText(/^age$/i), {
+        target: { value: "" },
+      });
+
+      expect(screen.queryByText(/\bNaN\b/)).not.toBeInTheDocument();
+      expect(
+        screen.getByText(/add your age, weight, and height/i),
+      ).toBeInTheDocument();
+    });
+
+    it("links to the TDEE calculator for a full daily burn", () => {
+      render(<BmrCalculatorPage />);
+
+      expect(
+        screen.getByRole("link", { name: /get a full tdee breakdown/i }),
+      ).toHaveAttribute("href", "/tools/tdee-calculator");
+    });
+  });
+
+  describe("TDEE Calculator Page", () => {
+    it("renders TDEE page with valid calorie and macro targets by goal", () => {
+      render(<TdeeCalculatorPage />);
+
+      expect(
+        screen.getByRole("heading", { name: /tdee calculator/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/maintenance calories \(tdee\)/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/calorie & macro targets by goal/i),
+      ).toBeInTheDocument();
+
+      // Ensure Fat Loss, Maintenance, and Muscle Gain cards display real non-zero values
+      expect(screen.getAllByText(/fat loss/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/maintenance/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/muscle gain/i).length).toBeGreaterThan(0);
+      expect(screen.queryByText(/\bNaN\b/)).not.toBeInTheDocument();
+    });
+
+    it("lets the activity breakdown rows set the activity level", () => {
+      render(<TdeeCalculatorPage />);
+
+      const sedentaryRow = screen.getByRole("button", { name: /sedentary/i });
+      expect(sedentaryRow).toHaveAttribute("aria-pressed", "false");
+
+      fireEvent.click(sedentaryRow);
+
+      expect(
+        screen.getByRole("button", { name: /sedentary/i }),
+      ).toHaveAttribute("aria-pressed", "true");
+    });
+  });
+
+  describe("Macro Calculator Page", () => {
+    it("renders Macro Calculator page with non-NaN totals and interactive split sliders", () => {
+      render(<MacroCalculatorPage />);
+
+      expect(
+        screen.getByRole("heading", { name: /macro calculator/i }),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/daily target summary/i)).toBeInTheDocument();
+      expect(screen.getByText(/macro distribution split/i)).toBeInTheDocument();
+
+      // Ensure protein/carbs/fats targets render valid numbers without NaN
+      expect(screen.queryByText(/\bNaN\b/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Weight Loss Calculator Page", () => {
+    it("renders Weight Loss & Timeline Calculator with target calorie deficit and timeline", () => {
+      render(<WeightLossCalculatorPage />);
+
+      expect(
+        screen.getByRole("heading", {
+          name: /weight loss & timeline calculator/i,
+        }),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/target daily calories/i)).toBeInTheDocument();
+      expect(screen.getByText(/estimated goal date/i)).toBeInTheDocument();
+      expect(screen.queryByText(/\bNaN\b/)).not.toBeInTheDocument();
+    });
+
+    it("reports a zero adjustment once the target matches current weight", () => {
+      render(<WeightLossCalculatorPage />);
+
+      fireEvent.change(screen.getByLabelText(/target weight/i), {
+        target: { value: "85" },
+      });
+
+      expect(
+        screen.getByText(/you're at your goal weight/i),
+      ).toBeInTheDocument();
+      const deficitRow = screen.getByText(/daily calorie deficit/i).parentElement;
+      expect(within(deficitRow as HTMLElement).getByText(/^0 kcal$/)).toBeInTheDocument();
+    });
+  });
+
+  describe("Protein Calculator Page", () => {
+    it("renders Protein Intake Calculator with per-meal targets and food reference table", () => {
+      render(<ProteinCalculatorPage />);
+
+      expect(
+        screen.getByRole("heading", { name: /protein intake calculator/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/recommended daily protein/i),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/high-protein food ideas/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/chicken breast \(cooked\)/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Tools Hub Page", () => {
+    it("renders hub page listing all 5 calculators", () => {
+      render(<ToolsHubPage />);
+
+      expect(
+        screen.getByRole("heading", {
+          name: /free nutrition & macro calculators/i,
+        }),
+      ).toBeInTheDocument();
+      expect(screen.getAllByText(/tdee calculator/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/bmr calculator/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/macro calculator/i).length).toBeGreaterThan(
+        0,
+      );
+      expect(screen.getAllByText(/weight loss/i).length).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText(/protein intake calculator/i).length,
+      ).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Cross navigation", () => {
+    it("offers every other calculator, but not the current one", () => {
+      render(<BmrCalculatorPage />);
+
+      const related = screen
+        .getByRole("heading", { name: /other free calculators/i })
+        .closest("section");
+      const links = within(related as HTMLElement).getAllByRole("link");
+      const hrefs = links.map((link) => link.getAttribute("href"));
+
+      expect(hrefs).toContain("/tools");
+      expect(hrefs).toContain("/tools/tdee-calculator");
+      expect(hrefs).not.toContain("/tools/bmr-calculator");
+    });
+
+    it("links back to the hub from the breadcrumb", () => {
+      render(<MacroCalculatorPage />);
+
+      const breadcrumb = screen.getByRole("navigation", { name: /breadcrumb/i });
+      expect(
+        within(breadcrumb).getByRole("link", { name: /free calculators/i }),
+      ).toHaveAttribute("href", "/tools");
+    });
+  });
+});

--- a/frontend/src/features/landing/tools/RelatedTools.tsx
+++ b/frontend/src/features/landing/tools/RelatedTools.tsx
@@ -1,0 +1,63 @@
+import { memo } from "react";
+import { Link } from "@tanstack/react-router";
+
+import { ArrowRightIcon } from "@/components/ui";
+
+import { CALCULATOR_TOOLS, TOOLS_HUB_PATH } from "./toolsCatalog";
+
+interface RelatedToolsProps {
+  currentPath: string;
+}
+
+/**
+ * Lets someone jump straight to the next number they need instead of
+ * backtracking to the hub.
+ */
+function RelatedTools({ currentPath }: RelatedToolsProps) {
+  const related = CALCULATOR_TOOLS.filter((tool) => tool.path !== currentPath);
+
+  if (related.length === 0) return null;
+
+  return (
+    <section className="mt-12">
+      <div className="mb-4 flex flex-wrap items-baseline justify-between gap-2">
+        <h2 className="text-xl font-bold tracking-tight text-foreground">
+          Other free calculators
+        </h2>
+        <Link
+          to={TOOLS_HUB_PATH}
+          className="inline-flex items-center gap-1 rounded-lg text-sm font-medium text-muted transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none"
+        >
+          View all
+          <ArrowRightIcon className="h-3.5 w-3.5" aria-hidden="true" />
+        </Link>
+      </div>
+
+      <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {related.map((tool) => (
+          <li key={tool.path}>
+            <Link
+              to={tool.path}
+              className="group flex h-full min-h-16 items-center justify-between gap-3 rounded-xl border border-border bg-surface px-4 py-3 transition-[border-color,background-color] duration-200 hover:border-primary/40 hover:bg-surface-2 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none"
+            >
+              <span className="min-w-0">
+                <span className="block text-sm font-semibold text-foreground">
+                  {tool.navLabel ?? tool.title}
+                </span>
+                <span className="block text-xs leading-relaxed text-muted">
+                  {tool.tagline}
+                </span>
+              </span>
+              <ArrowRightIcon
+                className="h-4 w-4 shrink-0 text-muted transition-transform duration-200 group-hover:translate-x-0.5 group-hover:text-foreground"
+                aria-hidden="true"
+              />
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default memo(RelatedTools);

--- a/frontend/src/features/landing/tools/ResultHeadline.tsx
+++ b/frontend/src/features/landing/tools/ResultHeadline.tsx
@@ -1,0 +1,48 @@
+import { memo } from "react";
+
+import AnimatedNumber from "@/components/animation/AnimatedNumber";
+
+import { INCOMPLETE_STATS_HINT } from "./calculatorInputs";
+import { calculatorEyebrowClass } from "./calculatorStyles";
+
+interface ResultHeadlineProps {
+  label: string;
+  value: number;
+  unit: string;
+  /** When false the number is replaced by a placeholder and a short hint. */
+  ready?: boolean;
+  /** Overrides the hint shown while `ready` is false. */
+  hint?: string;
+}
+
+/**
+ * The single headline figure at the top of every calculator result card.
+ */
+function ResultHeadline({
+  label,
+  value,
+  unit,
+  ready = true,
+  hint = INCOMPLETE_STATS_HINT,
+}: ResultHeadlineProps) {
+  return (
+    <div>
+      <span className={calculatorEyebrowClass}>{label}</span>
+      <div className="mt-2 flex items-baseline gap-2">
+        <span className="text-4xl font-extrabold tracking-tight text-foreground tabular-nums sm:text-5xl">
+          {ready ? (
+            <AnimatedNumber value={value} />
+          ) : (
+            <span aria-hidden>—</span>
+          )}
+        </span>
+        <span className="text-lg font-medium text-muted">{unit}</span>
+      </div>
+      {ready ? null : (
+        <p className="mt-2 text-sm leading-relaxed text-muted">{hint}</p>
+      )}
+    </div>
+  );
+}
+
+export default memo(ResultHeadline);

--- a/frontend/src/features/landing/tools/ToolsCtaBanner.tsx
+++ b/frontend/src/features/landing/tools/ToolsCtaBanner.tsx
@@ -1,0 +1,45 @@
+import { memo } from "react";
+import { Link } from "@tanstack/react-router";
+
+import { getButtonClasses } from "@/components/ui/Button";
+import { GITHUB_REPO_URL } from "@/utils/appConstants";
+
+interface ToolsCtaBannerProps {
+  heading: string;
+  body: string;
+}
+
+/**
+ * Shared closing call to action for the tools hub and every calculator page.
+ */
+function ToolsCtaBanner({ heading, body }: ToolsCtaBannerProps) {
+  return (
+    <section className="mt-12 rounded-2xl border border-primary/30 bg-surface p-6 text-center sm:p-8">
+      <h2 className="text-xl font-bold text-foreground sm:text-2xl">
+        {heading}
+      </h2>
+      <p className="mx-auto mt-2 max-w-xl text-sm leading-relaxed text-muted">
+        {body}
+      </p>
+      <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+        <Link
+          to="/register"
+          search={{ returnTo: undefined }}
+          className={getButtonClasses("primary", "lg", false, "px-5")}
+        >
+          Start tracking free
+        </Link>
+        <a
+          href={GITHUB_REPO_URL}
+          target="_blank"
+          rel="noreferrer"
+          className={getButtonClasses("secondary", "lg", false, "px-5")}
+        >
+          View the source
+        </a>
+      </div>
+    </section>
+  );
+}
+
+export default memo(ToolsCtaBanner);

--- a/frontend/src/features/landing/tools/buildToolSchema.test.ts
+++ b/frontend/src/features/landing/tools/buildToolSchema.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { buildToolSchema } from "./buildToolSchema";
+
+describe("buildToolSchema", () => {
+  it("generates WebApplication JSON-LD schema without FAQs", () => {
+    const json = buildToolSchema({
+      name: "TDEE Calculator",
+      description: "Calculate TDEE",
+      url: "https://macrotrackr.com/tools/tdee-calculator",
+    });
+
+    const parsed = JSON.parse(json);
+    expect(parsed["@type"]).toBe("WebApplication");
+    expect(parsed.name).toContain("TDEE Calculator");
+    expect(parsed.offers.price).toBe("0");
+  });
+
+  it("generates combined WebApplication and FAQPage JSON-LD schema with FAQs", () => {
+    const json = buildToolSchema({
+      name: "BMR Calculator",
+      description: "Calculate BMR",
+      url: "https://macrotrackr.com/tools/bmr-calculator",
+      faqs: [{ question: "What is BMR?", answer: "Basal Metabolic Rate" }],
+    });
+
+    const parsed = JSON.parse(json);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0]["@type"]).toBe("WebApplication");
+    expect(parsed[1]["@type"]).toBe("FAQPage");
+    expect(parsed[1].mainEntity[0].name).toBe("What is BMR?");
+  });
+});

--- a/frontend/src/features/landing/tools/buildToolSchema.ts
+++ b/frontend/src/features/landing/tools/buildToolSchema.ts
@@ -1,0 +1,59 @@
+import { APP_NAME, APP_URL, SCHEMA_ORG_CONTEXT } from "@/utils/appConstants";
+
+export interface FaqItem {
+  question: string;
+  answer: string;
+}
+
+export interface SchemaToolOptions {
+  name: string;
+  description: string;
+  url: string;
+  faqs?: FaqItem[];
+}
+
+export function buildToolSchema({
+  name,
+  description,
+  url,
+  faqs = [],
+}: SchemaToolOptions): string {
+  const webAppSchema = {
+    "@context": SCHEMA_ORG_CONTEXT,
+    "@type": "WebApplication",
+    name: `${name} | ${APP_NAME}`,
+    url,
+    applicationCategory: "HealthAndFitnessApplication",
+    operatingSystem: "All",
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
+    },
+    publisher: {
+      "@type": "Organization",
+      name: APP_NAME,
+      url: APP_URL,
+    },
+    description,
+  };
+
+  if (!faqs.length) {
+    return JSON.stringify(webAppSchema);
+  }
+
+  const faqSchema = {
+    "@context": SCHEMA_ORG_CONTEXT,
+    "@type": "FAQPage",
+    mainEntity: faqs.map((faq) => ({
+      "@type": "Question",
+      name: faq.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: faq.answer,
+      },
+    })),
+  };
+
+  return JSON.stringify([webAppSchema, faqSchema]);
+}

--- a/frontend/src/features/landing/tools/calculatorInputs.ts
+++ b/frontend/src/features/landing/tools/calculatorInputs.ts
@@ -1,0 +1,33 @@
+/**
+ * NumberField reports `undefined` while a field is empty, so every calculator
+ * input goes through here. Storing 0 keeps the field visually empty (the fields
+ * render `value || ""`) while guaranteeing the maths never sees NaN.
+ */
+export function toNumericInput(
+  value: number | undefined,
+  max?: number,
+): number {
+  if (value === undefined || Number.isNaN(value)) return 0;
+
+  const positive = Math.max(0, value);
+
+  return max === undefined ? positive : Math.min(max, positive);
+}
+
+export interface BodyStats {
+  weightKg: number;
+  heightCm: number;
+  age: number;
+}
+
+/** True once every stat the formulas need has a usable value. */
+export function hasValidBodyStats({
+  weightKg,
+  heightCm,
+  age,
+}: BodyStats): boolean {
+  return weightKg > 0 && heightCm > 0 && age > 0;
+}
+
+export const INCOMPLETE_STATS_HINT =
+  "Add your age, weight, and height to see your result.";

--- a/frontend/src/features/landing/tools/calculatorStyles.ts
+++ b/frontend/src/features/landing/tools/calculatorStyles.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared visual language for the public calculators. These intentionally use
+ * the same quiet, layered surfaces as the product UI while reserving the
+ * brand green for live values and primary actions.
+ */
+export const calculatorCardClass =
+  "rounded-2xl border border-border bg-surface p-5 sm:p-6";
+
+export const calculatorResultCardClass =
+  "rounded-2xl border border-primary/30 bg-gradient-to-b from-primary/[0.08] via-surface to-surface p-5 sm:p-6";
+
+export const calculatorEyebrowClass =
+  "text-xs font-semibold uppercase tracking-wider text-muted";
+
+export const calculatorSectionTitleClass =
+  "text-xl font-bold tracking-tight text-foreground";
+
+export const calculatorSectionDescriptionClass =
+  "mt-1 text-sm leading-relaxed text-muted";
+
+/** Result cards read as a label/value ledger; these keep every row aligned. */
+export const calculatorStatRowClass =
+  "flex items-baseline justify-between gap-3";
+
+export const calculatorStatLabelClass = "text-muted";
+
+export const calculatorStatValueClass =
+  "font-semibold text-foreground tabular-nums";
+
+/**
+ * The result column follows the inputs on small screens, matching the order
+ * people fill the calculator in, and moves to a sticky right rail on desktop.
+ */
+export const calculatorResultColumnClass =
+  "lg:col-span-5 lg:sticky lg:top-24 lg:self-start";

--- a/frontend/src/features/landing/tools/macroRedistribution.test.ts
+++ b/frontend/src/features/landing/tools/macroRedistribution.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { redistributeMacroPercentages } from "./macroRedistribution";
+
+describe("redistributeMacroPercentages", () => {
+  it("redistributes proportionally when one macro increases", () => {
+    const initial = {
+      proteinPercentage: 30,
+      carbsPercentage: 40,
+      fatsPercentage: 30,
+    };
+    const result = redistributeMacroPercentages("protein", 50, initial);
+    expect(result.proteinPercentage).toBe(50);
+    expect(
+      result.proteinPercentage + result.carbsPercentage + result.fatsPercentage,
+    ).toBe(100);
+  });
+
+  it("respects locked macros", () => {
+    const initial = {
+      proteinPercentage: 30,
+      carbsPercentage: 40,
+      fatsPercentage: 30,
+    };
+    const result = redistributeMacroPercentages("protein", 50, initial, [
+      "fats",
+    ]);
+    expect(result.proteinPercentage).toBe(50);
+    expect(result.fatsPercentage).toBe(30);
+    expect(result.carbsPercentage).toBe(20);
+  });
+
+  it("keeps total at 100 on extreme inputs", () => {
+    const initial = {
+      proteinPercentage: 30,
+      carbsPercentage: 40,
+      fatsPercentage: 30,
+    };
+    const result = redistributeMacroPercentages("protein", 100, initial);
+    expect(result.proteinPercentage).toBe(100);
+    expect(result.carbsPercentage).toBe(0);
+    expect(result.fatsPercentage).toBe(0);
+  });
+
+  it("clamps changed macro to available budget when another macro is locked", () => {
+    const initial = {
+      proteinPercentage: 30,
+      carbsPercentage: 40,
+      fatsPercentage: 30,
+    };
+    // Fats locked at 30%, so max available for protein + carbs is 70%
+    const result = redistributeMacroPercentages("protein", 80, initial, [
+      "fats",
+    ]);
+    expect(result.proteinPercentage).toBe(70);
+    expect(result.fatsPercentage).toBe(30);
+    expect(result.carbsPercentage).toBe(0);
+    expect(
+      result.proteinPercentage + result.carbsPercentage + result.fatsPercentage,
+    ).toBe(100);
+  });
+
+  it("returns unchanged state when changed macro or all remaining macros are locked", () => {
+    const initial = {
+      proteinPercentage: 30,
+      carbsPercentage: 40,
+      fatsPercentage: 30,
+    };
+    // Trying to change protein when protein is locked
+    const result1 = redistributeMacroPercentages("protein", 50, initial, [
+      "protein",
+    ]);
+    expect(result1).toEqual(initial);
+
+    // Trying to change protein when carbs AND fats are locked
+    const result2 = redistributeMacroPercentages("protein", 50, initial, [
+      "carbs",
+      "fats",
+    ]);
+    expect(result2).toEqual(initial);
+  });
+});

--- a/frontend/src/features/landing/tools/macroRedistribution.ts
+++ b/frontend/src/features/landing/tools/macroRedistribution.ts
@@ -1,0 +1,84 @@
+import type { MacroType } from "@/types/macro";
+
+export interface MacroPercentages {
+  proteinPercentage: number;
+  carbsPercentage: number;
+  fatsPercentage: number;
+}
+
+/**
+ * Adjusts macro percentages when one slider moves, keeping the sum at 100.
+ * Redistributes difference proportionally among unlocked remaining macros.
+ */
+export function redistributeMacroPercentages(
+  changedMacro: MacroType,
+  newValue: number,
+  current: MacroPercentages,
+  lockedMacros: MacroType[] = [],
+): MacroPercentages {
+  // If the macro being changed is itself locked, return current unchanged
+  if (lockedMacros.includes(changedMacro)) {
+    return current;
+  }
+
+  const keyMap: Record<MacroType, keyof MacroPercentages> = {
+    protein: "proteinPercentage",
+    carbs: "carbsPercentage",
+    fats: "fatsPercentage",
+  };
+
+  const changedKey = keyMap[changedMacro];
+  const otherMacros = (["protein", "carbs", "fats"] as const).filter(
+    (m) => m !== changedMacro,
+  );
+
+  const unlockedOthers = otherMacros.filter((m) => !lockedMacros.includes(m));
+
+  // If no other macros can absorb changes, return current unchanged
+  if (unlockedOthers.length === 0) {
+    return current;
+  }
+
+  // Calculate sum of locked other macros
+  const lockedOthersSum = otherMacros
+    .filter((m) => lockedMacros.includes(m))
+    .reduce((sum, m) => sum + current[keyMap[m]], 0);
+
+  const maxAllowed = Math.max(0, 100 - lockedOthersSum);
+  const clampedValue = Math.max(0, Math.min(maxAllowed, Math.round(newValue)));
+
+  const remaining = 100 - clampedValue - lockedOthersSum;
+
+  if (unlockedOthers.length === 1) {
+    const singleOtherKey = keyMap[unlockedOthers[0]];
+
+    return {
+      ...current,
+      [changedKey]: clampedValue,
+      [singleOtherKey]: Math.max(0, remaining),
+    };
+  }
+
+  // Both other macros are unlocked
+  const currentOtherSum =
+    current[keyMap[unlockedOthers[0]]] + current[keyMap[unlockedOthers[1]]];
+
+  let firstValue: number;
+  let secondValue: number;
+
+  if (currentOtherSum === 0) {
+    firstValue = Math.floor(remaining / 2);
+    secondValue = remaining - firstValue;
+  } else {
+    const ratio0 = current[keyMap[unlockedOthers[0]]] / currentOtherSum;
+    firstValue = Math.round(remaining * ratio0);
+    secondValue = remaining - firstValue;
+  }
+
+  return {
+    ...current,
+    [changedKey]: clampedValue,
+    [keyMap[unlockedOthers[0]]]: Math.max(0, firstValue),
+    [keyMap[unlockedOthers[1]]]: Math.max(0, secondValue),
+  };
+}

--- a/frontend/src/features/landing/tools/toolsCatalog.ts
+++ b/frontend/src/features/landing/tools/toolsCatalog.ts
@@ -1,0 +1,61 @@
+/**
+ * Single source of truth for the public calculators. The header dropdown, the
+ * tools hub, and the "related calculators" strip on each page all read from
+ * here so a new calculator only needs to be described once.
+ */
+export interface CalculatorTool {
+  /** Full page title, also used as the hub card heading. */
+  title: string;
+  /** Shorter label for dense surfaces; falls back to `title` when omitted. */
+  navLabel?: string;
+  path: string;
+  /** One-line summary for the header dropdown and related-tool cards. */
+  tagline: string;
+  /** Longer supporting copy for the tools hub. */
+  description: string;
+  /** Renders full width at the top of the hub grid. */
+  featured?: boolean;
+}
+
+export const CALCULATOR_TOOLS: readonly CalculatorTool[] = [
+  {
+    title: "TDEE Calculator",
+    path: "/tools/tdee-calculator",
+    tagline: "Maintenance calories and activity burn",
+    description:
+      "Start with your estimated maintenance calories, then use them to plan a cut, maintenance phase, or gain phase.",
+    featured: true,
+  },
+  {
+    title: "BMR Calculator",
+    path: "/tools/bmr-calculator",
+    tagline: "Resting energy your body burns at rest",
+    description:
+      "Estimate your Basal Metabolic Rate—the energy your body uses at rest for vital functions.",
+  },
+  {
+    title: "Macro Calculator",
+    path: "/tools/macro-calculator",
+    tagline: "Protein, carb, and fat percentage splits",
+    description:
+      "Set daily protein, carb, and fat ratios with interactive, lockable percentage sliders.",
+  },
+  {
+    title: "Weight Loss & Timeline Calculator",
+    navLabel: "Weight Loss Calculator",
+    path: "/tools/weight-loss-calculator",
+    tagline: "Calorie deficit, weekly pace, and goal date",
+    description:
+      "Estimate daily calorie deficits, weekly progress rates, and projected completion dates for your target weight.",
+  },
+  {
+    title: "Protein Intake Calculator",
+    navLabel: "Protein Calculator",
+    path: "/tools/protein-calculator",
+    tagline: "Daily and per-meal protein targets",
+    description:
+      "Estimate daily and per-meal protein targets for muscle building, fat loss, or endurance goals.",
+  },
+] as const;
+
+export const TOOLS_HUB_PATH = "/tools";

--- a/frontend/src/features/landing/tools/useBodyStats.ts
+++ b/frontend/src/features/landing/tools/useBodyStats.ts
@@ -1,0 +1,38 @@
+import { useState } from "react";
+
+import type { ActivityLevel, Gender } from "@/types/activity";
+import type { UnitSystem } from "@/utils/unitConversion";
+
+import { hasValidBodyStats } from "./calculatorInputs";
+
+/**
+ * Every calculator starts from the same body stats, so they all share this
+ * state and hand the whole bundle straight to <BodyStatsForm />.
+ */
+export function useBodyStats(initialWeightKg = 75) {
+  const [unitSystem, setUnitSystem] = useState<UnitSystem>("metric");
+  const [gender, setGender] = useState<Gender>("male");
+  const [age, setAge] = useState(28);
+  const [weightKg, setWeightKg] = useState(initialWeightKg);
+  const [heightCm, setHeightCm] = useState(175);
+  const [activityLevel, setActivityLevel] = useState<ActivityLevel>("medium");
+
+  return {
+    unitSystem,
+    setUnitSystem,
+    gender,
+    setGender,
+    age,
+    setAge,
+    weightKg,
+    setWeightKg,
+    heightCm,
+    setHeightCm,
+    activityLevel,
+    setActivityLevel,
+    /** True once age, weight, and height all have usable values. */
+    ready: hasValidBodyStats({ weightKg, heightCm, age }),
+  };
+}
+
+export type BodyStatsControls = ReturnType<typeof useBodyStats>;

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -23,7 +23,13 @@ import { Route as HomeRouteImport } from './routes/home'
 import { Route as GoalsRouteImport } from './routes/goals'
 import { Route as AuthReadyRouteImport } from './routes/auth-ready'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as ToolsIndexRouteImport } from './routes/tools/index'
 import { Route as BlogIndexRouteImport } from './routes/blog/index'
+import { Route as ToolsWeightLossCalculatorRouteImport } from './routes/tools/weight-loss-calculator'
+import { Route as ToolsTdeeCalculatorRouteImport } from './routes/tools/tdee-calculator'
+import { Route as ToolsProteinCalculatorRouteImport } from './routes/tools/protein-calculator'
+import { Route as ToolsMacroCalculatorRouteImport } from './routes/tools/macro-calculator'
+import { Route as ToolsBmrCalculatorRouteImport } from './routes/tools/bmr-calculator'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 
 const TermsRoute = TermsRouteImport.update({
@@ -96,9 +102,40 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ToolsIndexRoute = ToolsIndexRouteImport.update({
+  id: '/tools/',
+  path: '/tools/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const BlogIndexRoute = BlogIndexRouteImport.update({
   id: '/blog/',
   path: '/blog/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ToolsWeightLossCalculatorRoute =
+  ToolsWeightLossCalculatorRouteImport.update({
+    id: '/tools/weight-loss-calculator',
+    path: '/tools/weight-loss-calculator',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ToolsTdeeCalculatorRoute = ToolsTdeeCalculatorRouteImport.update({
+  id: '/tools/tdee-calculator',
+  path: '/tools/tdee-calculator',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ToolsProteinCalculatorRoute = ToolsProteinCalculatorRouteImport.update({
+  id: '/tools/protein-calculator',
+  path: '/tools/protein-calculator',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ToolsMacroCalculatorRoute = ToolsMacroCalculatorRouteImport.update({
+  id: '/tools/macro-calculator',
+  path: '/tools/macro-calculator',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ToolsBmrCalculatorRoute = ToolsBmrCalculatorRouteImport.update({
+  id: '/tools/bmr-calculator',
+  path: '/tools/bmr-calculator',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BlogSlugRoute = BlogSlugRouteImport.update({
@@ -123,7 +160,13 @@ export interface FileRoutesByFullPath {
   '/sso-callback': typeof SsoCallbackRoute
   '/terms': typeof TermsRoute
   '/blog/$slug': typeof BlogSlugRoute
+  '/tools/bmr-calculator': typeof ToolsBmrCalculatorRoute
+  '/tools/macro-calculator': typeof ToolsMacroCalculatorRoute
+  '/tools/protein-calculator': typeof ToolsProteinCalculatorRoute
+  '/tools/tdee-calculator': typeof ToolsTdeeCalculatorRoute
+  '/tools/weight-loss-calculator': typeof ToolsWeightLossCalculatorRoute
   '/blog/': typeof BlogIndexRoute
+  '/tools/': typeof ToolsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -141,7 +184,13 @@ export interface FileRoutesByTo {
   '/sso-callback': typeof SsoCallbackRoute
   '/terms': typeof TermsRoute
   '/blog/$slug': typeof BlogSlugRoute
+  '/tools/bmr-calculator': typeof ToolsBmrCalculatorRoute
+  '/tools/macro-calculator': typeof ToolsMacroCalculatorRoute
+  '/tools/protein-calculator': typeof ToolsProteinCalculatorRoute
+  '/tools/tdee-calculator': typeof ToolsTdeeCalculatorRoute
+  '/tools/weight-loss-calculator': typeof ToolsWeightLossCalculatorRoute
   '/blog': typeof BlogIndexRoute
+  '/tools': typeof ToolsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -160,7 +209,13 @@ export interface FileRoutesById {
   '/sso-callback': typeof SsoCallbackRoute
   '/terms': typeof TermsRoute
   '/blog/$slug': typeof BlogSlugRoute
+  '/tools/bmr-calculator': typeof ToolsBmrCalculatorRoute
+  '/tools/macro-calculator': typeof ToolsMacroCalculatorRoute
+  '/tools/protein-calculator': typeof ToolsProteinCalculatorRoute
+  '/tools/tdee-calculator': typeof ToolsTdeeCalculatorRoute
+  '/tools/weight-loss-calculator': typeof ToolsWeightLossCalculatorRoute
   '/blog/': typeof BlogIndexRoute
+  '/tools/': typeof ToolsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -180,7 +235,13 @@ export interface FileRouteTypes {
     | '/sso-callback'
     | '/terms'
     | '/blog/$slug'
+    | '/tools/bmr-calculator'
+    | '/tools/macro-calculator'
+    | '/tools/protein-calculator'
+    | '/tools/tdee-calculator'
+    | '/tools/weight-loss-calculator'
     | '/blog/'
+    | '/tools/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -198,7 +259,13 @@ export interface FileRouteTypes {
     | '/sso-callback'
     | '/terms'
     | '/blog/$slug'
+    | '/tools/bmr-calculator'
+    | '/tools/macro-calculator'
+    | '/tools/protein-calculator'
+    | '/tools/tdee-calculator'
+    | '/tools/weight-loss-calculator'
     | '/blog'
+    | '/tools'
   id:
     | '__root__'
     | '/'
@@ -216,7 +283,13 @@ export interface FileRouteTypes {
     | '/sso-callback'
     | '/terms'
     | '/blog/$slug'
+    | '/tools/bmr-calculator'
+    | '/tools/macro-calculator'
+    | '/tools/protein-calculator'
+    | '/tools/tdee-calculator'
+    | '/tools/weight-loss-calculator'
     | '/blog/'
+    | '/tools/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -235,7 +308,13 @@ export interface RootRouteChildren {
   SsoCallbackRoute: typeof SsoCallbackRoute
   TermsRoute: typeof TermsRoute
   BlogSlugRoute: typeof BlogSlugRoute
+  ToolsBmrCalculatorRoute: typeof ToolsBmrCalculatorRoute
+  ToolsMacroCalculatorRoute: typeof ToolsMacroCalculatorRoute
+  ToolsProteinCalculatorRoute: typeof ToolsProteinCalculatorRoute
+  ToolsTdeeCalculatorRoute: typeof ToolsTdeeCalculatorRoute
+  ToolsWeightLossCalculatorRoute: typeof ToolsWeightLossCalculatorRoute
   BlogIndexRoute: typeof BlogIndexRoute
+  ToolsIndexRoute: typeof ToolsIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -338,11 +417,53 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/tools/': {
+      id: '/tools/'
+      path: '/tools'
+      fullPath: '/tools/'
+      preLoaderRoute: typeof ToolsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/blog/': {
       id: '/blog/'
       path: '/blog'
       fullPath: '/blog/'
       preLoaderRoute: typeof BlogIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/tools/weight-loss-calculator': {
+      id: '/tools/weight-loss-calculator'
+      path: '/tools/weight-loss-calculator'
+      fullPath: '/tools/weight-loss-calculator'
+      preLoaderRoute: typeof ToolsWeightLossCalculatorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/tools/tdee-calculator': {
+      id: '/tools/tdee-calculator'
+      path: '/tools/tdee-calculator'
+      fullPath: '/tools/tdee-calculator'
+      preLoaderRoute: typeof ToolsTdeeCalculatorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/tools/protein-calculator': {
+      id: '/tools/protein-calculator'
+      path: '/tools/protein-calculator'
+      fullPath: '/tools/protein-calculator'
+      preLoaderRoute: typeof ToolsProteinCalculatorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/tools/macro-calculator': {
+      id: '/tools/macro-calculator'
+      path: '/tools/macro-calculator'
+      fullPath: '/tools/macro-calculator'
+      preLoaderRoute: typeof ToolsMacroCalculatorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/tools/bmr-calculator': {
+      id: '/tools/bmr-calculator'
+      path: '/tools/bmr-calculator'
+      fullPath: '/tools/bmr-calculator'
+      preLoaderRoute: typeof ToolsBmrCalculatorRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/blog/$slug': {
@@ -371,7 +492,13 @@ const rootRouteChildren: RootRouteChildren = {
   SsoCallbackRoute: SsoCallbackRoute,
   TermsRoute: TermsRoute,
   BlogSlugRoute: BlogSlugRoute,
+  ToolsBmrCalculatorRoute: ToolsBmrCalculatorRoute,
+  ToolsMacroCalculatorRoute: ToolsMacroCalculatorRoute,
+  ToolsProteinCalculatorRoute: ToolsProteinCalculatorRoute,
+  ToolsTdeeCalculatorRoute: ToolsTdeeCalculatorRoute,
+  ToolsWeightLossCalculatorRoute: ToolsWeightLossCalculatorRoute,
   BlogIndexRoute: BlogIndexRoute,
+  ToolsIndexRoute: ToolsIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/frontend/src/routes/tools/bmr-calculator.tsx
+++ b/frontend/src/routes/tools/bmr-calculator.tsx
@@ -1,0 +1,23 @@
+import { lazy, Suspense } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+
+import LoadingSpinner from "@/components/ui/LoadingSpinner";
+import { PublicSelfHostedGate } from "@/routes/-PublicSelfHostedGate";
+
+const BmrCalculatorPage = lazy(
+  () => import("@/features/landing/pages/BmrCalculatorPage"),
+);
+
+export const Route = createFileRoute("/tools/bmr-calculator")({
+  component: BmrCalculatorRoute,
+});
+
+function BmrCalculatorRoute() {
+  return (
+    <PublicSelfHostedGate>
+      <Suspense fallback={<LoadingSpinner fullScreen />}>
+        <BmrCalculatorPage />
+      </Suspense>
+    </PublicSelfHostedGate>
+  );
+}

--- a/frontend/src/routes/tools/index.tsx
+++ b/frontend/src/routes/tools/index.tsx
@@ -1,0 +1,23 @@
+import { lazy, Suspense } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+
+import LoadingSpinner from "@/components/ui/LoadingSpinner";
+import { PublicSelfHostedGate } from "@/routes/-PublicSelfHostedGate";
+
+const ToolsHubPage = lazy(
+  () => import("@/features/landing/pages/ToolsHubPage"),
+);
+
+export const Route = createFileRoute("/tools/")({
+  component: ToolsHubRoute,
+});
+
+function ToolsHubRoute() {
+  return (
+    <PublicSelfHostedGate>
+      <Suspense fallback={<LoadingSpinner fullScreen />}>
+        <ToolsHubPage />
+      </Suspense>
+    </PublicSelfHostedGate>
+  );
+}

--- a/frontend/src/routes/tools/macro-calculator.tsx
+++ b/frontend/src/routes/tools/macro-calculator.tsx
@@ -1,0 +1,23 @@
+import { lazy, Suspense } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+
+import LoadingSpinner from "@/components/ui/LoadingSpinner";
+import { PublicSelfHostedGate } from "@/routes/-PublicSelfHostedGate";
+
+const MacroCalculatorPage = lazy(
+  () => import("@/features/landing/pages/MacroCalculatorPage"),
+);
+
+export const Route = createFileRoute("/tools/macro-calculator")({
+  component: MacroCalculatorRoute,
+});
+
+function MacroCalculatorRoute() {
+  return (
+    <PublicSelfHostedGate>
+      <Suspense fallback={<LoadingSpinner fullScreen />}>
+        <MacroCalculatorPage />
+      </Suspense>
+    </PublicSelfHostedGate>
+  );
+}

--- a/frontend/src/routes/tools/protein-calculator.tsx
+++ b/frontend/src/routes/tools/protein-calculator.tsx
@@ -1,0 +1,23 @@
+import { lazy, Suspense } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+
+import LoadingSpinner from "@/components/ui/LoadingSpinner";
+import { PublicSelfHostedGate } from "@/routes/-PublicSelfHostedGate";
+
+const ProteinCalculatorPage = lazy(
+  () => import("@/features/landing/pages/ProteinCalculatorPage"),
+);
+
+export const Route = createFileRoute("/tools/protein-calculator")({
+  component: ProteinCalculatorRoute,
+});
+
+function ProteinCalculatorRoute() {
+  return (
+    <PublicSelfHostedGate>
+      <Suspense fallback={<LoadingSpinner fullScreen />}>
+        <ProteinCalculatorPage />
+      </Suspense>
+    </PublicSelfHostedGate>
+  );
+}

--- a/frontend/src/routes/tools/tdee-calculator.tsx
+++ b/frontend/src/routes/tools/tdee-calculator.tsx
@@ -1,0 +1,23 @@
+import { lazy, Suspense } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+
+import LoadingSpinner from "@/components/ui/LoadingSpinner";
+import { PublicSelfHostedGate } from "@/routes/-PublicSelfHostedGate";
+
+const TdeeCalculatorPage = lazy(
+  () => import("@/features/landing/pages/TdeeCalculatorPage"),
+);
+
+export const Route = createFileRoute("/tools/tdee-calculator")({
+  component: TdeeCalculatorRoute,
+});
+
+function TdeeCalculatorRoute() {
+  return (
+    <PublicSelfHostedGate>
+      <Suspense fallback={<LoadingSpinner fullScreen />}>
+        <TdeeCalculatorPage />
+      </Suspense>
+    </PublicSelfHostedGate>
+  );
+}

--- a/frontend/src/routes/tools/weight-loss-calculator.tsx
+++ b/frontend/src/routes/tools/weight-loss-calculator.tsx
@@ -1,0 +1,23 @@
+import { lazy, Suspense } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+
+import LoadingSpinner from "@/components/ui/LoadingSpinner";
+import { PublicSelfHostedGate } from "@/routes/-PublicSelfHostedGate";
+
+const WeightLossCalculatorPage = lazy(
+  () => import("@/features/landing/pages/WeightLossCalculatorPage"),
+);
+
+export const Route = createFileRoute("/tools/weight-loss-calculator")({
+  component: WeightLossCalculatorRoute,
+});
+
+function WeightLossCalculatorRoute() {
+  return (
+    <PublicSelfHostedGate>
+      <Suspense fallback={<LoadingSpinner fullScreen />}>
+        <WeightLossCalculatorPage />
+      </Suspense>
+    </PublicSelfHostedGate>
+  );
+}

--- a/frontend/src/utils/unitConversion.test.ts
+++ b/frontend/src/utils/unitConversion.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  cmToFtIn,
+  ftInToCm,
+  kgToLb,
+  lbToKg,
+} from "./unitConversion";
+
+describe("unitConversion", () => {
+  it("converts kg to lb and back with acceptable precision", () => {
+    expect(kgToLb(75)).toBe(165.3);
+    expect(lbToKg(165.3)).toBe(75);
+  });
+
+  it("handles zero and invalid inputs for weight", () => {
+    expect(kgToLb(0)).toBe(0);
+    expect(lbToKg(0)).toBe(0);
+  });
+
+  it("converts cm to feet and inches correctly", () => {
+    expect(cmToFtIn(175)).toEqual({ feet: 5, inches: 9 });
+    expect(cmToFtIn(180)).toEqual({ feet: 5, inches: 11 });
+  });
+
+  it("converts feet and inches to cm correctly", () => {
+    expect(ftInToCm(5, 9)).toBe(175);
+    expect(ftInToCm(5, 11)).toBe(180);
+  });
+
+  it("round-trips height within 1 cm", () => {
+    const { feet, inches } = cmToFtIn(175);
+    expect(ftInToCm(feet, inches)).toBe(175);
+  });
+});

--- a/frontend/src/utils/unitConversion.ts
+++ b/frontend/src/utils/unitConversion.ts
@@ -1,0 +1,31 @@
+// ponytail: metric-canonical state; UI converts display values when imperial is selected
+
+export type UnitSystem = "metric" | "imperial";
+
+export const LBS_PER_KG = 2.20462;
+export const CM_PER_INCH = 2.54;
+
+export function kgToLb(kg: number): number {
+  return kg > 0 ? Math.round(kg * LBS_PER_KG * 10) / 10 : 0;
+}
+
+export function lbToKg(lb: number): number {
+  return lb > 0 ? Math.round((lb / LBS_PER_KG) * 10) / 10 : 0;
+}
+
+export function cmToFtIn(cm: number): { feet: number; inches: number } {
+  if (!cm || cm <= 0) return { feet: 0, inches: 0 };
+  const totalInches = Math.round(cm / CM_PER_INCH);
+  const feet = Math.floor(totalInches / 12);
+  const inches = totalInches % 12;
+
+  return { feet, inches };
+}
+
+export function ftInToCm(feet: number, inches: number): number {
+  const safeFeet = Math.max(0, feet || 0);
+  const safeInches = Math.max(0, inches || 0);
+  const totalInches = safeFeet * 12 + safeInches;
+
+  return Math.round(totalInches * CM_PER_INCH);
+}


### PR DESCRIPTION
## Summary

Adds five free, account-free nutrition calculators and a hub that links them, as the organic-discovery surface for the project. Also mirrors container images to Docker Hub and starts building arm64.

## Calculators

- `/tools` hub plus TDEE, BMR, macro split, weight-loss timeline, and protein intake pages
- Everything runs client-side, so no sign-up and no API calls
- Shared `useBodyStats` hook holds the body-stats state; each page contributes only its own maths and result card
- Mobile order is inputs first, result below; two-up field grid keeps the form compact on phones

## Discovery

- WebApplication + FAQPage structured data on each calculator
- Sitemap generator covers `/tools*` and `/pricing`, with per-route `lastmod` derived from the newest blog post
- Header "Tools" menu and a footer link

## Header popover

The Tools menu uses the native popover API (`popover="auto"` + CSS anchor positioning) instead of hand-rolled outside-click and Escape listeners. Verified in Chrome: anchors 8px under the trigger, Escape closes it, focus returns to the button. jsdom has no popover API, so the imperative `hidePopover` calls are optional-chained.

## CI

`publish-images.yml` now pushes to Docker Hub alongside GHCR and builds `linux/amd64,linux/arm64`. Needs the `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets, which are already set.

## Testing

- `bun run test` — 701 passed across 109 files
- `bun run lint` — 0 errors
- Chrome: popover anchoring, Escape dismissal, calculator layout at 390x844 and 1280x800