### PR TITLE
fix(pwa): show loading state on UpdatePrompt when updating

### DIFF
--- a/frontend/src/components/layout/UpdatePrompt.test.tsx
+++ b/frontend/src/components/layout/UpdatePrompt.test.tsx
@@ -1,0 +1,76 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import UpdatePrompt from "./UpdatePrompt";
+
+describe("UpdatePrompt", () => {
+  let mockWorker: { postMessage: ReturnType<typeof vi.fn> };
+  let mockRegistration: {
+    waiting: typeof mockWorker | null;
+    addEventListener: ReturnType<typeof vi.fn>;
+  };
+  let swEventListeners: Record<string, () => void>;
+
+  beforeEach(() => {
+    mockWorker = {
+      postMessage: vi.fn(),
+    };
+
+    mockRegistration = {
+      waiting: mockWorker,
+      addEventListener: vi.fn(),
+    };
+
+    swEventListeners = {};
+
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: {
+        getRegistration: vi.fn().mockResolvedValue(mockRegistration),
+        addEventListener: vi.fn((event: string, handler: () => void) => {
+          swEventListeners[event] = handler;
+        }),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders prompt when service worker update is waiting", async () => {
+    await act(async () => {
+      render(<UpdatePrompt />);
+    });
+
+    expect(screen.getByText("A new version is ready.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Update" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Later" })).toBeInTheDocument();
+  });
+
+  it("dismisses prompt when Later is clicked", async () => {
+    await act(async () => {
+      render(<UpdatePrompt />);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Later" }));
+    expect(screen.queryByText("A new version is ready.")).not.toBeInTheDocument();
+  });
+
+  it("shows loading indicator and disables buttons when Update is clicked", async () => {
+    await act(async () => {
+      render(<UpdatePrompt />);
+    });
+
+    const updateButton = screen.getByRole("button", { name: "Update" });
+    const laterButton = screen.getByRole("button", { name: "Later" });
+
+    fireEvent.click(updateButton);
+
+    expect(mockWorker.postMessage).toHaveBeenCalledWith({ type: "SKIP_WAITING" });
+    expect(updateButton).toHaveAttribute("aria-busy", "true");
+    expect(updateButton).toBeDisabled();
+    expect(laterButton).toBeDisabled();
+    expect(screen.getByText("Updating…")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/layout/UpdatePrompt.tsx
+++ b/frontend/src/components/layout/UpdatePrompt.tsx
@@ -11,6 +11,7 @@ import Button from "@/components/ui/Button";
 const UpdatePrompt: React.FC = () => {
   const [waiting, setWaiting] = useState<ServiceWorker | null>(null);
   const [dismissed, setDismissed] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
 
   useEffect(() => {
     if (!("serviceWorker" in navigator)) return;
@@ -45,7 +46,8 @@ const UpdatePrompt: React.FC = () => {
   }, []);
 
   const applyUpdate = useCallback(() => {
-    if (!waiting) return;
+    if (!waiting || isUpdating) return;
+    setIsUpdating(true);
 
     // Reload once the new worker takes control, so the page and its chunks
     // always come from the same build.
@@ -55,7 +57,7 @@ const UpdatePrompt: React.FC = () => {
       { once: true },
     );
     waiting.postMessage({ type: "SKIP_WAITING" });
-  }, [waiting]);
+  }, [waiting, isUpdating]);
 
   if (!waiting || dismissed) return null;
 
@@ -71,12 +73,15 @@ const UpdatePrompt: React.FC = () => {
           variant="ghost"
           buttonSize="sm"
           onClick={() => setDismissed(true)}
+          disabled={isUpdating}
           text="Later"
         />
         <Button
           variant="primary"
           buttonSize="sm"
           onClick={applyUpdate}
+          isLoading={isUpdating}
+          loadingText="Updating…"
           text="Update"
         />
       </div>


### PR DESCRIPTION
## Summary of Changes
- Sets `isUpdating` loading state when clicking 'Update' in `UpdatePrompt.tsx`.
- Displays spinner indicator with `loadingText="Updating…"` on the update button and disables the 'Later' button to prevent duplicate clicks while the service worker activates and reloads.
- Adds test coverage in `UpdatePrompt.test.tsx`.