### PR TITLE
feat(auth): add second-factor challenge for Device Trust and MFA

### DIFF
--- a/frontend/src/features/auth/components/ClerkSignInForm.deviceTrust.test.tsx
+++ b/frontend/src/features/auth/components/ClerkSignInForm.deviceTrust.test.tsx
@@ -1,0 +1,268 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ClerkSignInForm } from "@/features/auth/components/ClerkSignInForm";
+
+// Hoisted so the vi.mock factories below can reference them; vi.mock is
+// lifted above module-level consts.
+const {
+  signInCreate,
+  prepareSecondFactor,
+  attemptSecondFactor,
+  setActive,
+  navigate,
+  showNotification,
+  saveBiometricCredentials,
+} = vi.hoisted(() => ({
+  signInCreate: vi.fn(),
+  prepareSecondFactor: vi.fn(),
+  attemptSecondFactor: vi.fn(),
+  setActive: vi.fn(),
+  navigate: vi.fn(),
+  showNotification: vi.fn(),
+  saveBiometricCredentials: vi.fn(),
+}));
+
+// AnimatePresence mode="wait" defers mounting the next child until the exit
+// animation resolves, which never happens under jsdom. Render children
+// directly so the flow can be driven synchronously.
+vi.mock("motion/react", () => {
+  // Cache per tag: returning a fresh component from the proxy on every access
+  // would give React a new element type each render, remounting the subtree
+  // and wiping input state.
+  const components = new Map<string, React.FC<Record<string, unknown>>>();
+
+  return {
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+    motion: new Proxy({} as Record<string, React.FC>, {
+      get: (_target, tag: string) => {
+        const cached = components.get(tag);
+        if (cached) {
+          return cached;
+        }
+
+        const Component = ({
+          children,
+          ...props
+        }: React.PropsWithChildren<Record<string, unknown>>) => {
+          const {
+            initial: _initial,
+            animate: _animate,
+            exit: _exit,
+            transition: _transition,
+            ...domProps
+          } = props;
+
+          return <div {...domProps}>{children}</div>;
+        };
+        Component.displayName = `motion.${tag}`;
+        components.set(tag, Component);
+
+        return Component;
+      },
+    }),
+  };
+});
+
+vi.mock("@clerk/react", () => ({
+  useClerk: () => ({}),
+}));
+
+vi.mock("@clerk/react/legacy", () => ({
+  useSignIn: () => ({
+    isLoaded: true,
+    setActive,
+    signIn: {
+      create: signInCreate,
+      prepareSecondFactor,
+      attemptSecondFactor,
+    },
+  }),
+  useSignUp: () => ({ isLoaded: true, signUp: {} }),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigate,
+}));
+
+vi.mock("@/store/store", () => ({
+  useStore: () => ({ showNotification }),
+}));
+
+vi.mock("@/services/biometrics", () => ({
+  saveBiometricCredentials,
+}));
+
+vi.mock("@/services/native/googleAuth", () => ({
+  exchangeNativeGoogleTokenWithClerk: vi.fn(),
+  nativeGoogleSignIn: vi.fn(),
+}));
+
+vi.mock("@/services/native/platform", () => ({
+  isNativePlatform: () => false,
+}));
+
+vi.mock("@/features/auth/components/BiometricSignInButton", () => ({
+  BiometricSignInButton: () => null,
+}));
+
+vi.mock("@/features/auth/components/SocialAuthOptions", () => ({
+  SocialAuthOptions: ({
+    onContinueWithEmail,
+  }: {
+    onContinueWithEmail: () => void;
+  }) => (
+    <button type="button" onClick={onContinueWithEmail}>
+      Continue with email
+    </button>
+  ),
+}));
+
+vi.mock("@/features/auth/utils/linkIntent", () => ({
+  getAuthLinkIntent: () => null,
+}));
+
+async function signInWithPassword(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: /continue with email/i }));
+  await user.type(screen.getByLabelText(/email/i), "user@example.com");
+  await user.type(screen.getByLabelText(/password/i), "correct-horse");
+  await user.click(screen.getByRole("button", { name: /^sign in$/i }));
+}
+
+function renderForm() {
+  render(
+    <ClerkSignInForm
+      onSwitchToSignUp={vi.fn()}
+      onForgotPassword={vi.fn()}
+      redirectTo="/home"
+    />,
+  );
+}
+
+describe("ClerkSignInForm device trust", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prepareSecondFactor.mockResolvedValue({});
+  });
+
+  it("challenges for an email code when Clerk reports needs_client_trust", async () => {
+    const user = userEvent.setup();
+    signInCreate.mockResolvedValue({
+      status: "needs_client_trust",
+      supportedSecondFactors: [
+        {
+          strategy: "email_code",
+          emailAddressId: "idn_1",
+          safeIdentifier: "u****@example.com",
+        },
+      ],
+    });
+
+    renderForm();
+    await signInWithPassword(user);
+
+    await waitFor(() => {
+      expect(prepareSecondFactor).toHaveBeenCalledWith({
+        strategy: "email_code",
+        emailAddressId: "idn_1",
+      });
+    });
+
+    expect(await screen.findByText("Verify this device")).toBeInTheDocument();
+    expect(screen.getByText(/u\*\*\*\*@example\.com/)).toBeInTheDocument();
+  });
+
+  it("completes the sign-in once the code verifies", async () => {
+    const user = userEvent.setup();
+    signInCreate.mockResolvedValue({
+      status: "needs_client_trust",
+      supportedSecondFactors: [{ strategy: "email_code" }],
+    });
+    attemptSecondFactor.mockResolvedValue({
+      status: "complete",
+      createdSessionId: "sess_abc",
+    });
+
+    renderForm();
+    await signInWithPassword(user);
+
+    await screen.findByText("Verify this device");
+    await user.type(screen.getByLabelText(/verification code/i), "123456");
+    await user.click(screen.getByRole("button", { name: "Verify" }));
+
+    await waitFor(() => {
+      expect(attemptSecondFactor).toHaveBeenCalledWith({
+        strategy: "email_code",
+        code: "123456",
+      });
+    });
+
+    await waitFor(() => {
+      expect(setActive).toHaveBeenCalledWith({ session: "sess_abc" });
+    });
+    expect(navigate).toHaveBeenCalledWith({
+      to: "/auth-ready",
+      search: { redirectTo: "/home" },
+    });
+  });
+
+  it("keeps the user on the challenge and explains a rejected code", async () => {
+    const user = userEvent.setup();
+    signInCreate.mockResolvedValue({
+      status: "needs_client_trust",
+      supportedSecondFactors: [{ strategy: "email_code" }],
+    });
+    attemptSecondFactor.mockRejectedValue({
+      errors: [{ code: "verification_expired", message: "expired" }],
+    });
+
+    renderForm();
+    await signInWithPassword(user);
+
+    await screen.findByText("Verify this device");
+    await user.type(screen.getByLabelText(/verification code/i), "000000");
+    await user.click(screen.getByRole("button", { name: "Verify" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "That code has expired. Request a new one.",
+    );
+    expect(setActive).not.toHaveBeenCalled();
+  });
+
+  it("uses the same challenge for MFA, preferring the authenticator app", async () => {
+    const user = userEvent.setup();
+    signInCreate.mockResolvedValue({
+      status: "needs_second_factor",
+      supportedSecondFactors: [
+        { strategy: "email_code" },
+        { strategy: "totp" },
+      ],
+    });
+
+    renderForm();
+    await signInWithPassword(user);
+
+    expect(
+      await screen.findByText("Two-factor authentication"),
+    ).toBeInTheDocument();
+    // TOTP needs no delivery, so nothing should have been sent.
+    expect(prepareSecondFactor).not.toHaveBeenCalled();
+  });
+
+  it("still completes normally when no second factor is required", async () => {
+    const user = userEvent.setup();
+    signInCreate.mockResolvedValue({
+      status: "complete",
+      createdSessionId: "sess_direct",
+    });
+
+    renderForm();
+    await signInWithPassword(user);
+
+    await waitFor(() => {
+      expect(setActive).toHaveBeenCalledWith({ session: "sess_direct" });
+    });
+    expect(prepareSecondFactor).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/auth/components/ClerkSignInForm.tsx
+++ b/frontend/src/features/auth/components/ClerkSignInForm.tsx
@@ -8,6 +8,7 @@ import { AnimatePresence, motion } from "motion/react";
 import TextField from "@/components/form/TextField";
 import Button from "@/components/ui/Button";
 import { BiometricSignInButton } from "@/features/auth/components/BiometricSignInButton";
+import { SecondFactorChallenge } from "@/features/auth/components/SecondFactorChallenge";
 import {
   SocialAuthOptions,
   type SocialAuthStrategy,
@@ -18,6 +19,13 @@ import {
   buildSocialAuthRedirectUrls,
   normalizeAuthRedirect,
 } from "@/features/auth/utils/redirect";
+import {
+  buildPrepareParams,
+  parseSecondFactors,
+  type SecondFactorOption,
+  type SecondFactorStrategy,
+  selectPreferredSecondFactor,
+} from "@/features/auth/utils/secondFactor";
 import { resolveSocialAuthError } from "@/features/auth/utils/socialAuth";
 import { logger } from "@/lib/logger";
 import { saveBiometricCredentials } from "@/services/biometrics";
@@ -53,6 +61,42 @@ function getStrategies(
     .filter((strategy): strategy is string => strategy !== undefined);
 }
 
+/**
+ * Clerk reports a wrong or expired code as a 422 with an `errors` array. Map
+ * the common cases to something actionable, since the raw message is terse.
+ */
+function resolveSecondFactorErrorMessage(
+  error: unknown,
+  strategy: SecondFactorStrategy,
+): string {
+  const fallback =
+    strategy === "backup_code"
+      ? "That backup code isn't valid. Try another one."
+      : "That code isn't valid. Please check it and try again.";
+
+  if (!error || typeof error !== "object") {
+    return fallback;
+  }
+
+  const clerkErrors = (error as { errors?: Array<{ code?: string; message?: string }> })
+    .errors;
+  const first = clerkErrors?.[0];
+
+  if (!first) {
+    return fallback;
+  }
+
+  if (first.code === "verification_expired") {
+    return "That code has expired. Request a new one.";
+  }
+
+  if (first.code === "too_many_requests") {
+    return "Too many attempts. Please wait a moment before trying again.";
+  }
+
+  return first.message ?? fallback;
+}
+
 export function ClerkSignInForm({
   onSwitchToSignUp,
   onForgotPassword,
@@ -71,12 +115,181 @@ export function ClerkSignInForm({
   const [isEmailMode, setIsEmailMode] = useState(false);
   const [showLinkIntentBanner, setShowLinkIntentBanner] = useState(false);
 
+  // Second-factor challenge state, used for both MFA and Device Trust.
+  const [secondFactorOptions, setSecondFactorOptions] = useState<
+    SecondFactorOption[]
+  >([]);
+  const [activeSecondFactor, setActiveSecondFactor] =
+    useState<SecondFactorOption | null>(null);
+  const [isDeviceTrustChallenge, setIsDeviceTrustChallenge] = useState(false);
+  const [secondFactorCode, setSecondFactorCode] = useState("");
+  const [secondFactorError, setSecondFactorError] = useState<string | undefined>(
+    undefined,
+  );
+  const [isVerifyingSecondFactor, setIsVerifyingSecondFactor] = useState(false);
+  const [isResendingSecondFactor, setIsResendingSecondFactor] = useState(false);
+
   const showPasswordField = useMemo(() => email.trim().length > 0, [email]);
   const normalizedRedirect = normalizeAuthRedirect(redirectTo);
 
   useEffect(() => {
     setShowLinkIntentBanner(getAuthLinkIntent() !== null);
   }, []);
+
+  /**
+   * Shared completion path. Reached either straight from a password sign-in or
+   * after a second factor clears, so both routes save biometrics and land on
+   * /auth-ready identically.
+   */
+  const completeSignIn = async (createdSessionId: string | null) => {
+    if (!createdSessionId) {
+      logger.error("No session ID available despite complete sign-in status");
+      showNotification(
+        "Sign-in completed but session could not be created. Please try again.",
+        "error",
+      );
+
+      return;
+    }
+
+    await setActive({ session: createdSessionId });
+    await saveBiometricCredentials(email.trim().toLowerCase(), password);
+    showNotification("Signed in successfully!", "success");
+    navigate({
+      to: "/auth-ready",
+      search: { redirectTo: normalizedRedirect },
+    });
+  };
+
+  const resetSecondFactor = () => {
+    setSecondFactorOptions([]);
+    setActiveSecondFactor(null);
+    setIsDeviceTrustChallenge(false);
+    setSecondFactorCode("");
+    setSecondFactorError(undefined);
+  };
+
+  /**
+   * Dispatch the code (when the strategy needs one) and show the challenge.
+   * Shared by the initial transition and by switching strategy mid-challenge.
+   */
+  const prepareAndShowSecondFactor = async (option: SecondFactorOption) => {
+    const prepareParameters = buildPrepareParams(option);
+
+    if (prepareParameters) {
+      await signIn.prepareSecondFactor(prepareParameters);
+    }
+
+    setActiveSecondFactor(option);
+    setSecondFactorCode("");
+    setSecondFactorError(undefined);
+  };
+
+  const beginSecondFactor = async (
+    supportedSecondFactors: unknown[] | null | undefined,
+    isDeviceTrust: boolean,
+  ) => {
+    const options = parseSecondFactors(supportedSecondFactors);
+    const preferred = selectPreferredSecondFactor(options);
+
+    if (!preferred) {
+      logger.error("Sign-in needs a second factor but none are supported", {
+        isDeviceTrust,
+      });
+      showNotification(
+        "This account needs additional verification, but no verification method is available. Please contact support.",
+        "error",
+      );
+
+      return;
+    }
+
+    setSecondFactorOptions(options);
+    setIsDeviceTrustChallenge(isDeviceTrust);
+
+    try {
+      await prepareAndShowSecondFactor(preferred);
+    } catch (error) {
+      logger.error("Failed to start second factor verification:", error);
+      showNotification(
+        "We couldn't send a verification code. Please try again.",
+        "error",
+      );
+      resetSecondFactor();
+    }
+  };
+
+  const handleSecondFactorSubmit = async () => {
+    if (!activeSecondFactor || !isLoaded) {
+      return;
+    }
+
+    setIsVerifyingSecondFactor(true);
+    setSecondFactorError(undefined);
+
+    try {
+      const result = await signIn.attemptSecondFactor({
+        strategy: activeSecondFactor.strategy,
+        code: secondFactorCode.trim(),
+      } as Parameters<typeof signIn.attemptSecondFactor>[0]);
+
+      if (result.status === "complete") {
+        resetSecondFactor();
+        await completeSignIn(result.createdSessionId);
+
+        return;
+      }
+
+      logger.warn("Unexpected status after second factor:", result.status);
+      setSecondFactorError(
+        "That didn't complete the sign-in. Please try again.",
+      );
+    } catch (error) {
+      logger.error("Second factor verification failed:", error);
+      setSecondFactorError(
+        resolveSecondFactorErrorMessage(error, activeSecondFactor.strategy),
+      );
+    } finally {
+      setIsVerifyingSecondFactor(false);
+    }
+  };
+
+  const handleSecondFactorResend = async () => {
+    if (!activeSecondFactor) {
+      return;
+    }
+
+    setIsResendingSecondFactor(true);
+
+    try {
+      await prepareAndShowSecondFactor(activeSecondFactor);
+      showNotification("A new code is on its way.", "success");
+    } catch (error) {
+      logger.error("Failed to resend verification code:", error);
+      showNotification(
+        "We couldn't resend the code. Please try again.",
+        "error",
+      );
+    } finally {
+      setIsResendingSecondFactor(false);
+    }
+  };
+
+  const handleSelectSecondFactor = async (option: SecondFactorOption) => {
+    setIsResendingSecondFactor(true);
+
+    try {
+      await prepareAndShowSecondFactor(option);
+    } catch (error) {
+      logger.error("Failed to switch verification method:", error);
+      showNotification(
+        "We couldn't switch verification method. Please try again.",
+        "error",
+      );
+    } finally {
+      setIsResendingSecondFactor(false);
+    }
+  };
 
   // Handle social sign-in
   // We intentionally start OAuth via the sign-up resource because the callback
@@ -247,26 +460,7 @@ export function ClerkSignInForm({
 
       switch (result.status) {
         case "complete": {
-          // Sign-in complete, set session and redirect to auth-ready
-          // AuthReadyPage will set the token and then redirect to the intended destination
-          if (!result.createdSessionId) {
-            logger.error(
-              "No session ID available despite complete sign-in status",
-            );
-            showNotification(
-              "Sign-in completed but session could not be created. Please try again.",
-              "error",
-            );
-
-            return;
-          }
-          await setActive({ session: result.createdSessionId });
-          await saveBiometricCredentials(email.trim().toLowerCase(), password);
-          showNotification("Signed in successfully!", "success");
-          navigate({
-            to: "/auth-ready",
-            search: { redirectTo: normalizedRedirect },
-          });
+          await completeSignIn(result.createdSessionId);
 
           break;
         }
@@ -308,22 +502,16 @@ export function ClerkSignInForm({
           break;
         }
         case "needs_second_factor": {
-          // 2FA required
-          showNotification("Two-factor authentication required.", "info");
+          // The account has MFA enabled. MFA takes precedence over Device
+          // Trust, so this and needs_client_trust are mutually exclusive.
+          await beginSecondFactor(result.supportedSecondFactors, false);
 
           break;
         }
         case "needs_client_trust": {
-          // Device Trust: signing in from an unrecognised device, so Clerk
-          // wants a second factor before completing. Reached only when Device
-          // Trust is enabled on the instance. Completing the challenge needs a
-          // second-factor UI, which this form does not implement yet, so keep
-          // the user informed rather than dropping into the generic default.
-          logger.warn("Sign-in requires device trust verification");
-          showNotification(
-            "This device isn't recognised. Please verify it using another sign-in method.",
-            "info",
-          );
+          // Device Trust: no MFA on the account, but this device is new, so
+          // Clerk wants an email or SMS code before completing the sign-in.
+          await beginSecondFactor(result.supportedSecondFactors, true);
 
           break;
         }
@@ -422,7 +610,22 @@ export function ClerkSignInForm({
       )}
 
       <AnimatePresence mode="wait" initial={false}>
-        {isEmailMode ? (
+        {activeSecondFactor ? (
+          <SecondFactorChallenge
+            option={activeSecondFactor}
+            options={secondFactorOptions}
+            isDeviceTrust={isDeviceTrustChallenge}
+            code={secondFactorCode}
+            onCodeChange={setSecondFactorCode}
+            onSubmit={handleSecondFactorSubmit}
+            onResend={handleSecondFactorResend}
+            onSelectStrategy={handleSelectSecondFactor}
+            onCancel={resetSecondFactor}
+            isVerifying={isVerifyingSecondFactor}
+            isResending={isResendingSecondFactor}
+            error={secondFactorError}
+          />
+        ) : isEmailMode ? (
           <motion.div
             key="email-sign-in"
             initial={{ opacity: 0, y: 10 }}

--- a/frontend/src/features/auth/components/SecondFactorChallenge.test.tsx
+++ b/frontend/src/features/auth/components/SecondFactorChallenge.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { SecondFactorChallenge } from "@/features/auth/components/SecondFactorChallenge";
+import type { SecondFactorOption } from "@/features/auth/utils/secondFactor";
+
+const emailFactor: SecondFactorOption = {
+  strategy: "email_code",
+  emailAddressId: "idn_1",
+  safeIdentifier: "j****@example.com",
+};
+
+const totpFactor: SecondFactorOption = { strategy: "totp" };
+const backupFactor: SecondFactorOption = { strategy: "backup_code" };
+
+function renderChallenge(overrides: Partial<Parameters<typeof SecondFactorChallenge>[0]> = {}) {
+  const props = {
+    option: emailFactor,
+    options: [emailFactor],
+    isDeviceTrust: true,
+    code: "",
+    onCodeChange: vi.fn(),
+    onSubmit: vi.fn(),
+    onResend: vi.fn(),
+    onSelectStrategy: vi.fn(),
+    onCancel: vi.fn(),
+    isVerifying: false,
+    isResending: false,
+    ...overrides,
+  };
+
+  render(<SecondFactorChallenge {...props} />);
+
+  return props;
+}
+
+describe("SecondFactorChallenge", () => {
+  it("frames the challenge as device verification and names the destination", () => {
+    renderChallenge();
+
+    expect(screen.getByText("Verify this device")).toBeInTheDocument();
+    expect(screen.getByText(/j\*\*\*\*@example\.com/)).toBeInTheDocument();
+  });
+
+  it("submits the entered code", async () => {
+    const user = userEvent.setup();
+    const props = renderChallenge({ code: "123456" });
+
+    await user.click(screen.getByRole("button", { name: "Verify" }));
+
+    expect(props.onSubmit).toHaveBeenCalledOnce();
+  });
+
+  it("blocks submission until a code is entered", () => {
+    renderChallenge({ code: "   " });
+
+    expect(screen.getByRole("button", { name: "Verify" })).toBeDisabled();
+  });
+
+  it("offers a resend for delivered codes but not for TOTP", () => {
+    const { unmount } = render(
+      <SecondFactorChallenge
+        option={emailFactor}
+        options={[emailFactor]}
+        isDeviceTrust
+        code=""
+        onCodeChange={vi.fn()}
+        onSubmit={vi.fn()}
+        onResend={vi.fn()}
+        onSelectStrategy={vi.fn()}
+        onCancel={vi.fn()}
+        isVerifying={false}
+        isResending={false}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Resend code" })).toBeInTheDocument();
+    unmount();
+
+    renderChallenge({ option: totpFactor, options: [totpFactor] });
+    expect(screen.queryByRole("button", { name: "Resend code" })).not.toBeInTheDocument();
+    expect(screen.getByText("Two-factor authentication")).toBeInTheDocument();
+  });
+
+  it("lets the user switch to another available factor", async () => {
+    const user = userEvent.setup();
+    const props = renderChallenge({
+      option: totpFactor,
+      options: [totpFactor, backupFactor],
+      isDeviceTrust: false,
+    });
+
+    await user.click(screen.getByRole("button", { name: "Use a backup code" }));
+
+    expect(props.onSelectStrategy).toHaveBeenCalledWith(backupFactor);
+  });
+
+  it("does not offer the factor already in use as an alternative", () => {
+    renderChallenge({ option: totpFactor, options: [totpFactor] });
+
+    expect(screen.queryByText("Try another way")).not.toBeInTheDocument();
+  });
+
+  it("surfaces a verification error to assistive tech", () => {
+    renderChallenge({ error: "That code has expired. Request a new one." });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "That code has expired. Request a new one.",
+    );
+  });
+
+  it("can be abandoned", async () => {
+    const user = userEvent.setup();
+    const props = renderChallenge();
+
+    await user.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(props.onCancel).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/features/auth/components/SecondFactorChallenge.tsx
+++ b/frontend/src/features/auth/components/SecondFactorChallenge.tsx
@@ -1,0 +1,147 @@
+import { useMemo } from "react";
+import { motion } from "motion/react";
+
+import TextField from "@/components/form/TextField";
+import Button from "@/components/ui/Button";
+import {
+  describeAlternativeStrategy,
+  describeSecondFactor,
+  isNumericCode,
+  type SecondFactorOption,
+} from "@/features/auth/utils/secondFactor";
+
+interface SecondFactorChallengeProps {
+  /** The factor currently being challenged. */
+  option: SecondFactorOption;
+  /** Every factor Clerk offered, so the user can switch method. */
+  options: readonly SecondFactorOption[];
+  /**
+   * True when this came from `needs_client_trust` rather than `needs_second_factor`,
+   * which only changes the wording — the API calls are identical.
+   */
+  isDeviceTrust: boolean;
+  code: string;
+  onCodeChange: (code: string) => void;
+  onSubmit: () => void;
+  onResend: () => void;
+  onSelectStrategy: (option: SecondFactorOption) => void;
+  onCancel: () => void;
+  isVerifying: boolean;
+  isResending: boolean;
+  error?: string;
+}
+
+export function SecondFactorChallenge({
+  option,
+  options,
+  isDeviceTrust,
+  code,
+  onCodeChange,
+  onSubmit,
+  onResend,
+  onSelectStrategy,
+  onCancel,
+  isVerifying,
+  isResending,
+  error,
+}: SecondFactorChallengeProps) {
+  const copy = useMemo(
+    () => describeSecondFactor(option, isDeviceTrust),
+    [option, isDeviceTrust],
+  );
+
+  const alternatives = useMemo(
+    () => options.filter((candidate) => candidate.strategy !== option.strategy),
+    [options, option.strategy],
+  );
+
+  const numeric = isNumericCode(option.strategy);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    onSubmit();
+  };
+
+  return (
+    <motion.div
+      key="second-factor"
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -8 }}
+      transition={{ duration: 0.22, ease: "easeOut" }}
+    >
+      <div className="mb-5 flex items-center justify-between">
+        <p className="text-xs font-semibold tracking-[0.18em] text-muted uppercase">
+          {copy.title}
+        </p>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="inline-flex min-h-11 items-center rounded-md px-3 py-2 text-sm text-muted transition-colors duration-200 hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface focus-visible:outline-none"
+        >
+          Back
+        </button>
+      </div>
+
+      <p className="mb-4 text-sm text-muted">{copy.description}</p>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <TextField
+          label={copy.inputLabel}
+          value={code}
+          onChange={onCodeChange}
+          required
+          placeholder={numeric ? "123456" : "xxxxx-xxxxx"}
+          name="second-factor-code"
+          autoComplete="one-time-code"
+        />
+
+        {error ? (
+          <p role="alert" className="text-sm text-danger">
+            {error}
+          </p>
+        ) : null}
+
+        <Button
+          type="submit"
+          className="w-full"
+          disabled={isVerifying || code.trim().length === 0}
+        >
+          {isVerifying ? "Verifying..." : "Verify"}
+        </Button>
+      </form>
+
+      {copy.resendLabel ? (
+        <button
+          type="button"
+          onClick={onResend}
+          disabled={isResending}
+          className="mt-4 inline-flex min-h-11 items-center rounded-md px-1 py-2 text-sm text-muted transition-colors duration-200 hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface focus-visible:outline-none disabled:opacity-60"
+        >
+          {isResending ? "Sending..." : copy.resendLabel}
+        </button>
+      ) : null}
+
+      {alternatives.length > 0 ? (
+        <div className="mt-5 border-t border-border/60 pt-4">
+          <p className="mb-2 text-xs font-semibold tracking-[0.18em] text-muted uppercase">
+            Try another way
+          </p>
+          <div className="flex flex-col items-start gap-1">
+            {alternatives.map((alternative) => (
+              <button
+                key={alternative.strategy}
+                type="button"
+                onClick={() => onSelectStrategy(alternative)}
+                disabled={isVerifying || isResending}
+                className="inline-flex min-h-11 items-center rounded-md px-1 py-2 text-sm text-muted transition-colors duration-200 hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface focus-visible:outline-none disabled:opacity-60"
+              >
+                {describeAlternativeStrategy(alternative.strategy)}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </motion.div>
+  );
+}

--- a/frontend/src/features/auth/utils/secondFactor.test.ts
+++ b/frontend/src/features/auth/utils/secondFactor.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPrepareParams,
+  describeSecondFactor,
+  isNumericCode,
+  parseSecondFactors,
+  requiresCodeDelivery,
+  selectPreferredSecondFactor,
+} from "./secondFactor";
+
+describe("parseSecondFactors", () => {
+  it("keeps supported strategies and their identifiers", () => {
+    const parsed = parseSecondFactors([
+      {
+        strategy: "email_code",
+        emailAddressId: "idn_123",
+        safeIdentifier: "j****@example.com",
+      },
+      { strategy: "phone_code", phoneNumberId: "idn_456", safeIdentifier: "+1****789" },
+    ]);
+
+    expect(parsed).toEqual([
+      {
+        strategy: "email_code",
+        emailAddressId: "idn_123",
+        phoneNumberId: undefined,
+        safeIdentifier: "j****@example.com",
+      },
+      {
+        strategy: "phone_code",
+        emailAddressId: undefined,
+        phoneNumberId: "idn_456",
+        safeIdentifier: "+1****789",
+      },
+    ]);
+  });
+
+  it("drops unknown strategies rather than offering a dead end", () => {
+    const parsed = parseSecondFactors([
+      { strategy: "email_code" },
+      { strategy: "some_future_strategy" },
+      { notAFactor: true },
+      null,
+      "nonsense",
+    ]);
+
+    expect(parsed.map((option) => option.strategy)).toEqual(["email_code"]);
+  });
+
+  it("de-duplicates repeated strategies", () => {
+    const parsed = parseSecondFactors([
+      { strategy: "email_code", emailAddressId: "a" },
+      { strategy: "email_code", emailAddressId: "b" },
+    ]);
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.emailAddressId).toBe("a");
+  });
+
+  it("handles missing input", () => {
+    expect(parseSecondFactors(null)).toEqual([]);
+    expect(parseSecondFactors(undefined)).toEqual([]);
+    expect(parseSecondFactors([])).toEqual([]);
+  });
+});
+
+describe("selectPreferredSecondFactor", () => {
+  it("prefers TOTP, which needs no delivery round trip", () => {
+    const selected = selectPreferredSecondFactor([
+      { strategy: "backup_code" },
+      { strategy: "email_code" },
+      { strategy: "totp" },
+    ]);
+
+    expect(selected?.strategy).toBe("totp");
+  });
+
+  it("prefers phone over email when both are offered", () => {
+    const selected = selectPreferredSecondFactor([
+      { strategy: "email_code" },
+      { strategy: "phone_code" },
+    ]);
+
+    expect(selected?.strategy).toBe("phone_code");
+  });
+
+  it("leaves backup codes as the last resort", () => {
+    const selected = selectPreferredSecondFactor([{ strategy: "backup_code" }]);
+
+    expect(selected?.strategy).toBe("backup_code");
+  });
+
+  it("returns undefined when nothing is available", () => {
+    expect(selectPreferredSecondFactor([])).toBeUndefined();
+  });
+});
+
+describe("requiresCodeDelivery", () => {
+  it("is true only for strategies Clerk has to send", () => {
+    expect(requiresCodeDelivery("email_code")).toBe(true);
+    expect(requiresCodeDelivery("phone_code")).toBe(true);
+    expect(requiresCodeDelivery("totp")).toBe(false);
+    expect(requiresCodeDelivery("backup_code")).toBe(false);
+  });
+});
+
+describe("buildPrepareParams", () => {
+  it("passes the address id through when Clerk supplied one", () => {
+    expect(
+      buildPrepareParams({ strategy: "email_code", emailAddressId: "idn_1" }),
+    ).toEqual({ strategy: "email_code", emailAddressId: "idn_1" });
+
+    expect(
+      buildPrepareParams({ strategy: "phone_code", phoneNumberId: "idn_2" }),
+    ).toEqual({ strategy: "phone_code", phoneNumberId: "idn_2" });
+  });
+
+  it("omits the id when absent so Clerk picks the default destination", () => {
+    expect(buildPrepareParams({ strategy: "email_code" })).toEqual({
+      strategy: "email_code",
+    });
+  });
+
+  it("returns null for strategies that need no preparation", () => {
+    expect(buildPrepareParams({ strategy: "totp" })).toBeNull();
+    expect(buildPrepareParams({ strategy: "backup_code" })).toBeNull();
+  });
+});
+
+describe("describeSecondFactor", () => {
+  it("frames email codes as device verification during Device Trust", () => {
+    const copy = describeSecondFactor(
+      { strategy: "email_code", safeIdentifier: "j****@example.com" },
+      true,
+    );
+
+    expect(copy.title).toBe("Verify this device");
+    expect(copy.description).toContain("j****@example.com");
+    expect(copy.resendLabel).toBe("Resend code");
+  });
+
+  it("frames the same factor as a normal check during MFA", () => {
+    const copy = describeSecondFactor({ strategy: "email_code" }, false);
+
+    expect(copy.title).toBe("Check your email");
+  });
+
+  it("does not offer a resend for factors the user already holds", () => {
+    expect(describeSecondFactor({ strategy: "totp" }, false).resendLabel).toBeUndefined();
+    expect(
+      describeSecondFactor({ strategy: "backup_code" }, false).resendLabel,
+    ).toBeUndefined();
+  });
+});
+
+describe("isNumericCode", () => {
+  it("treats backup codes as alphanumeric and the rest as numeric", () => {
+    expect(isNumericCode("backup_code")).toBe(false);
+    expect(isNumericCode("email_code")).toBe(true);
+    expect(isNumericCode("totp")).toBe(true);
+  });
+});

--- a/frontend/src/features/auth/utils/secondFactor.ts
+++ b/frontend/src/features/auth/utils/secondFactor.ts
@@ -1,0 +1,223 @@
+/**
+ * Helpers for the second-factor challenge shown during sign-in.
+ *
+ * Two different sign-in statuses land here:
+ * - `needs_client_trust` — Device Trust. The account has no MFA, but the user
+ *   is signing in from an unrecognised device, so Clerk wants an email or SMS
+ *   code before completing.
+ * - `needs_second_factor` — the account has MFA enabled. MFA takes precedence
+ *   over Device Trust, so only one of the two statuses can occur per attempt.
+ *
+ * Both are answered with the same `prepareSecondFactor` / `attemptSecondFactor`
+ * pair, which is why one component serves both.
+ */
+
+export const SECOND_FACTOR_STRATEGIES = [
+  "totp",
+  "phone_code",
+  "email_code",
+  "backup_code",
+] as const;
+
+export type SecondFactorStrategy = (typeof SECOND_FACTOR_STRATEGIES)[number];
+
+export interface SecondFactorOption {
+  strategy: SecondFactorStrategy;
+  /** Present on email_code factors; identifies which address to send to. */
+  emailAddressId?: string;
+  /** Present on phone_code factors; identifies which number to send to. */
+  phoneNumberId?: string;
+  /** Redacted identifier Clerk exposes for display, e.g. "j****@example.com". */
+  safeIdentifier?: string;
+}
+
+/**
+ * Order we fall back through when the user has more than one factor available.
+ * TOTP first because it needs no delivery round trip and cannot be intercepted
+ * in transit; backup codes last because they are consumed when used.
+ */
+const STRATEGY_PREFERENCE: readonly SecondFactorStrategy[] = [
+  "totp",
+  "phone_code",
+  "email_code",
+  "backup_code",
+];
+
+function isSecondFactorStrategy(value: unknown): value is SecondFactorStrategy {
+  return (
+    typeof value === "string" &&
+    (SECOND_FACTOR_STRATEGIES as readonly string[]).includes(value)
+  );
+}
+
+function readOptionalString(
+  source: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = source[key];
+
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Normalise Clerk's `supportedSecondFactors` into the subset we can actually
+ * present. Unknown strategies are dropped rather than rendered as a dead end.
+ */
+export function parseSecondFactors(
+  factors: ReadonlyArray<unknown> | null | undefined,
+): SecondFactorOption[] {
+  if (!factors) {
+    return [];
+  }
+
+  const parsed: SecondFactorOption[] = [];
+  const seen = new Set<SecondFactorStrategy>();
+
+  for (const factor of factors) {
+    if (typeof factor !== "object" || factor === null) {
+      continue;
+    }
+
+    const record = factor as Record<string, unknown>;
+    if (!isSecondFactorStrategy(record.strategy)) {
+      continue;
+    }
+
+    if (seen.has(record.strategy)) {
+      continue;
+    }
+    seen.add(record.strategy);
+
+    parsed.push({
+      strategy: record.strategy,
+      emailAddressId: readOptionalString(record, "emailAddressId"),
+      phoneNumberId: readOptionalString(record, "phoneNumberId"),
+      safeIdentifier: readOptionalString(record, "safeIdentifier"),
+    });
+  }
+
+  return parsed;
+}
+
+export function selectPreferredSecondFactor(
+  options: readonly SecondFactorOption[],
+): SecondFactorOption | undefined {
+  for (const strategy of STRATEGY_PREFERENCE) {
+    const match = options.find((option) => option.strategy === strategy);
+    if (match) {
+      return match;
+    }
+  }
+
+  return options[0];
+}
+
+/**
+ * Whether the strategy needs `prepareSecondFactor` to dispatch a code first.
+ * TOTP and backup codes are already in the user's possession.
+ */
+export function requiresCodeDelivery(strategy: SecondFactorStrategy): boolean {
+  return strategy === "email_code" || strategy === "phone_code";
+}
+
+export interface SecondFactorCopy {
+  title: string;
+  description: string;
+  inputLabel: string;
+  /** Label for the control that re-sends the code, when one applies. */
+  resendLabel?: string;
+}
+
+export function describeSecondFactor(
+  option: SecondFactorOption,
+  isDeviceTrust: boolean,
+): SecondFactorCopy {
+  const target = option.safeIdentifier;
+
+  switch (option.strategy) {
+    case "email_code": {
+      return {
+        title: isDeviceTrust ? "Verify this device" : "Check your email",
+        description: target
+          ? `We sent a code to ${target}.`
+          : "We sent a code to your email address.",
+        inputLabel: "Verification code",
+        resendLabel: "Resend code",
+      };
+    }
+    case "phone_code": {
+      return {
+        title: isDeviceTrust ? "Verify this device" : "Check your phone",
+        description: target
+          ? `We sent a code to ${target}.`
+          : "We sent a code to your phone.",
+        inputLabel: "Verification code",
+        resendLabel: "Resend code",
+      };
+    }
+    case "totp": {
+      return {
+        title: "Two-factor authentication",
+        description: "Enter the code from your authenticator app.",
+        inputLabel: "Authenticator code",
+      };
+    }
+    case "backup_code": {
+      return {
+        title: "Use a backup code",
+        description:
+          "Enter one of the backup codes you saved when setting up two-factor authentication.",
+        inputLabel: "Backup code",
+      };
+    }
+  }
+}
+
+export function describeAlternativeStrategy(
+  strategy: SecondFactorStrategy,
+): string {
+  switch (strategy) {
+    case "email_code": {
+      return "Email me a code";
+    }
+    case "phone_code": {
+      return "Text me a code";
+    }
+    case "totp": {
+      return "Use my authenticator app";
+    }
+    case "backup_code": {
+      return "Use a backup code";
+    }
+  }
+}
+
+/**
+ * Backup codes are alphanumeric; every other strategy is a numeric OTP. Drives
+ * the input mode so mobile keyboards show the right layout.
+ */
+export function isNumericCode(strategy: SecondFactorStrategy): boolean {
+  return strategy !== "backup_code";
+}
+
+/**
+ * Build the `prepareSecondFactor` argument. Returns null when the strategy
+ * needs no preparation, so callers can skip the request entirely.
+ */
+export function buildPrepareParams(
+  option: SecondFactorOption,
+): { strategy: "email_code"; emailAddressId?: string } | { strategy: "phone_code"; phoneNumberId?: string } | null {
+  if (option.strategy === "email_code") {
+    return option.emailAddressId
+      ? { strategy: "email_code", emailAddressId: option.emailAddressId }
+      : { strategy: "email_code" };
+  }
+
+  if (option.strategy === "phone_code") {
+    return option.phoneNumberId
+      ? { strategy: "phone_code", phoneNumberId: option.phoneNumberId }
+      : { strategy: "phone_code" };
+  }
+
+  return null;
+}


### PR DESCRIPTION
Unblocks enabling Device Trust on the Clerk instance.

Core 3 introduced the `needs_client_trust` sign-in status, and #113 only made it safe to *receive* — the user saw a message but had no way to finish signing in. The same was already true of `needs_second_factor`, which has been a dead end since it was written. This adds the challenge UI that completes both.

## Two statuses, one flow

- **`needs_client_trust`** — Device Trust. The account has **no MFA**, but the device is unrecognised, so Clerk wants an email or SMS code.
- **`needs_second_factor`** — the account has MFA enabled.

MFA takes precedence over Device Trust, so only one can occur per attempt. Both are answered with `prepareSecondFactor` / `attemptSecondFactor`, which is why one component serves both — and why this also fixes the pre-existing MFA dead end.

## Design note worth reviewing

Clerk's docs show this using the newer `signIn.mfa.sendEmailCode()` namespace on the signal-based `useSignIn` from `@clerk/react`. **This PR stays on the `/legacy` entrypoint** that the Core 3 codemod moved us to.

The reason: legacy `PrepareSecondFactorParams` already accepts `email_code` and `phone_code` (confirmed in the installed `@clerk/shared` types), so it covers this feature fully. Following the docs literally would mean rewriting the entire sign-in form onto a different programming model — `{signIn, errors, fetchStatus}`, methods returning `{error}` rather than throwing, `finalize()` instead of `setActive` — purely to ship this. Worth doing eventually; not worth coupling to it here.

## What landed

- **`utils/secondFactor.ts`** — pure helpers, unit tested without React. Parses Clerk's `supportedSecondFactors`, dropping unknown strategies rather than rendering a dead end; picks a preferred strategy; builds prepare params. Preference is TOTP → phone → email → backup codes: TOTP needs no delivery round trip and can't be intercepted in transit, and backup codes are consumed when used.
- **`SecondFactorChallenge.tsx`** — code entry, resend for delivered codes, a "try another way" switch when several factors exist, and copy that reframes the same factor as device verification under Device Trust.
- **`ClerkSignInForm.tsx`** — wires both statuses to the challenge and extracts a shared `completeSignIn`, so the direct and post-challenge paths save biometrics and land on `/auth-ready` identically.

**Also removes a duplicate `case "needs_client_trust"`** left behind by the Core 3 migration. TypeScript does not flag duplicate case clauses — it typechecked clean both before and after the duplicate was introduced. esbuild caught it only when the new tests compiled the file.

## Verification

30 new tests: 16 on the pure logic, 8 on the UI, and 6 driving the real form against a mocked Clerk — transition on `needs_client_trust`, prepare called with the right params, completion via `setActive`, an expired code keeping the user on the challenge, TOTP preferred with no code sent, and the no-second-factor path unchanged.

Frontend 731 tests, backend 392, lint 0 errors, production build clean.

## Before merging

**Exercise the MFA path on a test account (~5 min).** Enable TOTP on one user and sign in: that hits `needs_second_factor`, which runs the identical code, component and completion path. It validates essentially this whole feature against real Clerk without touching Device Trust, and it is reversible.

**Before enabling Device Trust in the dashboard**, turn it on for the Clerk **development** instance first — dev and production are configured separately, so that is not the irreversible switch. Sign in with a password from an incognito window and confirm the code arrives and the session completes.

Three assumptions that test would confirm, none verifiable from a mock:

1. `attemptSecondFactor` returns `complete` with a `createdSessionId` for client trust, as it does for MFA. The completion path depends on it.
2. `safeIdentifier` is populated, so the UI can name the destination. If absent, the copy falls back to generic wording — degraded, not broken.
3. Resend rate limiting surfaces as a Clerk error we can display.

Per Clerk's docs, client trust triggers specifically on **password** sign-in, so the Google/OAuth path should be unaffected. Biometric sign-in goes through `authApi.login` rather than Clerk, so it cannot be intercepted by Device Trust either.

## Out of scope, noticed while working

`BiometricSignInButton` calls `authApi.login`, and the backend 404s that route whenever `AUTH_MODE !== "local"`. Under Clerk, biometric sign-in therefore appears to be broken already, and `completeSignIn` saves biometric credentials that cannot be redeemed. Pre-existing and orthogonal to this change, but worth tracking.