### PR TITLE
fix(router): prevent router hook match errors during exit transitions

### DIFF
--- a/frontend/src/features/auth/components/ResetPasswordForm.tsx
+++ b/frontend/src/features/auth/components/ResetPasswordForm.tsx
@@ -9,7 +9,7 @@ import { useResetPassword } from "@/hooks/auth/useAuthQueries";
 import { useStore } from "@/store/store";
 
 function ResetPasswordForm() {
-  const search = useSearch({ from: "/reset-password" });
+  const search = (useSearch({ strict: false }) ?? {}) as { token?: string };
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const { showNotification } = useStore();

--- a/frontend/src/features/auth/pages/AuthReadyPage.tsx
+++ b/frontend/src/features/auth/pages/AuthReadyPage.tsx
@@ -16,7 +16,7 @@ export default function AuthReadyPage() {
 
 function ClerkAuthReadyPage() {
   const navigate = useNavigate();
-  const search = useSearch({ from: "/auth-ready" }) as { redirectTo?: string };
+  const search = (useSearch({ strict: false }) ?? {}) as { redirectTo?: string };
   const redirectTo = resolveProfileSetupRedirect(search.redirectTo);
   const { error, setupAuth } = useAuthReady(redirectTo);
 

--- a/frontend/src/features/auth/pages/ProfileSetupPage.tsx
+++ b/frontend/src/features/auth/pages/ProfileSetupPage.tsx
@@ -27,7 +27,7 @@ export default function ProfileSetupPage() {
 
 function ClerkProfileSetupPage() {
   const { isSignedIn, isLoaded } = useAuth();
-  const search = useSearch({ from: "/profile-setup" }) as {
+  const search = (useSearch({ strict: false }) ?? {}) as {
     redirectTo?: string;
   };
   const { data: user, isLoading: isUserLoading } = useUser({

--- a/frontend/src/features/auth/pages/SignInPage.tsx
+++ b/frontend/src/features/auth/pages/SignInPage.tsx
@@ -13,8 +13,8 @@ import { resolveAuthReturnTo } from "@/features/auth/utils/redirect";
  */
 export default function SignInPage() {
   const navigate = useNavigate();
-  const search = useSearch({ from: "/login" });
-  const returnTo = search.returnTo as string | undefined;
+  const search = (useSearch({ strict: false }) ?? {}) as { returnTo?: string };
+  const returnTo = search.returnTo;
   const returnToSearch = { returnTo: resolveAuthReturnTo(returnTo) };
 
   return (

--- a/frontend/src/features/auth/pages/SignUpPage.tsx
+++ b/frontend/src/features/auth/pages/SignUpPage.tsx
@@ -13,8 +13,8 @@ import { resolveAuthReturnTo } from "@/features/auth/utils/redirect";
  */
 export default function SignUpPage() {
   const navigate = useNavigate();
-  const search = useSearch({ from: "/register" });
-  const returnTo = search.returnTo as string | undefined;
+  const search = (useSearch({ strict: false }) ?? {}) as { returnTo?: string };
+  const returnTo = search.returnTo;
   const returnToSearch = { returnTo: resolveAuthReturnTo(returnTo) };
 
   return (

--- a/frontend/src/features/auth/pages/SsoCallbackPage.tsx
+++ b/frontend/src/features/auth/pages/SsoCallbackPage.tsx
@@ -47,7 +47,7 @@ function ClerkSsoCallbackPage() {
   const { isLoaded: authLoaded, isSignedIn } = useAuth();
   const { user, isLoaded: userLoaded } = useUser();
   const navigate = useNavigate();
-  const search = useSearch({ from: "/sso-callback" }) as {
+  const search = (useSearch({ strict: false }) ?? {}) as {
     redirectTo?: string;
     flow?: string;
   };

--- a/frontend/src/features/landing/pages/BlogArticlePage.test.tsx
+++ b/frontend/src/features/landing/pages/BlogArticlePage.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import BlogArticlePage from "./BlogArticlePage";
+
+let mockParams: { slug?: string } = { slug: "v3-0-0" };
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to, ...props }: any) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+  useParams: () => mockParams,
+  useNavigate: () => vi.fn(),
+  useSearch: () => ({}),
+  useLocation: () => ({ pathname: "/blog/v3-0-0" }),
+}));
+
+describe("BlogArticlePage", () => {
+  it("renders the article for a valid slug", () => {
+    mockParams = { slug: "v3-0-0" };
+    render(<BlogArticlePage />);
+
+    expect(
+      screen.getAllByRole("heading", { level: 1 }).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText(/back to the blog/i)).toBeInTheDocument();
+  });
+
+  it("retains the article during exit transition when route params detach", () => {
+    mockParams = { slug: "v3-0-0" };
+    const { rerender } = render(<BlogArticlePage />);
+
+    expect(
+      screen.getAllByRole("heading", { level: 1 }).length,
+    ).toBeGreaterThan(0);
+
+    // Simulates router match changing to /blog while AnimatePresence keeps exiting page mounted
+    mockParams = {};
+    rerender(<BlogArticlePage />);
+
+    // Must not crash and must not flash not found
+    expect(
+      screen.getAllByRole("heading", { level: 1 }).length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText(/article not found/i)).not.toBeInTheDocument();
+  });
+
+  it("renders not found state when given an invalid slug", () => {
+    mockParams = { slug: "non-existent-article-slug" };
+    render(<BlogArticlePage />);
+
+    expect(screen.getByText(/article not found/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/landing/pages/BlogArticlePage.tsx
+++ b/frontend/src/features/landing/pages/BlogArticlePage.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useCallback, useMemo, useState } from "react";
+import React, { Suspense, useCallback, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { Link, useParams } from "@tanstack/react-router";
 import { motion, useReducedMotion, useScroll, useSpring } from "motion/react";
@@ -258,7 +258,12 @@ const ReadingProgress: React.FC = () => {
 };
 
 const BlogArticlePage: React.FC = () => {
-  const { slug } = useParams({ from: "/blog/$slug" });
+  const params = useParams({ strict: false }) as { slug?: string };
+  const lastSlugRef = useRef(params.slug);
+  if (params.slug) {
+    lastSlugRef.current = params.slug;
+  }
+  const slug = params.slug || lastSlugRef.current || "";
   const shouldReduceMotion = useReducedMotion();
   const post = getPostBySlug(slug);
   const [copiedLink, setCopiedLink] = useState(false);

--- a/frontend/src/features/landing/pages/BlogIndexPage.tsx
+++ b/frontend/src/features/landing/pages/BlogIndexPage.tsx
@@ -20,8 +20,8 @@ interface BlogIndexSearch {
 
 const BlogIndexPage: React.FC = () => {
   const shouldReduceMotion = useReducedMotion();
-  const navigate = useNavigate({ from: "/blog/" });
-  const search = useSearch({ from: "/blog/" }) as BlogIndexSearch;
+  const navigate = useNavigate();
+  const search = (useSearch({ strict: false }) ?? {}) as BlogIndexSearch;
 
   usePageMetadata({
     title: "Blog — MacroTrackr",

--- a/frontend/src/features/settings/pages/SettingsPage.tsx
+++ b/frontend/src/features/settings/pages/SettingsPage.tsx
@@ -41,7 +41,7 @@ const VALID_TABS = new Set<TabType>([
 
 export default function SettingsPage() {
   // Read tab from URL search params
-  const search = useSearch({ from: "/settings" }) as { tab?: string };
+  const search = (useSearch({ strict: false }) ?? {}) as { tab?: string };
 
   // Use TanStack Query for settings data and mutations
   const {


### PR DESCRIPTION
## Summary of Changes
- **Blog Article Navigation**: Replaced strict `useParams({ from: "/blog/$slug" })` with non-strict `useParams({ strict: false })` and retained the previous slug reference during the 200ms exit animation so `BlogArticlePage` does not throw `Could not find a match for from: /blog/$slug` when navigating back to `/blog`.
- **Router Hook Hardening**: Replaced strict `useSearch` and `useNavigate` route constraints across `BlogIndexPage`, `SignInPage`, `SignUpPage`, `ProfileSetupPage`, `SsoCallbackPage`, `AuthReadyPage`, `ResetPasswordForm`, and `SettingsPage` with non-strict equivalents to prevent navigation transitions from crashing while unmounting.
- **Tests**: Added `BlogArticlePage.test.tsx` covering valid slug rendering, slug retention during exit animation detached state, and invalid slug handling.