### PR TITLE
security: harden auth, rate limiting, response headers and deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ need to reach backend on `localhost`.
 Services:
 
 - frontend: `http://localhost:5173` (Mapped to internal container port 80)
-- backend API: `http://localhost:3000` (Direct access usually not needed since frontend proxies `/api`)
+- backend API: not published to the host. It is reachable only from the frontend container,
+  which proxies `/api`. Exposing it directly would let clients bypass nginx and forge the
+  `X-Real-IP` header that per-client rate limiting relies on (`TRUST_PROXY`). If you need
+  direct access, add a `ports` mapping and set `TRUST_PROXY=false`.
 
 The SQLite database is persisted at `./data/macrotrackr.db`.
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,6 +10,12 @@ CORS_ORIGIN=http://localhost:5173
 PUBLIC_APP_NAME=Macro Tracker
 SUPPORT_EMAIL=support@local.invalid
 
+# Enable only when a reverse proxy in front of the API overwrites X-Real-IP.
+# When false, rate limiting keys on the socket address, which clients cannot
+# forge. Enabling it while the API is directly reachable lets a client spoof
+# its identity and bypass rate limits.
+TRUST_PROXY=false
+
 # --- Runtime Profiles ---
 APP_MODE=self-hosted
 AUTH_MODE=local
@@ -19,3 +25,7 @@ EMAIL_MODE=disabled
 
 # --- Telemetry & Metrics (Optional) ---
 ENABLE_METRICS=false
+# Shared secret for /metrics and /metrics/queries. Set this whenever the API is
+# publicly reachable: without it /metrics serves the full registry to anyone.
+# Send it as `X-Metrics-Key` or `Authorization: Bearer <key>`.
+# METRICS_API_KEY=

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,6 +12,12 @@ RUN bun install
 ENV NODE_ENV=production
 ENV PORT=3000
 
+# The SQLite file lives on a mounted volume; give the runtime user a home for it.
+RUN mkdir -p /data && chown -R bun:bun /app /data
+
+# Drop root. The `bun` user ships with the base image.
+USER bun
+
 EXPOSE 3000
 
 CMD ["bun", "run", "src/index.ts"]

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -7,6 +7,7 @@ import { clerkAuthMiddleware } from "./middleware/clerk-auth";
 import { localAuthMiddleware } from "./middleware/local-auth";
 import { rateLimiters } from "./middleware/rate-limit";
 import { requestLimitsMiddleware } from "./middleware/request-limits";
+import { securityHeadersMiddleware } from "./middleware/security-headers";
 import {
   correlationMiddleware,
   enhancedApiLogging,
@@ -173,17 +174,21 @@ function buildUnexpectedErrorPayload(
   error: unknown,
   statusCode: number
 ): ErrorResponsePayload {
+  const isProduction = config.NODE_ENV === "production";
+
+  // Raw error messages from unhandled 5xx failures routinely carry internals
+  // (SQL fragments, file paths, upstream URLs). Only surface them off-prod.
+  const shouldRedactMessage = isProduction && statusCode >= 500;
+
   const base: ErrorResponsePayload = {
     code: code || "INTERNAL_ERROR",
     message:
-      error instanceof Error ? error.message : "An unexpected error occurred",
+      !shouldRedactMessage && error instanceof Error
+        ? error.message
+        : "An unexpected error occurred",
   };
 
-  if (
-    config.NODE_ENV !== "production" &&
-    statusCode >= 500 &&
-    error instanceof Error
-  ) {
+  if (!isProduction && statusCode >= 500 && error instanceof Error) {
     base.details = error.stack;
   }
 
@@ -270,7 +275,8 @@ function registerCoreRoutes(app: Elysia, db: Database): void {
     .use(correlationMiddleware)
     .use(enhancedApiLogging)
 
-    // Apply rate limiting
+    // Apply rate limiting (strict bucket for credential endpoints first)
+    .use(rateLimiters.auth)
     .use(rateLimiters.api);
 
   if (withClerk) {
@@ -302,6 +308,9 @@ function registerCoreRoutes(app: Elysia, db: Database): void {
 
 export function createApp(db: Database) {
   const app = new Elysia()
+    // Baseline security response headers
+    .use(securityHeadersMiddleware)
+
     // Request size limits for security
     .use(requestLimitsMiddleware)
 
@@ -349,7 +358,15 @@ export function createApp(db: Database) {
           const allowed = Array.isArray(config.CORS_ORIGIN)
             ? config.CORS_ORIGIN
             : [config.CORS_ORIGIN];
-          return allowed.includes(requestOrigin) || allowed.includes("*");
+
+          // A wildcard is incompatible with credentialed requests: reflecting
+          // any origin back with Allow-Credentials lets any site read the API
+          // as the signed-in user. Only honour it outside production.
+          if (allowed.includes("*")) {
+            return config.NODE_ENV !== "production";
+          }
+
+          return allowed.includes(requestOrigin);
         },
         credentials: true,
         allowedHeaders: ["Content-Type", "Authorization"],

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -35,6 +35,14 @@ const BaseEnvSchema = z.object({
     .transform((value) => value === true || value === "true")
     .default(false),
 
+  // Only enable when the app sits behind a reverse proxy that overwrites
+  // X-Forwarded-For. When false, rate limiting keys on the socket address so
+  // clients cannot spoof their identity with a forged header.
+  TRUST_PROXY: z
+    .union([z.boolean(), z.literal("true"), z.literal("false")])
+    .transform((value) => value === true || value === "true")
+    .default(false),
+
   STRIPE_SECRET_KEY: z.string().optional(),
   STRIPE_WEBHOOK_SECRET: z.string().optional(),
   STRIPE_PRICE_ID_MONTHLY: z.string().optional(),
@@ -225,6 +233,7 @@ const configProxyTarget: Config = {
   PUBLIC_APP_NAME: "",
   SUPPORT_EMAIL: "",
   ENABLE_METRICS: false,
+  TRUST_PROXY: false,
   STRIPE_SECRET_KEY: "",
   STRIPE_WEBHOOK_SECRET: "",
   STRIPE_PRICE_ID_MONTHLY: "",

--- a/backend/src/lib/auth/session.ts
+++ b/backend/src/lib/auth/session.ts
@@ -1,5 +1,5 @@
 import type { Database } from "bun:sqlite";
-import { randomBytes, createHash } from "node:crypto";
+import { randomBytes, createHash, timingSafeEqual } from "node:crypto";
 import { generateId } from "../../utils/id-generator";
 
 const SESSION_COOKIE_NAME = "mt_session";
@@ -27,6 +27,17 @@ export interface ResolvedSession {
 
 function hashSecret(secret: string): string {
   return createHash("sha256").update(secret).digest("hex");
+}
+
+function secretMatches(rawSecret: string, storedHash: string): boolean {
+  const candidate = Buffer.from(hashSecret(rawSecret), "hex");
+  const stored = Buffer.from(storedHash, "hex");
+
+  if (candidate.length !== stored.length) {
+    return false;
+  }
+
+  return timingSafeEqual(candidate, stored);
 }
 
 function createRawSecret(): string {
@@ -79,18 +90,35 @@ export function createExpiredSessionCookieValue(): string {
   return `${SESSION_COOKIE_NAME}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0`;
 }
 
+/**
+ * Endpoints where the session token may travel in the query string.
+ *
+ * Query strings leak into proxy access logs, browser history and Referer
+ * headers, so this is limited to the SSE stream: EventSource cannot set an
+ * Authorization header, and cookies are unavailable on cross-origin native
+ * (Capacitor) builds.
+ */
+const QUERY_TOKEN_ALLOWED_PATHS = new Set(["/api/sync/events"]);
+
+function isClerkToken(token: string): boolean {
+  return token.startsWith("pk_") || token.startsWith("sess_");
+}
+
 export function readSessionTokenFromRequest(request: Request): string | null {
   const authHeader = request.headers.get("authorization");
   if (authHeader && authHeader.startsWith("Bearer ")) {
     const bearerToken = authHeader.slice(7).trim();
-    if (bearerToken && !bearerToken.startsWith("pk_") && !bearerToken.startsWith("sess_")) {
+    if (bearerToken && !isClerkToken(bearerToken)) {
       return bearerToken;
     }
   }
 
-  const queryToken = new URL(request.url).searchParams.get("token");
-  if (queryToken && !queryToken.startsWith("pk_") && !queryToken.startsWith("sess_")) {
-    return queryToken;
+  const url = new URL(request.url);
+  if (QUERY_TOKEN_ALLOWED_PATHS.has(url.pathname)) {
+    const queryToken = url.searchParams.get("token");
+    if (queryToken && !isClerkToken(queryToken)) {
+      return queryToken;
+    }
   }
 
   const cookies = parseCookieHeader(request.headers.get("cookie"));
@@ -173,7 +201,7 @@ export function resolveSession(
     return null;
   }
 
-  if (row.secret_hash !== hashSecret(rawSecret)) {
+  if (!secretMatches(rawSecret, row.secret_hash)) {
     return null;
   }
 

--- a/backend/src/lib/http/schemas.ts
+++ b/backend/src/lib/http/schemas.ts
@@ -10,9 +10,12 @@ export const EmailSchema = t.String({
   error: "Invalid email format.",
 });
 
+// bcrypt only considers the first 72 bytes, so anything beyond that is a
+// silently ignored suffix as well as wasted hashing work on attacker input.
 export const PasswordSchema = t.String({
   minLength: 8,
-  error: "Password must be at least 8 characters long.",
+  maxLength: 72,
+  error: "Password must be between 8 and 72 characters long.",
 });
 
 export const RequiredStringSchema = t.String({

--- a/backend/src/middleware/clerk-auth.ts
+++ b/backend/src/middleware/clerk-auth.ts
@@ -177,11 +177,43 @@ function getPrimaryClerkEmail(clerkUser: {
  * Clerk authentication middleware for Elysia
  * Validates Clerk JWT tokens and extracts user information
  */
+/**
+ * Origins allowed to present Clerk session tokens to this API.
+ *
+ * Without this, a session token minted for a different Clerk frontend can be
+ * replayed against our backend. Derived from the configured app URL and CORS
+ * allowlist so it tracks deployment config automatically.
+ */
+function getAuthorizedParties(): string[] | undefined {
+  const origins = new Set<string>();
+
+  const addOrigin = (value: string | undefined) => {
+    if (!value || value === "*") {
+      return;
+    }
+    try {
+      origins.add(new URL(value).origin);
+    } catch {
+      // Ignore entries that are not absolute URLs.
+    }
+  };
+
+  addOrigin(config.APP_URL);
+
+  const corsOrigins = Array.isArray(config.CORS_ORIGIN)
+    ? config.CORS_ORIGIN
+    : [config.CORS_ORIGIN];
+  for (const origin of corsOrigins) {
+    addOrigin(origin);
+  }
+
+  return origins.size > 0 ? [...origins] : undefined;
+}
+
 export const clerkAuthMiddleware = clerkPlugin({
   publishableKey: config.CLERK_PUBLISHABLE_KEY,
   secretKey: config.CLERK_SECRET_KEY,
-  // Optional: restrict authorized parties
-  // authorizedParties: [config.CORS_ORIGIN as string],
+  authorizedParties: getAuthorizedParties(),
 })
   .resolve(
     { as: "scoped" },

--- a/backend/src/middleware/rate-limit.ts
+++ b/backend/src/middleware/rate-limit.ts
@@ -1,17 +1,26 @@
 // src/middleware/rate-limit.ts
 import { Elysia } from "elysia";
+import { config } from "../config";
 import { loggerHelpers } from "../lib/observability/logger";
 
 interface RateLimitConfig {
   windowMs: number; // Time window in milliseconds
   maxRequests: number; // Maximum requests per window
   message?: string;
-  keyGenerator?: (request: Request) => string;
+  /** Namespace so separate limiters never share a bucket for the same client. */
+  scope: string;
+  /** Only apply the limiter when this returns true. */
+  appliesTo?: (request: Request) => boolean;
+  keyGenerator?: (request: Request, server: RequestIpResolver | null) => string;
 }
 
 interface RateLimitEntry {
   count: number;
   resetTime: number;
+}
+
+interface RequestIpResolver {
+  requestIP?: (request: Request) => { address?: string } | null;
 }
 
 // In-memory store for rate limiting (use Redis in production for distributed systems)
@@ -34,26 +43,58 @@ function startCleanupInterval() {
   }, 60000); // Clean up every minute
 }
 
-export const rateLimit = (config: RateLimitConfig) => {
+/**
+ * Resolve the client identity to rate limit on.
+ *
+ * X-Forwarded-For is attacker-controlled unless a reverse proxy overwrites it,
+ * so it is only consulted when TRUST_PROXY is enabled. Otherwise we fall back
+ * to the socket address, which a client cannot forge.
+ */
+export function resolveClientIdentifier(
+  request: Request,
+  server: RequestIpResolver | null,
+): string {
+  if (config.TRUST_PROXY) {
+    // X-Real-IP is preferred: our nginx sets it to $remote_addr, overwriting
+    // anything the client sent. X-Forwarded-For is *appended* to, so its
+    // leftmost entry is still whatever the client claimed.
+    const realIp = request.headers.get("x-real-ip")?.trim();
+    if (realIp) {
+      return realIp;
+    }
+
+    const forwarded = request.headers.get("x-forwarded-for");
+    const clientIp = forwarded?.split(",")[0]?.trim();
+    if (clientIp) {
+      return clientIp;
+    }
+  }
+
+  const socketAddress = server?.requestIP?.(request)?.address;
+  return socketAddress ?? "unknown";
+}
+
+export const rateLimit = (limitConfig: RateLimitConfig) => {
   startCleanupInterval();
 
   const {
     windowMs,
     maxRequests,
+    scope,
+    appliesTo,
     message = "Too many requests, please try again later",
-    keyGenerator = (request: Request) => {
-      // Default: use IP address
-      const headers = request.headers;
-      return (
-        headers.get("x-forwarded-for") ??
-        headers.get("x-real-ip") ??
-        "unknown"
-      );
-    },
-  } = config;
+    keyGenerator = resolveClientIdentifier,
+  } = limitConfig;
 
-  return new Elysia().onRequest(({ request, set }) => {
-    const key = keyGenerator(request);
+  return new Elysia().onRequest((context) => {
+    const { request, set } = context;
+
+    if (appliesTo && !appliesTo(request)) {
+      return;
+    }
+
+    const server = (context as { server?: RequestIpResolver | null }).server ?? null;
+    const key = `${scope}:${keyGenerator(request, server)}`;
     const now = Date.now();
 
     // Get or create rate limit entry
@@ -109,12 +150,43 @@ export const rateLimit = (config: RateLimitConfig) => {
   });
 };
 
+/** Credential endpoints worth protecting against online brute force. */
+const SENSITIVE_AUTH_PATHS = new Set([
+  "/api/auth/login",
+  "/api/auth/register",
+  "/api/auth/forgot-password",
+  "/api/auth/reset-password",
+  "/api/auth/change-password",
+]);
+
+export function isSensitiveAuthRequest(request: Request): boolean {
+  if (request.method !== "POST") {
+    return false;
+  }
+
+  try {
+    return SENSITIVE_AUTH_PATHS.has(new URL(request.url).pathname);
+  } catch {
+    return false;
+  }
+}
+
 // Pre-configured rate limiters for different endpoints
 export const rateLimiters = {
   // Moderate rate limiting for API endpoints
   api: rateLimit({
+    scope: "api",
     windowMs: 15 * 60 * 1000, // 15 minutes
     maxRequests: 1000, // 1000 requests per 15 minutes
     message: "Too many API requests, please try again later",
+  }),
+
+  // Strict limit for credential endpoints to blunt password guessing
+  auth: rateLimit({
+    scope: "auth",
+    windowMs: 15 * 60 * 1000,
+    maxRequests: 20,
+    appliesTo: isSensitiveAuthRequest,
+    message: "Too many authentication attempts, please try again later",
   }),
 };

--- a/backend/src/middleware/security-headers.ts
+++ b/backend/src/middleware/security-headers.ts
@@ -1,0 +1,52 @@
+// src/middleware/security-headers.ts
+import { Elysia } from "elysia";
+import { config } from "../config";
+
+const ONE_YEAR_SECONDS = 31536000;
+
+/**
+ * Baseline response hardening for every API response.
+ *
+ * The API only ever returns JSON, so it can use a maximally restrictive CSP
+ * and framing policy — nothing here is meant to be embedded or rendered.
+ */
+export function getSecurityHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "no-referrer",
+    "Cross-Origin-Resource-Policy": "same-site",
+    "Cross-Origin-Opener-Policy": "same-origin",
+    "Permissions-Policy": "camera=(), microphone=(), geolocation=(), payment=()",
+    "Content-Security-Policy": "default-src 'none'; frame-ancestors 'none'; base-uri 'none'",
+  };
+
+  if (config.NODE_ENV === "production") {
+    headers["Strict-Transport-Security"] =
+      `max-age=${ONE_YEAR_SECONDS}; includeSubDomains`;
+  }
+
+  return headers;
+}
+
+function isDocsPath(request: Request): boolean {
+  try {
+    const { pathname } = new URL(request.url);
+    return pathname.startsWith("/api/docs") || pathname.startsWith("/api/api/docs");
+  } catch {
+    return false;
+  }
+}
+
+export const securityHeadersMiddleware = new Elysia({ name: "security-headers" })
+  .onRequest(({ request, set }) => {
+    const headers = getSecurityHeaders();
+
+    // Swagger UI (development only) needs to load its own scripts and styles.
+    if (isDocsPath(request)) {
+      delete headers["Content-Security-Policy"];
+      delete headers["Cross-Origin-Resource-Policy"];
+    }
+
+    Object.assign(set.headers, headers);
+  });

--- a/backend/src/modules/auth/clerk-webhook.ts
+++ b/backend/src/modules/auth/clerk-webhook.ts
@@ -223,7 +223,6 @@ export const clerkWebhookHandler = (app: Elysia) =>
       try {
         event = verifyWebhookSignature(request, payload);
       } catch (error) {
-        console.error("VERIFY ERROR:", error);
         logger.warn({ error }, "Invalid Clerk webhook signature");
         context.set.status = 400;
         return {

--- a/backend/src/modules/billing/webhook-handler.ts
+++ b/backend/src/modules/billing/webhook-handler.ts
@@ -76,9 +76,6 @@ export const webhookHandler = new Elysia({ name: "webhookHandler" })
             hasRawBody: !!rawBodyText,
             rawBodyLength: rawBodyText?.length ?? 0,
             hasSignature: !!signature,
-            signature: signature ? signature.substring(0, 20) + "..." : "none",
-            rawBodyPreview:
-              rawBodyText ? rawBodyText.substring(0, 100) + "..." : "none",
           },
           "Received Stripe webhook request"
         );
@@ -140,7 +137,6 @@ export const webhookHandler = new Elysia({ name: "webhookHandler" })
             eventType: normalizedEvent.type,
             eventId: normalizedEvent.id,
             format: normalizedEvent.format,
-            payload: normalizedEvent,
           },
           `Processing Stripe webhook: ${normalizedEvent.type} (${normalizedEvent.format})`
         );

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -53,7 +53,6 @@ export const healthRoutes = new Elysia({ name: "health-routes" })
            version: "1.0.0",
            environment: config.NODE_ENV,
            database: "error",
-           error: error instanceof Error ? error.message : "Unknown error",
          };
        }
      },
@@ -86,7 +85,6 @@ export const healthRoutes = new Elysia({ name: "health-routes" })
         return {
           status: "not ready",
           reason: "database error",
-          error: error instanceof Error ? error.message : "Unknown error",
         };
       }
     },

--- a/backend/src/routes/metrics.ts
+++ b/backend/src/routes/metrics.ts
@@ -33,7 +33,17 @@ function isDiagnosticsAuthorized(request: Request): boolean {
 }
 
 export const metricsRoutes = new Elysia()
-  .get("/metrics", () => {
+  .get("/metrics", ({ request, set }) => {
+    // The registry exposes the full route inventory and traffic volumes.
+    // Require the diagnostics key whenever one is configured.
+    if (config.METRICS_API_KEY?.trim() && !isDiagnosticsAuthorized(request)) {
+      set.status = 403;
+      return {
+        code: "FORBIDDEN",
+        message: "Metrics access denied",
+      };
+    }
+
     const metrics = getMetricsRegistry();
     const prometheusOutput = metrics.exportPrometheus();
     return new Response(prometheusOutput, {

--- a/backend/tests/lib/session.test.ts
+++ b/backend/tests/lib/session.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { readSessionTokenFromRequest } from "../../src/lib/auth/session";
+
+describe("readSessionTokenFromRequest", () => {
+  it("reads a bearer token", () => {
+    const request = new Request("https://api.test/api/user/me", {
+      headers: { authorization: "Bearer sess-id.secret" },
+    });
+
+    expect(readSessionTokenFromRequest(request)).toBe("sess-id.secret");
+  });
+
+  it("ignores Clerk tokens presented as bearer credentials", () => {
+    const request = new Request("https://api.test/api/user/me", {
+      headers: { authorization: "Bearer sess_clerk123" },
+    });
+
+    expect(readSessionTokenFromRequest(request)).toBeNull();
+  });
+
+  it("reads the session cookie", () => {
+    const request = new Request("https://api.test/api/user/me", {
+      headers: { cookie: "mt_session=sess-id.secret; other=1" },
+    });
+
+    expect(readSessionTokenFromRequest(request)).toBe("sess-id.secret");
+  });
+
+  it("rejects a query-string token on ordinary API routes", () => {
+    const request = new Request("https://api.test/api/user/me?token=sess-id.secret");
+
+    expect(readSessionTokenFromRequest(request)).toBeNull();
+  });
+
+  it("accepts a query-string token on the SSE stream, which cannot set headers", () => {
+    const request = new Request("https://api.test/api/sync/events?token=sess-id.secret");
+
+    expect(readSessionTokenFromRequest(request)).toBe("sess-id.secret");
+  });
+});

--- a/backend/tests/middleware/rate-limit.test.ts
+++ b/backend/tests/middleware/rate-limit.test.ts
@@ -1,43 +1,143 @@
-import { describe, expect, it } from "vitest";
-import { rateLimit, rateLimiters } from "../../src/middleware/rate-limit";
+import { afterEach, describe, expect, it } from "vitest";
+import { Elysia } from "elysia";
+import {
+  isSensitiveAuthRequest,
+  rateLimit,
+  rateLimiters,
+  resolveClientIdentifier,
+} from "../../src/middleware/rate-limit";
+import { resetConfigCache, setConfigOverrides } from "../../src/config";
+
+function makeRequest(headers: Record<string, string> = {}, url = "https://api.test/api/ping") {
+  return new Request(url, { headers });
+}
+
+afterEach(() => {
+  resetConfigCache();
+});
 
 describe("rate-limit middleware", () => {
-  describe("rateLimit", () => {
-    it("should be a function", () => {
-      expect(typeof rateLimit).toBe("function");
+  describe("resolveClientIdentifier", () => {
+    it("ignores forwarded headers when the proxy is not trusted", () => {
+      setConfigOverrides({ TRUST_PROXY: false });
+
+      const identifier = resolveClientIdentifier(
+        makeRequest({ "x-forwarded-for": "1.2.3.4", "x-real-ip": "5.6.7.8" }),
+        { requestIP: () => ({ address: "10.0.0.9" }) },
+      );
+
+      expect(identifier).toBe("10.0.0.9");
     });
 
-    it("should return an Elysia instance", () => {
-      const middleware = rateLimit({
-        windowMs: 60000,
-        maxRequests: 100,
-      });
-      expect(middleware).toBeDefined();
-      expect(typeof middleware).toBe("object");
+    it("falls back to a shared bucket when the socket address is unavailable", () => {
+      setConfigOverrides({ TRUST_PROXY: false });
+
+      expect(
+        resolveClientIdentifier(makeRequest({ "x-forwarded-for": "1.2.3.4" }), null),
+      ).toBe("unknown");
     });
 
-    it("should accept custom message", () => {
-      const middleware = rateLimit({
-        windowMs: 60000,
-        maxRequests: 100,
-        message: "Custom rate limit message",
-      });
-      expect(middleware).toBeDefined();
+    it("prefers the proxy-overwritten X-Real-IP over the appendable X-Forwarded-For", () => {
+      setConfigOverrides({ TRUST_PROXY: true });
+
+      const identifier = resolveClientIdentifier(
+        makeRequest({ "x-forwarded-for": "1.2.3.4, 10.0.0.9", "x-real-ip": "10.0.0.9" }),
+        { requestIP: () => ({ address: "172.18.0.2" }) },
+      );
+
+      expect(identifier).toBe("10.0.0.9");
+    });
+  });
+
+  describe("isSensitiveAuthRequest", () => {
+    it("matches credential endpoints", () => {
+      expect(
+        isSensitiveAuthRequest(
+          new Request("https://api.test/api/auth/login", { method: "POST" }),
+        ),
+      ).toBe(true);
     });
 
-    it("should accept custom keyGenerator", () => {
-      const middleware = rateLimit({
-        windowMs: 60000,
-        maxRequests: 100,
-        keyGenerator: () => "custom-key",
-      });
-      expect(middleware).toBeDefined();
+    it("ignores unrelated routes and non-POST verbs", () => {
+      expect(
+        isSensitiveAuthRequest(
+          new Request("https://api.test/api/macros", { method: "POST" }),
+        ),
+      ).toBe(false);
+      expect(
+        isSensitiveAuthRequest(new Request("https://api.test/api/auth/login")),
+      ).toBe(false);
+    });
+  });
+
+  describe("enforcement", () => {
+    it("rejects a client once it exceeds the window budget", async () => {
+      setConfigOverrides({ TRUST_PROXY: true });
+
+      const app = new Elysia()
+        .use(
+          rateLimit({
+            scope: `test-${Math.random()}`,
+            windowMs: 60000,
+            maxRequests: 2,
+          }),
+        )
+        .get("/api/ping", () => ({ ok: true }));
+
+      const headers = { "x-real-ip": "203.0.113.10" };
+      expect((await app.handle(makeRequest(headers))).status).toBe(200);
+      expect((await app.handle(makeRequest(headers))).status).toBe(200);
+
+      const blocked = await app.handle(makeRequest(headers));
+      expect(blocked.status).toBe(429);
+      expect(blocked.headers.get("Retry-After")).toBeTruthy();
+    });
+
+    it("does not let a forged X-Forwarded-For reset the counter", async () => {
+      setConfigOverrides({ TRUST_PROXY: false });
+
+      const app = new Elysia()
+        .use(
+          rateLimit({
+            scope: `spoof-${Math.random()}`,
+            windowMs: 60000,
+            maxRequests: 1,
+          }),
+        )
+        .get("/api/ping", () => ({ ok: true }));
+
+      expect(
+        (await app.handle(makeRequest({ "x-forwarded-for": "1.1.1.1" }))).status,
+      ).toBe(200);
+      expect(
+        (await app.handle(makeRequest({ "x-forwarded-for": "2.2.2.2" }))).status,
+      ).toBe(429);
+    });
+
+    it("only applies a scoped limiter to the paths it targets", async () => {
+      setConfigOverrides({ TRUST_PROXY: true });
+
+      const app = new Elysia()
+        .use(
+          rateLimit({
+            scope: `scoped-${Math.random()}`,
+            windowMs: 60000,
+            maxRequests: 1,
+            appliesTo: isSensitiveAuthRequest,
+          }),
+        )
+        .get("/api/ping", () => ({ ok: true }));
+
+      const headers = { "x-real-ip": "203.0.113.11" };
+      expect((await app.handle(makeRequest(headers))).status).toBe(200);
+      expect((await app.handle(makeRequest(headers))).status).toBe(200);
     });
   });
 
   describe("rateLimiters", () => {
-    it("should have api rate limiter", () => {
+    it("exposes the api and auth limiters", () => {
       expect(rateLimiters.api).toBeDefined();
+      expect(rateLimiters.auth).toBeDefined();
     });
   });
 });

--- a/backend/tests/middleware/security-headers.test.ts
+++ b/backend/tests/middleware/security-headers.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Elysia } from "elysia";
+import { getSecurityHeaders, securityHeadersMiddleware } from "../../src/middleware/security-headers";
+import { resetConfigCache, setConfigOverrides } from "../../src/config";
+
+afterEach(() => {
+  resetConfigCache();
+});
+
+describe("security headers middleware", () => {
+  it("sets the baseline hardening headers on responses", async () => {
+    const app = new Elysia()
+      .use(securityHeadersMiddleware)
+      .get("/api/ping", () => ({ ok: true }));
+
+    const response = await app.handle(new Request("https://api.test/api/ping"));
+
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("X-Frame-Options")).toBe("DENY");
+    expect(response.headers.get("Referrer-Policy")).toBe("no-referrer");
+    expect(response.headers.get("Content-Security-Policy")).toContain("frame-ancestors 'none'");
+  });
+
+  it("relaxes CSP for the development docs UI only", async () => {
+    const app = new Elysia()
+      .use(securityHeadersMiddleware)
+      .get("/api/docs", () => "ui");
+
+    const response = await app.handle(new Request("https://api.test/api/docs"));
+
+    expect(response.headers.get("Content-Security-Policy")).toBeNull();
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+
+  it("only sends HSTS in production", () => {
+    setConfigOverrides({ NODE_ENV: "development" });
+    expect(getSecurityHeaders()["Strict-Transport-Security"]).toBeUndefined();
+
+    resetConfigCache();
+    setConfigOverrides({ NODE_ENV: "production" });
+    expect(getSecurityHeaders()["Strict-Transport-Security"]).toContain("max-age=31536000");
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,14 @@ services:
       EMAIL_MODE: ${EMAIL_MODE:-disabled}
       APP_URL: ${APP_URL:-http://localhost:5173}
       CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:5173}
-    ports:
-      - "3000:3000"
+      # The bundled nginx overwrites X-Real-IP, so per-client rate limiting can
+      # trust it. Set to false if the backend is ever exposed without a proxy.
+      TRUST_PROXY: ${TRUST_PROXY:-true}
+    # Not published to the host: the frontend proxies /api/ to this service on
+    # the compose network. Publishing it would let clients reach the backend
+    # directly and forge the proxy headers that TRUST_PROXY tells it to honour.
+    expose:
+      - "3000"
 
   frontend:
     image: ${FRONTEND_IMAGE:-ghcr.io/arogan178/macrotrackr-frontend:latest}

--- a/frontend/capacitor.config.ts
+++ b/frontend/capacitor.config.ts
@@ -13,6 +13,10 @@ const config: CapacitorConfig = {
     hostname,
     androidScheme: "https",
     cleartext: isLocalDev,
+    // Every entry here is a host the webview may navigate to, so keep it to
+    // the sign-in flows that actually need it. Analytics never navigates, and
+    // a wildcard over a large provider surface (e.g. *.cloudflare.com) turns
+    // any open redirect on that surface into a webview navigation.
     allowNavigation: [
       "*.clerk.com",
       "*.clerk.accounts.dev",
@@ -21,10 +25,8 @@ const config: CapacitorConfig = {
       "*.macrotrackr.com",
       "accounts.google.com",
       "*.google.com",
-      "*.google-analytics.com",
       "appleid.apple.com",
-      "*.cloudflare.com",
-      "*.challenges.cloudflare.com",
+      "challenges.cloudflare.com",
     ],
   },
   plugins: {

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,6 +5,25 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
+  # Don't advertise the nginx version in responses and error pages.
+  server_tokens off;
+
+  # Baseline security headers. `always` so they also apply to error responses.
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header X-Frame-Options "DENY" always;
+  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+  add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), interest-cohort=()" always;
+  add_header Cross-Origin-Opener-Policy "same-origin" always;
+
+  # HSTS is only meaningful over TLS; harmless on plain HTTP requests.
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+  # App scripts are bundled, so no inline script is permitted. The remote
+  # origins are the SDKs that load their own code at runtime (Clerk, PostHog,
+  # Stripe) and are only reachable in managed mode. 'unsafe-inline' styles are
+  # required by Tailwind and by Clerk's injected component styles.
+  add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com https://*.posthog.com https://js.stripe.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; connect-src 'self' https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://js.stripe.com https://*.clerk.accounts.dev https://*.clerk.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
+
   location /api/ {
     proxy_pass http://backend:3000;
     proxy_http_version 1.1;
@@ -14,23 +33,41 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
   }
 
+  # NOTE: an `add_header` in a location block discards every `add_header`
+  # inherited from the server block, so the security headers below must be
+  # repeated in each location that sets one of its own.
+
   location = /index.html {
     add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), interest-cohort=()" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com https://*.posthog.com https://js.stripe.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; connect-src 'self' https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://js.stripe.com https://*.clerk.accounts.dev https://*.clerk.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
     try_files $uri =404;
   }
 
   location = /service-worker.js {
     add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     try_files $uri =404;
   }
 
   location ^~ /assets/ {
     add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     try_files $uri =404;
   }
 
   location ~* \.(png|webp|ico|jpg|svg)$ {
     add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Content-Security-Policy "default-src 'none'; style-src 'unsafe-inline'; sandbox" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     try_files $uri =404;
   }
 

--- a/frontend/src/features/auth/utils/redirect.test.ts
+++ b/frontend/src/features/auth/utils/redirect.test.ts
@@ -38,6 +38,19 @@ describe("auth redirect helpers", () => {
     );
   });
 
+  it("rejects redirects that browsers would resolve off-origin", () => {
+    // Backslashes are normalized to slashes during URL parsing, so these are
+    // equivalent to "//evil.example".
+    expect(isSafeAppRedirect("/\\evil.example")).toBe(false);
+    expect(isSafeAppRedirect("/\\\\evil.example")).toBe(false);
+    expect(normalizeAuthRedirect("/\\evil.example")).toBe("/home");
+
+    // Control characters are stripped, so these collapse to "//evil.example".
+    expect(isSafeAppRedirect("/\t/evil.example")).toBe(false);
+    expect(isSafeAppRedirect("/\n/evil.example")).toBe(false);
+    expect(normalizeAuthRedirect("/\t/evil.example")).toBe("/home");
+  });
+
   it("marks profile setup redirects to skip sync", () => {
     expect(shouldBypassSyncForRedirect("/profile-setup")).toBe(true);
     expect(shouldBypassSyncForRedirect("/profile-setup?redirectTo=%2Fpricing")).toBe(

--- a/frontend/src/features/auth/utils/redirect.ts
+++ b/frontend/src/features/auth/utils/redirect.ts
@@ -49,6 +49,15 @@ export function buildRedirectFromLocation(location: {
   return query ? `${pathname}?${query}` : pathname;
 }
 
+// Browsers normalize backslashes to forward slashes in URLs, so "/\evil.com"
+// and "/\\evil.com" resolve off-origin exactly like "//evil.com".
+const BACKSLASH_PATTERN = /\\/u;
+
+// Tabs, newlines and other control characters are stripped during URL parsing,
+// which lets "/\tevil.com" or "java\nscript:" slip past a naive prefix check.
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001F\u007F]/u;
+
 export function isSafeAppRedirect(value: string | undefined): value is string {
   const candidate = normalizeCandidate(value);
 
@@ -56,6 +65,15 @@ export function isSafeAppRedirect(value: string | undefined): value is string {
     return false;
   }
 
+  if (
+    BACKSLASH_PATTERN.test(candidate) ||
+    CONTROL_CHARACTER_PATTERN.test(candidate)
+  ) {
+    return false;
+  }
+
+  // A single leading slash keeps the redirect on this origin; a second one
+  // (or a scheme) makes it protocol-relative and therefore off-site.
   return candidate.startsWith("/") && !candidate.startsWith("//");
 }
 


### PR DESCRIPTION
A hardening pass across the backend, frontend and deployment config. No feature changes; every item below is a fix for something that was exploitable, leaky, or missing.

## Backend

**Rate limiting was bypassable and did not cover credentials.** The limiter keyed directly on `X-Forwarded-For`, so any client could rotate the header per request for unlimited throughput, while direct connections all collapsed into a single `"unknown"` bucket. Key resolution now sits behind a new `TRUST_PROXY` setting; with it off the socket address is used, which cannot be forged.

> One subtlety worth reading closely: when `TRUST_PROXY` is on we prefer `X-Real-IP`, because our nginx **overwrites** it. `X-Forwarded-For` uses `$proxy_add_x_forwarded_for`, which *appends*, so its leftmost entry is still whatever the client claimed.

Also added a strict 20-per-15-min bucket for `login`, `register`, `forgot-password`, `reset-password` and `change-password`. These previously sat behind only the 1000-request global bucket, leaving room for online password guessing. Verified end to end: 20 × 401, then 429.

**Other backend fixes**

- **New `security-headers` middleware** — nosniff, frame-deny, referrer, permissions, COOP/CORP, HSTS in production, and a `default-src 'none'` CSP appropriate for a JSON API. Relaxed for the development-only Swagger UI.
- **Production 5xx responses echoed the raw error message**, which routinely carries SQL fragments and file paths. Redacted in production; stack details remain available off-prod.
- **`CORS_ORIGIN: "*"` combined with `credentials: true`** let any site read the API as the signed-in user. The wildcard is now honoured off-prod only.
- **Clerk `authorizedParties` was commented out**, so a session token minted for another Clerk frontend could be replayed against this API. Now populated from `APP_URL` and `CORS_ORIGIN`.
- **`/metrics` served the full registry unauthenticated** while `/metrics/queries` was gated. Now requires `METRICS_API_KEY` when one is set.
- **Session tokens were accepted from the query string on every route.** Query strings leak into proxy logs, browser history and `Referer`. Restricted to the SSE stream, the one endpoint that genuinely cannot set an `Authorization` header.
- Constant-time session secret comparison; passwords bounded at 72 bytes (bcrypt's effective limit, so the silently-ignored suffix and the wasted hashing work on attacker input both go away).
- Stripe webhook no longer logs the event payload or raw body preview; removed a `console.error` debug leftover from the Clerk handler; health probes no longer return internal error messages.

## Frontend

**Open-redirect bypass in `isSafeAppRedirect`.** It rejected `//` but not backslashes or control characters. Browsers normalize `/\evil.example` and strip the tab in `/\t/evil.example`, so both resolve off-origin exactly like `//evil.example`. This value reaches `navigate()` from the sign-in, SSO-callback, biometric and profile-setup paths. Tests added for both bypasses.

**Narrowed Capacitor `allowNavigation`.** Every entry is a host the native webview may navigate to, so `*.cloudflare.com` is replaced by `challenges.cloudflare.com` and the analytics wildcard is dropped, since analytics never navigates. `*.google.com` is deliberately kept — Google OAuth bounces between google.com hosts and breaking native sign-in is worse than the marginal tightening.

Checked and found clean: the three `dangerouslySetInnerHTML` sites are `JSON.stringify` over static JSON-LD; all `target="_blank"` links carry `rel="noreferrer"`; the service worker does no runtime caching of authenticated responses.

## Deployment

- **nginx had no security headers at all.** Added the full set plus a CSP allowing only the SDK origins that load their own code at runtime, and `server_tokens off`. Note that an `add_header` inside a `location` **discards every inherited one**, so the headers are repeated in the four locations that set their own `Cache-Control`. Config validated with `nginx -t`.
- **Backend port 3000 is no longer published** in compose. It is reachable from the frontend container, which proxies `/api`. Publishing it would let clients bypass nginx and forge the `X-Real-IP` that `TRUST_PROXY` tells the API to trust. README documents how to opt back out.
- Backend image drops from root to the `bun` user.

## Verification

- backend: typecheck + 392 tests (12 new)
- frontend: typecheck + 702 tests, lint clean
- `nginx -t` passes; security headers and the 429 confirmed against the running app

## Needs a human check before merge

- **Native Google sign-in on an APK**, for the `allowNavigation` narrowing — the one change I could not exercise.
- **A Docker Compose run**, since the backend is deliberately no longer on `localhost:3000`.

## Not included

Left deliberately: the nginx master still runs as root (moving to `nginx-unprivileged` means changing the listen port and the published `5173:80` contract — worth doing, but a separate call). The session token also still lives in `localStorage`, because the native Capacitor build is cross-origin and cannot rely on the HttpOnly cookie the web app already gets; removing it is an auth-transport change, not a hardening tweak.