### PR TITLE
fix(auth): route Clerk navigation through the SPA router

### DIFF
--- a/frontend/src/components/auth/ClerkAppShell.tsx
+++ b/frontend/src/components/auth/ClerkAppShell.tsx
@@ -2,6 +2,7 @@ import { type ReactNode } from "react";
 import { ClerkProvider } from "@clerk/react";
 
 import { clerkAppearance } from "@/lib/clerkAppearance";
+import { navigateWithRouter } from "@/lib/clerkNavigation";
 
 import { ClerkTokenSync } from "./ClerkTokenSync";
 
@@ -17,6 +18,8 @@ export function ClerkAppShell({ publishableKey, children }: ClerkAppShellProps) 
       afterSignOutUrl="/"
       signInFallbackRedirectUrl="/home"
       signUpFallbackRedirectUrl="/home"
+      routerPush={(to) => navigateWithRouter(to, false)}
+      routerReplace={(to) => navigateWithRouter(to, true)}
       appearance={clerkAppearance}
     >
       <ClerkTokenSync />

--- a/frontend/src/lib/clerkNavigation.test.ts
+++ b/frontend/src/lib/clerkNavigation.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { navigateWithRouter, toInternalPath } from "./clerkNavigation";
+
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn() }));
+
+// Mocked via the relative path: the "@" alias does not resolve from test
+// files here, so vi.mock("@/AppRouter") would silently miss and the real
+// router would load.
+vi.mock("../AppRouter", () => ({ router: { navigate } }));
+
+const assign = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  navigate.mockResolvedValue(undefined);
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    value: { ...globalThis.location, origin: "https://macrotrackr.com", assign },
+  });
+});
+
+describe("toInternalPath", () => {
+  it("keeps same-origin absolute URLs, preserving search and hash", () => {
+    expect(
+      toInternalPath("https://macrotrackr.com/auth-ready?redirectTo=%2Fhome"),
+    ).toBe("/auth-ready?redirectTo=%2Fhome");
+
+    expect(toInternalPath("https://macrotrackr.com/home#section")).toBe(
+      "/home#section",
+    );
+  });
+
+  it("keeps relative paths", () => {
+    expect(toInternalPath("/sso-callback?flow=signin")).toBe(
+      "/sso-callback?flow=signin",
+    );
+  });
+
+  it("rejects other origins, including Clerk's own subdomains", () => {
+    // The Account Portal is a different origin even though it shares the
+    // apex domain, so it must not be routed through the SPA.
+    expect(toInternalPath("https://accounts.macrotrackr.com/sign-in")).toBeNull();
+    expect(toInternalPath("https://clerk.macrotrackr.com/v1/foo")).toBeNull();
+    expect(toInternalPath("https://accounts.google.com/o/oauth2/auth")).toBeNull();
+  });
+});
+
+describe("navigateWithRouter", () => {
+  it("routes internal destinations through the SPA router", async () => {
+    await navigateWithRouter("https://macrotrackr.com/auth-ready", false);
+
+    expect(navigate).toHaveBeenCalledWith({ to: "/auth-ready", replace: false });
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it("honours replace semantics", async () => {
+    await navigateWithRouter("/home", true);
+
+    expect(navigate).toHaveBeenCalledWith({ to: "/home", replace: true });
+  });
+
+  it("falls back to a real navigation for external destinations", async () => {
+    await navigateWithRouter("https://accounts.macrotrackr.com/sign-in", false);
+
+    expect(assign).toHaveBeenCalledWith("https://accounts.macrotrackr.com/sign-in");
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/clerkNavigation.ts
+++ b/frontend/src/lib/clerkNavigation.ts
@@ -1,0 +1,42 @@
+import { router } from "@/AppRouter";
+
+/**
+ * Bridges Clerk's navigation to TanStack Router.
+ *
+ * Without a router bridge Clerk navigates by assigning to window.location,
+ * which tears down and reboots the SPA mid-sign-in. That showed up as
+ * /sso-callback fetching itself, two loading spinners in a row, and the
+ * auth-ready route mounting twice (which in turn synced the account twice).
+ *
+ * Clerk also hands us absolute URLs for destinations it owns, such as the
+ * Account Portal on a custom domain. Those are not our routes, so anything
+ * cross-origin must fall through to a real browser navigation.
+ */
+export function toInternalPath(to: string): string | null {
+  try {
+    const url = new URL(to, globalThis.location.origin);
+    if (url.origin !== globalThis.location.origin) {
+      return null;
+    }
+
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    // Not a resolvable URL: let the browser deal with it.
+    return null;
+  }
+}
+
+export function navigateWithRouter(
+  to: string,
+  replace: boolean,
+): Promise<unknown> {
+  const internalPath = toInternalPath(to);
+
+  if (internalPath === null) {
+    globalThis.location.assign(to);
+
+    return Promise.resolve();
+  }
+
+  return router.navigate({ to: internalPath, replace });
+}


### PR DESCRIPTION
`ClerkProvider` was given no `routerPush` / `routerReplace`, so Clerk navigated by assigning to `window.location`. Every Clerk-initiated redirect tore down and rebooted the SPA.

Visible in the production nginx logs, where the callback page fetches **itself** two seconds after the OAuth return:

```
GET /sso-callback?flow=signin&redirectTo=%2Fhome   referer: accounts.google.com
GET /sso-callback?flow=signin&redirectTo=%2Fhome   referer: macrotrackr.com/sso-callback
```

## What this explains

- **The two loading spinners.** The callback page renders its spinner, reloads, renders it again, then routes to `/auth-ready` for a third.
- **`clerk-sync` firing twice per sign-in.** Each hard navigation is a fresh document, which resets the `hasInitializedRef` guard in `useAuthReady`. Those HTML requests are absent from the nginx log because the service worker serves them from precache — which is why the double mount was not obvious from the logs alone.

## Change

Bridges Clerk to TanStack Router using the existing module-level `router` singleton, so no hook or provider reordering is required.

**Cross-origin destinations deliberately bypass the router.** Clerk hands us absolute URLs for pages it owns — notably the Account Portal at `accounts.macrotrackr.com`, which shares our apex domain but is a *different origin*. Routing those through the SPA would fail, so they fall through to a real browser navigation. That distinction is the main thing worth reviewing here, and it is covered by tests.

## Sequencing note

This is safe to land now, but was deliberately held until #117. The reload it removes was masking transient errors on the callback page — without #117's stale-chunk recovery in place, removing the reload could have turned a flicker into a persistent error screen.

## Not included

A dedupe for the doubled `clerk-sync`. It looks like a symptom of the hard navigation plus the CSP block fixed in #116, rather than an independent defect. Better re-checked once these are deployed than papered over with machinery that might hide a real problem.

## Verification

Frontend 742 tests (6 new, covering same-origin routing, replace semantics, and the cross-origin fallback), typecheck clean, lint 0 errors, build clean.

Worth watching after deploy: sign-in should show one spinner rather than two, `/sso-callback` should appear once in the nginx log, and `clerk-sync` should fire once.
