### PR TITLE
fix(csp): allow Clerk's custom domains in the content security policy

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -22,7 +22,13 @@ server {
   # origins are the SDKs that load their own code at runtime (Clerk, PostHog,
   # Stripe) and are only reachable in managed mode. 'unsafe-inline' styles are
   # required by Tailwind and by Clerk's injected component styles.
-  add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com https://*.posthog.com https://js.stripe.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; connect-src 'self' https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://js.stripe.com https://*.clerk.accounts.dev https://*.clerk.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
+  #
+  # *.macrotrackr.com is required because Clerk is served from custom domains
+  # (clerk.macrotrackr.com for clerk-js and its chunks, accounts.macrotrackr.com
+  # for the Account Portal). 'self' is the apex only, and neither *.clerk.com
+  # nor *.clerk.accounts.dev matches a custom domain, so without this the SDK
+  # fails to load with a ChunkLoadError partway through sign-in.
+  add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://*.macrotrackr.com https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com https://*.posthog.com https://js.stripe.com; style-src 'self' 'unsafe-inline' https://*.macrotrackr.com https://fonts.googleapis.com; font-src 'self' https://*.macrotrackr.com https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; connect-src 'self' https:; worker-src 'self' blob:; frame-src https://*.macrotrackr.com https://challenges.cloudflare.com https://js.stripe.com https://*.clerk.accounts.dev https://*.clerk.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
 
   location /api/ {
     proxy_pass http://backend:3000;
@@ -45,7 +51,7 @@ server {
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), interest-cohort=()" always;
     add_header Cross-Origin-Opener-Policy "same-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com https://*.posthog.com https://js.stripe.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; connect-src 'self' https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://js.stripe.com https://*.clerk.accounts.dev https://*.clerk.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://*.macrotrackr.com https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com https://*.posthog.com https://js.stripe.com; style-src 'self' 'unsafe-inline' https://*.macrotrackr.com https://fonts.googleapis.com; font-src 'self' https://*.macrotrackr.com https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; connect-src 'self' https:; worker-src 'self' blob:; frame-src https://*.macrotrackr.com https://challenges.cloudflare.com https://js.stripe.com https://*.clerk.accounts.dev https://*.clerk.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
     try_files $uri =404;
   }
 


### PR DESCRIPTION
Clerk is served from **custom domains** on this instance — `clerk.macrotrackr.com` for clerk-js and its lazily loaded chunks, `accounts.macrotrackr.com` for the Account Portal.

The CSP added in #112 allows `'self'`, `*.clerk.com` and `*.clerk.accounts.dev`. A custom domain matches **none** of those: `'self'` is the apex only, and Clerk's wildcards cover Clerk-owned domains. So the policy blocks the auth SDK's own script loads.

Observed in a production browser console mid-sign-in:

```
Loading failed for the <script> with source
  "https://clerk.macrotrackr.com/npm/@clerk/ui@1.30.1/dist/ui-common_....js"

[Clerk UI] Failed to initialize component renderer:
  ChunkLoadError: Loading chunk 6666 failed
```

## Change

Adds `https://*.macrotrackr.com` to `script-src`, `style-src`, `font-src` and `frame-src`, in both the server-level header and the `index.html` location that has to repeat it (an `add_header` in a location discards inherited ones).

`connect-src` and `img-src` already permitted `https:`, so neither needed changing. This grants nothing beyond our own domain.

Validated with `nginx -t`.

## How this got in

A latent breakage from #112. I wrote the CSP against Clerk's *default* domains without checking which ones this instance actually uses, and the test suite covers the backend's security-header middleware rather than the nginx config — so nothing caught it.

Worth noting for whoever reviews: a CSP that blocks the auth SDK degrades rather than fails loudly. Clerk falls back to the hosted Account Portal, so sign-in half-works, which is why this surfaced as intermittent redirect weirdness rather than an obvious outage.

## Not addressed here

The same console showed a second, unrelated failure:

```
TypeError: error loading dynamically imported module:
  https://macrotrackr.com/assets/auth-ready.DNcL2ehE.js
Error caught by boundary
```

That is a same-origin chunk, so CSP is not involved — it looks like a stale-asset problem, most likely the service worker's `skipWaiting()` / `clientsClaim()` swapping the precache under a running page after a deploy while `/assets/` is served `immutable` and missing files 404. Tracking separately.
