### PR TITLE
feat(clerk): migrate to Clerk Core 3 (@clerk/react v6, @clerk/backend v3)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -42,7 +42,7 @@
     "@elysiajs/cors": "^1.4.1",
     "@elysiajs/swagger": "^1.3.1",
     "elysia": "^1.4.28",
-    "elysia-clerk": "^0.13.2",
+    "elysia-clerk": "^1.0.2",
     "pino": "^9.14.0",
     "pino-pretty": "^13.1.3",
     "resend": "^4.8.0",

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "@elysiajs/cors": "^1.4.1",
         "@elysiajs/swagger": "^1.3.1",
         "elysia": "^1.4.28",
-        "elysia-clerk": "^0.13.2",
+        "elysia-clerk": "^1.0.2",
         "pino": "^9.14.0",
         "pino-pretty": "^13.1.3",
         "resend": "^4.8.0",
@@ -54,7 +54,7 @@
         "@capacitor/splash-screen": "^8.0.2",
         "@capacitor/status-bar": "^8.0.3",
         "@capgo/capacitor-native-biometric": "^8.6.2",
-        "@clerk/clerk-react": "^5.61.9",
+        "@clerk/react": "^6.14.1",
         "@codetrix-studio/capacitor-google-auth": "^3.4.0-rc.4",
         "@remotion/player": "^4.0.448",
         "@tanstack/query-async-storage-persister": "^5.99.0",
@@ -81,7 +81,7 @@
       },
       "devDependencies": {
         "@capacitor/cli": "^8.4.2",
-        "@clerk/testing": "^1.14.5",
+        "@clerk/testing": "^2.2.22",
         "@eslint/js": "^9.39.4",
         "@playwright/test": "^1.59.1",
         "@stylistic/eslint-plugin": "^5.10.0",
@@ -140,9 +140,6 @@
         "workbox-precaching": "^7.4.0",
       },
     },
-  },
-  "overrides": {
-    "@clerk/shared": "^3.47.5",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
@@ -369,15 +366,13 @@
 
     "@capgo/capacitor-native-biometric": ["@capgo/capacitor-native-biometric@8.6.2", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-nLdiPRRs8vRLRgYgB1rZYYU5GPfGx+OoVsAicw+t1kVn0jaSluvWii+VMJFd33vPFK5qkhLqRsUGe4b0H7tndA=="],
 
-    "@clerk/backend": ["@clerk/backend@2.30.1", "", { "dependencies": { "@clerk/shared": "^3.44.0", "@clerk/types": "^4.101.14", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-GoxnJzVH0ycNPAGCDMfo3lPBFbo5nehpLSVFjgGEnzIRGGahBtAB8PQT7KM2zo58pD8apjb/+suhcB/WCiEasQ=="],
+    "@clerk/backend": ["@clerk/backend@3.16.4", "", { "dependencies": { "@clerk/shared": "^4.28.1", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-7A9YlBLesYgKFn4DcaCq64Ggezmbzx+xYdWsiQLrMQV+U4Bm9LtDdyaNirQ0SStSsZy6PzL8RHw5zMmmEt0zMA=="],
 
-    "@clerk/clerk-react": ["@clerk/clerk-react@5.61.9", "", { "dependencies": { "@clerk/shared": "^3.47.8", "tslib": "2.8.1" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-PRIodE1QVem/eV3wrjicJJiJ2pkGiZfI6t1vekE/+04cIHciXyvUezQ/468gGPl31xd7BiCNO3uKNM14TXEKZQ=="],
+    "@clerk/react": ["@clerk/react@6.14.1", "", { "dependencies": { "@clerk/shared": "^4.28.1", "tslib": "2.8.1" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" } }, "sha512-rSFJUyfOuMeySbmkTv+g4DpPp492lpgVKERtrzm0wo+PwnWXoGjVkrpWb6mZMKLQAvq2dU2LnKitljcbLDKUXA=="],
 
-    "@clerk/shared": ["@clerk/shared@3.47.8", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-cPURU1it/Eal4uXO9SOcHzw9sfE6Opi21W8EJUg+Ri80Q6JKtK8qBmyOpIyqgf09EanexhTzS4xrmYlvn2p7Iw=="],
+    "@clerk/shared": ["@clerk/shared@4.28.1", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-OhpUczN6t8CYJ+g8HdzN1O4SFC2EANOZRDwlE3rXxKu13eNtyFbLspt+d6Nhb/PmcThS/fIAKYnQQrwv0vIEwg=="],
 
-    "@clerk/testing": ["@clerk/testing@1.14.5", "", { "dependencies": { "@clerk/backend": "^2.33.2", "@clerk/shared": "^3.47.4", "@clerk/types": "^4.101.22", "dotenv": "17.2.2" }, "peerDependencies": { "@playwright/test": "^1", "cypress": "^13 || ^14" }, "optionalPeers": ["@playwright/test", "cypress"] }, "sha512-N5ZgBi204gOSmkNxj8go181T85FGIX0QaSDRx3T6tQhG5pGuYA/psRhgPjWUhzWx2zvxz+Y0uItdxq+HmCt8zg=="],
-
-    "@clerk/types": ["@clerk/types@4.101.22", "", { "dependencies": { "@clerk/shared": "^3.47.4" } }, "sha512-74hV9MMw9MzOOSuJNJMFP95XZ2jDfPS1v3pfALS3rSQa+h/lNREU+fLGArzYckEpqNtuF6xy0odg9YqF5BLNhA=="],
+    "@clerk/testing": ["@clerk/testing@2.2.22", "", { "dependencies": { "@clerk/backend": "^3.16.4", "@clerk/shared": "^4.28.1", "dotenv": "17.2.2" }, "peerDependencies": { "@playwright/test": "^1", "cypress": "^13 || ^14 || ^15" }, "optionalPeers": ["@playwright/test", "cypress"] }, "sha512-1SxfnCysXRtyxlEa4Qz1V5+QVOC93kjojumzm9iifoqqCKI1nRUurwt2vksYBhcO0/WWv21rE6dKiGNiTs8a6Q=="],
 
     "@codetrix-studio/capacitor-google-auth": ["@codetrix-studio/capacitor-google-auth@3.4.0-rc.4", "", { "peerDependencies": { "@capacitor/core": "^6.0.0" } }, "sha512-d548/xKrbMHHbzMYSWnlgZCLZYo2zzY7Onrh3x8ujojrb7atkNK68I6su5WgmaBt4E+R4gxBsWams4554aOFjA=="],
 
@@ -1221,7 +1216,7 @@
 
     "elysia": ["elysia@1.4.28", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-Vrx8sBnvq8squS/3yNBzR1jBXI+SgmnmvwawPjNuEHndUe5l1jV2Gp6JJ4ulDkEB8On6bWmmuyPpA+bq4t+WYg=="],
 
-    "elysia-clerk": ["elysia-clerk@0.13.2", "", { "dependencies": { "@clerk/backend": "^2.23.0", "@clerk/shared": "^3.35.0" }, "peerDependencies": { "elysia": "^1.2.0" } }, "sha512-f7C1+Fl7n1jEo8i8u3Is+fq+c63+EfAoqYEAFXBzDrcgE+vEBuRc9rDWeEjL9vBeRH1Uv/Jd9ku/08E7xoZ4vg=="],
+    "elysia-clerk": ["elysia-clerk@1.0.2", "", { "dependencies": { "@clerk/backend": "^3.12.0", "@clerk/shared": "^4.25.6" }, "peerDependencies": { "elysia": "^1.4.0" } }, "sha512-155aVP9ukofhKSCaPYsnbj/wBNs5Gg+yJdeM6NQI5xrhDVEm9LipKIlXTvHkitSkCs7GY469P+UKmcQJZ9xXFA=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -2303,8 +2298,6 @@
 
     "svix": ["svix@1.90.0", "", { "dependencies": { "standardwebhooks": "1.0.0", "uuid": "^10.0.0" } }, "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw=="],
 
-    "swr": ["swr@2.3.4", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg=="],
-
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
     "synckit": ["synckit@0.11.12", "", { "dependencies": { "@pkgr/core": "^0.2.9" } }, "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ=="],
@@ -2593,13 +2586,7 @@
 
     "@capacitor/cli/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
-    "@clerk/backend/@clerk/types": ["@clerk/types@4.101.14", "", { "dependencies": { "@clerk/shared": "^3.44.0" } }, "sha512-jl7DywmeaZx1IntgEXcjDZq2uyk+X/1yAZOjxOboeGTS0rNTiQNhv7xK8tFVjexsUAFrYlwC1AxhFuJiMDQjow=="],
-
-    "@clerk/shared/csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
-
-    "@clerk/shared/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
-
-    "@clerk/testing/@clerk/backend": ["@clerk/backend@2.33.2", "", { "dependencies": { "@clerk/shared": "^3.47.4", "@clerk/types": "^4.101.22", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-5nNPTdSLCTt7yVvMdd5CoEYZXVQhA9i0C50PxmAOjApYDIEfASedP9KXRb+YARiDrOSHQg0qFJhWUnujaG3hpw=="],
+    "@clerk/shared/@tanstack/query-core": ["@tanstack/query-core@5.101.4", "", {}, "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw=="],
 
     "@clerk/testing/dotenv": ["dotenv@17.2.2", "", {}, "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "@capacitor/splash-screen": "^8.0.2",
     "@capacitor/status-bar": "^8.0.3",
     "@capgo/capacitor-native-biometric": "^8.6.2",
-    "@clerk/clerk-react": "^5.61.9",
+    "@clerk/react": "^6.14.1",
     "@codetrix-studio/capacitor-google-auth": "^3.4.0-rc.4",
     "@remotion/player": "^4.0.448",
     "@tanstack/query-async-storage-persister": "^5.99.0",
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@capacitor/cli": "^8.4.2",
-    "@clerk/testing": "^1.14.5",
+    "@clerk/testing": "^2.2.22",
     "@eslint/js": "^9.39.4",
     "@playwright/test": "^1.59.1",
     "@stylistic/eslint-plugin": "^5.10.0",

--- a/frontend/src/components/auth/ClerkAppShell.tsx
+++ b/frontend/src/components/auth/ClerkAppShell.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from "react";
-import { ClerkProvider } from "@clerk/clerk-react";
+import { ClerkProvider } from "@clerk/react";
 
 import { clerkAppearance } from "@/lib/clerkAppearance";
 

--- a/frontend/src/components/auth/ClerkTokenSync.tsx
+++ b/frontend/src/components/auth/ClerkTokenSync.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from "react";
-import { useAuth, useSession } from "@clerk/clerk-react";
+import { useAuth, useSession } from "@clerk/react";
 
 import { setAuthToken, setGetToken } from "@/api/core";
 

--- a/frontend/src/features/auth/components/ClerkSignInForm.tsx
+++ b/frontend/src/features/auth/components/ClerkSignInForm.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Browser } from "@capacitor/browser";
-import { useClerk, useSignIn, useSignUp } from "@clerk/clerk-react";
+import { useClerk } from "@clerk/react";
+import { useSignIn, useSignUp } from "@clerk/react/legacy";
 import { useNavigate } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "motion/react";
 
@@ -309,6 +310,20 @@ export function ClerkSignInForm({
         case "needs_second_factor": {
           // 2FA required
           showNotification("Two-factor authentication required.", "info");
+
+          break;
+        }
+        case "needs_client_trust": {
+          // Device Trust: signing in from an unrecognised device, so Clerk
+          // wants a second factor before completing. Reached only when Device
+          // Trust is enabled on the instance. Completing the challenge needs a
+          // second-factor UI, which this form does not implement yet, so keep
+          // the user informed rather than dropping into the generic default.
+          logger.warn("Sign-in requires device trust verification");
+          showNotification(
+            "This device isn't recognised. Please verify it using another sign-in method.",
+            "info",
+          );
 
           break;
         }

--- a/frontend/src/features/auth/components/ClerkSignUpForm.tsx
+++ b/frontend/src/features/auth/components/ClerkSignUpForm.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { Browser } from "@capacitor/browser";
-import { useClerk, useSignIn, useSignUp } from "@clerk/clerk-react";
+import { useClerk } from "@clerk/react";
+import { useSignIn, useSignUp } from "@clerk/react/legacy";
 import { useNavigate } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "motion/react";
 

--- a/frontend/src/features/auth/components/ProfileCreationForm.tsx
+++ b/frontend/src/features/auth/components/ProfileCreationForm.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useAuth, useUser } from "@clerk/clerk-react";
+import { useAuth, useUser } from "@clerk/react";
 import { useNavigate } from "@tanstack/react-router";
 
 import { authApi } from "@/api/auth";

--- a/frontend/src/features/auth/hooks/useAuthReady.ts
+++ b/frontend/src/features/auth/hooks/useAuthReady.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from "react";
-import { useAuth, useClerk } from "@clerk/clerk-react";
+import { useAuth, useClerk } from "@clerk/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 

--- a/frontend/src/features/auth/pages/ProfileSetupPage.tsx
+++ b/frontend/src/features/auth/pages/ProfileSetupPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useAuth } from "@clerk/clerk-react";
+import { useAuth } from "@clerk/react";
 import { Navigate, useSearch } from "@tanstack/react-router";
 
 import LoadingSpinner from "@/components/ui/LoadingSpinner";

--- a/frontend/src/features/auth/pages/SsoCallbackPage.tsx
+++ b/frontend/src/features/auth/pages/SsoCallbackPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useAuth, useClerk, useUser } from "@clerk/clerk-react";
+import { useAuth, useClerk, useUser } from "@clerk/react";
 import { Navigate, useNavigate, useSearch } from "@tanstack/react-router";
 
 import { authApi } from "@/api/auth";
@@ -69,8 +69,8 @@ function ClerkSsoCallbackPage() {
 
     handleRedirectCallback({
       // We handle routing ourselves, so tell Clerk to stay on this page
-      afterSignInUrl: globalThis.location.href,
-      afterSignUpUrl: globalThis.location.href,
+      signInFallbackRedirectUrl: globalThis.location.href,
+      signUpFallbackRedirectUrl: globalThis.location.href,
     }).catch((error_) => {
       // Clerk may throw if the callback was already handled (e.g. page refresh)
       // This is safe to ignore if the user is already signed in

--- a/frontend/src/features/settings/components/ConnectedAccountsForm.tsx
+++ b/frontend/src/features/settings/components/ConnectedAccountsForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useReverification, useUser } from "@clerk/clerk-react";
+import { useReverification, useUser } from "@clerk/react";
 
 import CardContainer from "@/components/form/CardContainer";
 import Button from "@/components/ui/Button";

--- a/frontend/src/hooks/auth/useAuthQueries.clerk.ts
+++ b/frontend/src/hooks/auth/useAuthQueries.clerk.ts
@@ -1,4 +1,4 @@
-import { useAuth, useClerk, useUser as useClerkUser } from "@clerk/clerk-react";
+import { useAuth, useClerk, useUser as useClerkUser } from "@clerk/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 

--- a/frontend/src/hooks/auth/useAuthState.clerk.ts
+++ b/frontend/src/hooks/auth/useAuthState.clerk.ts
@@ -1,4 +1,4 @@
-import { useAuth } from "@clerk/clerk-react";
+import { useAuth } from "@clerk/react";
 
 export interface AppAuthState {
   isLoaded: boolean;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -152,7 +152,7 @@ export default defineConfig(({ command }) => {
             "vendor-query": ["@tanstack/react-query"],
             "vendor-charts": ["recharts"],
             "vendor-motion": ["motion"],
-            "vendor-clerk": ["@clerk/clerk-react"],
+            "vendor-clerk": ["@clerk/react"],
             "vendor-ui": [
               "lucide-react",
               "clsx",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,5 @@
   "devDependencies": {
     "@types/react-syntax-highlighter": "^15.5.13",
     "typescript": "^5.9.3"
-  },
-  "comment:overrides": "@clerk/shared 3.x is vulnerable at <=3.47.4 (GHSA-w24r-5266-9c3c, GHSA-vqx2-fgx2-5wq9). Pinned to the patched 3.x line: 4.x is a major bump that violates @clerk/clerk-react's own ^3.47.2 constraint.",
-  "overrides": {
-    "@clerk/shared": "^3.47.5"
   }
 }


### PR DESCRIPTION
Required before Device Trust can be enabled on the Clerk instance. The dashboard's Device Trust update introduces a `needs_client_trust` sign-in status and sets `@clerk/react` v6 and `@clerk/backend` v3 as version floors.

Generated with `bunx @clerk/upgrade --sdk=react --release=core-3`, then reviewed by hand.

## Packages

| package | from | to |
| --- | --- | --- |
| `@clerk/clerk-react` | ^5.61.9 | `@clerk/react` ^6.14.1 (renamed in Core 3) |
| `@clerk/testing` | ^1.14.5 | ^2.2.22 (for `@clerk/shared` 4.x) |
| `elysia-clerk` | ^0.13.2 | ^1.0.2 |

`elysia-clerk` 1.0.2 depends on `@clerk/backend ^3.12.0` and `@clerk/shared ^4.25.6`, resolving to 3.16.4 and 4.28.1.

The root `@clerk/shared` override is **dropped**. It pinned the patched 3.x line to close GHSA-w24r-5266-9c3c; 4.28.1 is past that range, so the override is now both unnecessary and wrong.

The backend calls no `@clerk/backend` APIs directly — only `clerkClient.users` via the plugin context — so the v3 consolidation of `verifyToken` / `verifySecret` / `verifyAccessToken` into a single `verify()` needs no changes here.

## Source

- Import sites moved to `@clerk/react` across 11 files.
- `useSignIn` and `useSignUp` now come from the **`@clerk/react/legacy`** entrypoint, where Core 3 moved them.
- `SsoCallbackPage`: `afterSignInUrl` / `afterSignUpUrl` are removed in Core 3, replaced by `signInFallbackRedirectUrl` / `signUpFallbackRedirectUrl`.
- `ClerkSignInForm`: handle the new `needs_client_trust` status. Without it, sign-in falls into the `default` branch and tells the user *"Sign-in status: needs_client_trust. Please try again or contact support"* — a dead end for every sign-in from an unrecognised device.

### Worth a look in review

**`vite.config.ts`** — the `vendor-clerk` manual chunk referenced the old package name. The upgrade tool does not scan config files, and left unchanged this would silently stop matching and fold Clerk into the main bundle with no error. Verified the 213 kB chunk still emits after the fix.

**The tool's scan reports false positives.** It flagged 37 "legacy redirect props", but most are our own `redirectUrl` / `redirectTo` variables in `features/auth/utils/redirect.ts`, plus unrelated colour props in `HabitForm`. Only the two `SsoCallbackPage` props were genuine. Those false positives were deliberately left alone.

## Do not enable Device Trust yet

This migration makes `needs_client_trust` **safe to receive**, but not completable. Finishing a device-trust challenge requires a second-factor UI, and this app has none — `prepareSecondFactor` / `attemptSecondFactor` appear nowhere, so the existing `needs_second_factor` branch is already a dead end for the same reason.

Enabling Device Trust in the dashboard would block every sign-in from an unrecognised device, including fresh APK installs, and **it cannot be reverted**. The second-factor UI is a feature and should land first.

The native Google path in `services/native/googleAuth.ts` fails closed rather than dead-ending, and already used the new `signInFallbackRedirectUrl` name.

## Verification

- backend: typecheck + 392 tests
- frontend: typecheck + 702 tests
- production build succeeds with the `vendor-clerk` chunk intact
- `bun audit --prod` unchanged at 32 / 1 critical; `@clerk/shared` 4.28.1 carries no advisories

Still worth a manual login click-through on web and an APK before merge, since this is the auth SDK.