### PR TITLE
fix(auth): restore force redirects in the OAuth callback

### DIFF
--- a/frontend/src/features/auth/pages/SsoCallbackPage.test.tsx
+++ b/frontend/src/features/auth/pages/SsoCallbackPage.test.tsx
@@ -1,0 +1,72 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import SSOCallbackPage from "@/features/auth/pages/SsoCallbackPage";
+
+const { handleRedirectCallback, signOut, navigate } = vi.hoisted(() => ({
+  handleRedirectCallback: vi.fn(),
+  signOut: vi.fn(),
+  navigate: vi.fn(),
+}));
+
+vi.mock("@clerk/react", () => ({
+  useClerk: () => ({ handleRedirectCallback, signOut }),
+  useAuth: () => ({ isLoaded: true, isSignedIn: false }),
+  useUser: () => ({ user: null, isLoaded: true }),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Navigate: () => null,
+  useNavigate: () => navigate,
+  useSearch: () => ({ redirectTo: "/home", flow: "signin" }),
+}));
+
+vi.mock("@/config/runtime", () => ({ isClerkAuthMode: true }));
+
+vi.mock("@/components/layout/PageBackground", () => ({ default: () => null }));
+vi.mock("@/components/ui/LoadingSpinner", () => ({ default: () => null }));
+
+describe("SSOCallbackPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handleRedirectCallback.mockResolvedValue(undefined);
+  });
+
+  /**
+   * Regression guard. This page routes the user itself in a second effect, so
+   * Clerk must be told to stay put while the callback is processed.
+   *
+   * The fallback variants are NOT equivalent: they only apply when there is no
+   * redirect_url in the path, and otherwise fall through to their "/" default,
+   * dumping the user on the landing page mid-sign-in. The Core 3 codemod
+   * rewrote afterSignInUrl/afterSignUpUrl (which were force redirects) into the
+   * fallback variants, which broke Google sign-in.
+   */
+  it("pins Clerk to the current page with force redirects, not fallbacks", async () => {
+    render(<SSOCallbackPage />);
+
+    await waitFor(() => {
+      expect(handleRedirectCallback).toHaveBeenCalledOnce();
+    });
+
+    const params = handleRedirectCallback.mock.calls[0]?.[0] ?? {};
+
+    expect(params).toHaveProperty("signInForceRedirectUrl");
+    expect(params).toHaveProperty("signUpForceRedirectUrl");
+    expect(params.signInForceRedirectUrl).toBe(globalThis.location.href);
+    expect(params.signUpForceRedirectUrl).toBe(globalThis.location.href);
+
+    // Fallbacks would defeat the purpose by defaulting to "/".
+    expect(params).not.toHaveProperty("signInFallbackRedirectUrl");
+    expect(params).not.toHaveProperty("signUpFallbackRedirectUrl");
+  });
+
+  it("only processes the callback once", async () => {
+    const { rerender } = render(<SSOCallbackPage />);
+    rerender(<SSOCallbackPage />);
+
+    await waitFor(() => {
+      expect(handleRedirectCallback).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/frontend/src/features/auth/pages/SsoCallbackPage.tsx
+++ b/frontend/src/features/auth/pages/SsoCallbackPage.tsx
@@ -68,9 +68,15 @@ function ClerkSsoCallbackPage() {
     hasProcessedCallback.current = true;
 
     handleRedirectCallback({
-      // We handle routing ourselves, so tell Clerk to stay on this page
-      signInFallbackRedirectUrl: globalThis.location.href,
-      signUpFallbackRedirectUrl: globalThis.location.href,
+      // We handle routing ourselves (step 2 below), so tell Clerk to stay put.
+      //
+      // These must be the *force* variants. The fallback variants only apply
+      // "if there's no redirect_url in the path already" and otherwise default
+      // to "/", which sends the user to the landing page mid-sign-in. The
+      // Core 3 codemod rewrote the old afterSignInUrl/afterSignUpUrl props to
+      // the fallback variants, but those props had force semantics.
+      signInForceRedirectUrl: globalThis.location.href,
+      signUpForceRedirectUrl: globalThis.location.href,
     }).catch((error_) => {
       // Clerk may throw if the callback was already handled (e.g. page refresh)
       // This is safe to ignore if the user is already signed in


### PR DESCRIPTION
Google sign-in intermittently dropped the user on the landing page. The session was created correctly — signing in a second time went straight to `/home` — but the first attempt navigated to `/` instead of completing the flow.

## Cause

`SsoCallbackPage` routes the user itself in a second effect, so Clerk has to be told to stay on the callback page while the redirect is processed. That was `afterSignInUrl` / `afterSignUpUrl`, which **always** redirect to the URL given.

The Core 3 codemod in #113 rewrote both to their *fallback* variants. Those are not equivalent — from `@clerk/shared`'s own types:

> `signInFallbackRedirectUrl` — "The fallback URL to redirect to after the user signs in, **if there's no `redirect_url` in the path already**." `@default '/'`
>
> `signInForceRedirectUrl` — "If provided, this URL will **always** be redirected to after the user signs in."

So "stay on this page" stopped applying unconditionally and Clerk could fall through to its `/` default — the landing page. The dependence on whether a `redirect_url` happens to be in the path explains why the bounce is intermittent rather than every time.

I reviewed that mapping during the migration and accepted it as a rename. The prop names look interchangeable, it typechecked, and no test covered the semantics — only a real OAuth round trip exposes the difference.

## Audit of the other redirect props

Checked all three remaining usages; none are affected:

| location | prop | verdict |
| --- | --- | --- |
| `ClerkAppShell` | `signIn/signUpFallbackRedirectUrl="/home"` | correct — provider-level default, predates the migration |
| `googleAuth.ts` | `signInFallbackRedirectUrl="/sso-callback"` | correct — genuine fallback, predates the migration |
| `SsoCallbackPage` | both | **mis-mapped, fixed here** |

Only the callback page expressed "stay here", so only it needed force semantics.

## Test

Adds a regression test pinning the force variants and asserting the fallback variants are absent. **Verified it fails against the previous code** before restoring the fix, so it isn't a test that passes by construction.

Frontend 733 tests, typecheck clean, lint 0 errors, build clean.

## Known related issues, deliberately not in this PR

Two further defects were found while diagnosing this, both pre-existing and independent. Keeping them separate so this fix can be evaluated on its own while the flow is being debugged in production:

1. **Clerk hard-navigates instead of routing through the SPA.** `ClerkAppShell` passes no `routerPush` / `routerReplace`, so Clerk falls back to `window.location`. The nginx logs show `/sso-callback` fetching itself two seconds later — a full page reload mid-sign-in. This is what produces the two loading spinners, and it is also the code path where a browser extension was observed throwing `TypeError: "focus" is read-only` inside Clerk's `__internal_windowNavigate`.

2. **`clerk-sync` fires twice per sign-in** (visible in the backend logs, ~4s apart, both referred from `/auth-ready`). Looks like an effect-stability issue around `setupAuth` in `useAuthReady`.

Note that fixing (1) removes the reload that currently *masks* transient errors on the callback page — so whatever error is flashing there should be identified before that change lands, or it may become a persistent error screen instead of a flicker.
