### PR TITLE
fix(seo): exclude auth/private routes from sitemap and robots, dynamic canonicals

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -33,7 +33,6 @@
       content="macro tracking, macronutrients, nutrition tracker, MacroTrackr, macro tracker"
     />
     <meta name="robots" content="index,follow" />
-    <link rel="canonical" href="https://macrotrackr.com/" />
 
     <!-- Open Graph -->
     <meta property="og:site_name" content="MacroTrackr" />

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,7 +1,16 @@
 # robots.txt for Macro Tracker
-# Allow all crawlers to access the site
 User-agent: *
 Allow: /
+Disallow: /home
+Disallow: /goals
+Disallow: /reporting
+Disallow: /settings
+Disallow: /profile-setup
+Disallow: /auth-ready
+Disallow: /sso-callback
+Disallow: /login
+Disallow: /register
+Disallow: /reset-password
 
 # Sitemap
 Sitemap: https://macrotrackr.com/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -55,24 +55,6 @@
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://macrotrackr.com/login</loc>
-    <lastmod>2026-08-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
-  </url>
-  <url>
-    <loc>https://macrotrackr.com/register</loc>
-    <lastmod>2026-08-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
-  </url>
-  <url>
-    <loc>https://macrotrackr.com/reset-password</loc>
-    <lastmod>2026-08-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
-  </url>
-  <url>
     <loc>https://macrotrackr.com/privacy</loc>
     <lastmod>2026-08-15</lastmod>
     <changefreq>yearly</changefreq>

--- a/frontend/scripts/generate-sitemap.js
+++ b/frontend/scripts/generate-sitemap.js
@@ -14,9 +14,6 @@ const routes = [
   { path: "/tools/weight-loss-calculator", changefreq: "monthly", priority: 0.6 },
   { path: "/tools/protein-calculator", changefreq: "monthly", priority: 0.6 },
   { path: "/pricing", changefreq: "monthly", priority: 0.6 },
-  { path: "/login", changefreq: "monthly", priority: 0.5 },
-  { path: "/register", changefreq: "monthly", priority: 0.5 },
-  { path: "/reset-password", changefreq: "monthly", priority: 0.5 },
   { path: "/privacy", changefreq: "yearly", priority: 0.2 },
   { path: "/terms", changefreq: "yearly", priority: 0.2 },
 ];


### PR DESCRIPTION
## Summary
- Excluded unindexable auth routes (`/login`, `/register`, `/reset-password`) from `sitemap.xml` and `generate-sitemap.js`.
- Added `Disallow` directives in `robots.txt` for private app routes and auth endpoints to prevent crawler crawl budget waste and redirect churn.
- Removed hardcoded root canonical tag from `index.html` so `usePageMetadata` dynamically manages canonical URLs per route without default conflicts.