### PR TITLE
fix(ui): unify mobile nav breakpoints and move logout to settings

### DIFF
--- a/frontend/src/components/chart/DateRangeSelector.tsx
+++ b/frontend/src/components/chart/DateRangeSelector.tsx
@@ -83,7 +83,7 @@ export default function DateRangeSelector({
 
         {/* Export CSV Button aligned right on same line */}
         <div className="shrink-0">
-          <div className="flex lg:hidden">
+          <div className="flex md:hidden">
             <IconButton
               variant="export"
               ariaLabel="Export data as CSV file"
@@ -91,7 +91,7 @@ export default function DateRangeSelector({
               disabled={isExportDisabled}
             />
           </div>
-          <div className="hidden lg:flex">
+          <div className="hidden md:flex">
             <Button
               onClick={onExportClick}
               disabled={isExportDisabled}

--- a/frontend/src/components/layout/AppHeader.test.tsx
+++ b/frontend/src/components/layout/AppHeader.test.tsx
@@ -6,7 +6,6 @@ import AppHeader from "./AppHeader";
 
 let pathname = "/home";
 const navigateMock = vi.fn();
-const logoutMock = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({
   useLocation: () => ({ pathname }),
@@ -25,15 +24,10 @@ vi.mock("@tanstack/react-router", () => ({
   ),
 }));
 
-vi.mock("@/hooks/auth/useAuthQueries", () => ({
-  useLogout: () => ({ mutate: logoutMock, isPending: false }),
-}));
-
 describe("AppHeader", () => {
   beforeEach(() => {
     pathname = "/home";
     navigateMock.mockReset();
-    logoutMock.mockReset();
   });
 
   it("renders exactly one navigation landmark per mode", () => {
@@ -51,7 +45,6 @@ describe("AppHeader", () => {
     for (const label of ["Home", "Goals", "Analytics", "Settings"]) {
       expect(within(nav).getByText(label)).toBeInTheDocument();
     }
-    expect(within(nav).getByText("Log out")).toBeInTheDocument();
   });
 
   it("marks the current app route as the current page", () => {
@@ -61,6 +54,15 @@ describe("AppHeader", () => {
     const current = screen.getAllByRole("button", { current: "page" });
     expect(current).toHaveLength(1);
     expect(current[0]).toHaveTextContent("Goals");
+  });
+
+  it("navigates when an app route button is clicked", async () => {
+    render(<AppHeader mode="app" />);
+
+    const nav = screen.getByRole("navigation", { name: "Main navigation" });
+    await userEvent.click(within(nav).getByText("Analytics"));
+
+    expect(navigateMock).toHaveBeenCalledWith({ to: "/reporting" });
   });
 
   it("carries the public destinations in public mode", () => {
@@ -94,16 +96,12 @@ describe("AppHeader", () => {
     }
   });
 
-  it("opens the same sheet for the app destinations", async () => {
+  it("has no menu button in app mode because MobileTabBar handles mobile navigation", () => {
     render(<AppHeader mode="app" />);
 
-    await userEvent.click(screen.getByRole("button", { name: "Open menu" }));
-
-    const sheet = screen.getByRole("dialog", { name: "Main navigation" });
-    expect(within(sheet).getByText("Analytics")).toBeInTheDocument();
-
-    await userEvent.click(within(sheet).getByText("Analytics"));
-    expect(navigateMock).toHaveBeenCalledWith({ to: "/reporting" });
+    expect(
+      screen.queryByRole("button", { name: "Open menu" }),
+    ).not.toBeInTheDocument();
   });
 
   it("has no menu button in minimal mode", () => {

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -11,7 +11,6 @@ import {
   GithubIcon,
   GoalsIcon,
   HomeIcon,
-  LogoutIcon,
   MenuIcon,
   ReportingIcon,
   SettingsIcon,
@@ -20,7 +19,6 @@ import {
   CALCULATOR_TOOLS,
   TOOLS_HUB_PATH,
 } from "@/features/landing/tools/toolsCatalog";
-import { useLogout } from "@/hooks/auth/useAuthQueries";
 import { DOCS_URL, GITHUB_REPO_URL } from "@/utils/appConstants";
 
 import LogoButton from "./LogoButton";
@@ -109,7 +107,7 @@ const HeaderFrame: React.FC<HeaderFrameProps> = ({
           aria-label={label}
           style={{ touchAction: "manipulation" }}
         >
-          <div className="flex min-w-0 items-center gap-2 lg:gap-4">
+          <div className="flex min-w-0 items-center gap-2 md:gap-4">
             <LogoButton compact ariaLabel={logoLabel} onClick={onLogoClick} />
             {leading}
           </div>
@@ -125,7 +123,7 @@ const HeaderFrame: React.FC<HeaderFrameProps> = ({
                 onClick={menu.onToggle}
                 aria-label={menu.isOpen ? "Close menu" : "Open menu"}
                 aria-expanded={menu.isOpen}
-                className={`${iconButtonClasses} lg:hidden ${
+                className={`${iconButtonClasses} md:hidden ${
                   menu.isOpen ? "bg-surface-2 text-foreground" : ""
                 }`}
               >
@@ -244,41 +242,7 @@ const ToolsDropdown: React.FC<{ isActive: boolean; currentPath: string }> = ({
 };
 
 const AppModeHeader: React.FC = () => {
-  const { navigate, isActiveRoute, goTo, isSheetOpen, setIsSheetOpen } =
-    useHeaderNavigation();
-  const shouldReduceMotion = useReducedMotion() ?? false;
-  const logoutMutation = useLogout();
-
-  const handleLogout = useCallback(() => {
-    logoutMutation.mutate();
-    setIsSheetOpen(false);
-  }, [logoutMutation, setIsSheetOpen]);
-
-  const items = useMemo<MobileNavItem[]>(
-    () =>
-      APP_NAV_ITEMS.map((item) => ({
-        key: item.path,
-        label: item.label,
-        icon: item.icon,
-        isActive: isActiveRoute(item.path),
-        onSelect: () => goTo(item.path),
-      })),
-    [goTo, isActiveRoute],
-  );
-
-  const actions = useMemo<MobileNavAction[]>(
-    () => [
-      {
-        key: "logout",
-        label: "Log out",
-        icon: LogoutIcon,
-        onSelect: handleLogout,
-        disabled: logoutMutation.isPending,
-        tone: "danger",
-      },
-    ],
-    [handleLogout, logoutMutation.isPending],
-  );
+  const { navigate, isActiveRoute, goTo } = useHeaderNavigation();
 
   return (
     <HeaderFrame
@@ -288,7 +252,7 @@ const AppModeHeader: React.FC = () => {
         navigate({ to: "/home", search: { limit: 20, offset: 0 } })
       }
       leading={
-        <div className="hidden items-center gap-2 lg:flex">
+        <div className="hidden items-center gap-2 md:flex">
           {APP_NAV_ITEMS.map(({ path, label, icon: Icon }) => {
             const isActive = isActiveRoute(path);
 
@@ -309,38 +273,7 @@ const AppModeHeader: React.FC = () => {
           })}
         </div>
       }
-      trailing={
-        <div className="hidden lg:flex">
-          <button
-            type="button"
-            onClick={handleLogout}
-            disabled={logoutMutation.isPending}
-            className={getButtonClasses(
-              "ghost",
-              "sm",
-              false,
-              "gap-2.5 rounded-full font-medium",
-            )}
-          >
-            <LogoutIcon className="h-4 w-4" />
-            <span>Log out</span>
-          </button>
-        </div>
-      }
-      menu={{
-        isOpen: isSheetOpen,
-        onToggle: () => setIsSheetOpen((open) => !open),
-      }}
-    >
-      <MobileNavSheet
-        isOpen={isSheetOpen}
-        onClose={() => setIsSheetOpen(false)}
-        items={items}
-        actions={actions}
-        shouldReduceMotion={shouldReduceMotion}
-        label="Main navigation"
-      />
-    </HeaderFrame>
+    />
   );
 };
 
@@ -412,7 +345,7 @@ const PublicModeHeader: React.FC = () => {
       logoLabel="MacroTrackr home"
       onLogoClick={() => navigate({ to: "/" })}
       center={
-        <div className="hidden items-center justify-center gap-1 lg:flex lg:flex-1">
+        <div className="hidden items-center justify-center gap-1 md:flex md:flex-1">
           <ToolsDropdown
             isActive={isActiveRoute("/tools")}
             currentPath={pathname}
@@ -452,7 +385,7 @@ const PublicModeHeader: React.FC = () => {
         </div>
       }
       trailing={
-        <div className="hidden items-center gap-3 lg:flex">
+        <div className="hidden items-center gap-3 md:flex">
           <Link
             to="/login"
             search={{ returnTo: undefined }}

--- a/frontend/src/components/layout/InstallPrompt.tsx
+++ b/frontend/src/components/layout/InstallPrompt.tsx
@@ -68,7 +68,7 @@ const InstallPrompt: React.FC = () => {
     <div
       role="complementary"
       aria-label="Install MacroTrackr"
-      className="fixed inset-x-4 z-80 mx-auto flex max-w-md items-center gap-3 rounded-card border border-border bg-surface px-4 py-3 lg:hidden"
+      className="fixed inset-x-4 z-80 mx-auto flex max-w-md items-center gap-3 rounded-card border border-border bg-surface px-4 py-3 md:hidden"
       style={{ bottom: "calc(5rem + var(--sab))" }}
     >
       <p className="flex-1 text-sm">

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -78,7 +78,7 @@ const MainLayout: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
       <main
         id="main-content"
         className={`relative min-h-screen ${
-          isAuthenticated ? "pb-[calc(4.5rem+var(--sab))] lg:pb-0" : ""
+          isAuthenticated ? "pb-[calc(4.5rem+var(--sab))] md:pb-0" : ""
         }`}
       >
         {children}

--- a/frontend/src/components/layout/MobileNavSheet.tsx
+++ b/frontend/src/components/layout/MobileNavSheet.tsx
@@ -54,7 +54,7 @@ const MobileNavSheet: React.FC<MobileNavSheetProps> = ({
     {isOpen && (
       <>
         <motion.div
-          className="fixed inset-0 z-60 bg-black/60 backdrop-blur-xs lg:hidden"
+          className="fixed inset-0 z-60 bg-black/60 backdrop-blur-xs md:hidden"
           onClick={onClose}
           aria-hidden="true"
           initial={shouldReduceMotion ? false : { opacity: 0 }}
@@ -67,7 +67,7 @@ const MobileNavSheet: React.FC<MobileNavSheetProps> = ({
         <motion.div
           role="dialog"
           aria-label={label}
-          className="fixed inset-x-4 z-70 rounded-card border border-border bg-surface p-2.5 lg:hidden"
+          className="fixed inset-x-4 z-70 rounded-card border border-border bg-surface p-2.5 md:hidden"
           style={{ top: "calc(5rem + var(--sat))" }}
           initial={shouldReduceMotion ? false : { opacity: 0, y: -8 }}
           animate={{ opacity: 1, y: 0 }}

--- a/frontend/src/components/layout/MobileTabBar.tsx
+++ b/frontend/src/components/layout/MobileTabBar.tsx
@@ -74,7 +74,7 @@ const MobileTabBar: React.FC<MobileTabBarProps> = ({ onLog }) => {
   return (
     <nav
       aria-label="Primary"
-      className="fixed inset-x-0 bottom-0 z-70 flex items-stretch border-t border-border bg-surface pb-[var(--sab)] lg:hidden"
+      className="fixed inset-x-0 bottom-0 z-70 flex items-stretch border-t border-border bg-surface pb-[var(--sab)] md:hidden"
     >
       {left.map(renderTab)}
 

--- a/frontend/src/features/macroTracking/components/DesktopEntryTable.tsx
+++ b/frontend/src/features/macroTracking/components/DesktopEntryTable.tsx
@@ -472,7 +472,7 @@ const DesktopEntryTable = memo(
     );
 
     return (
-      <div className="hidden lg:block">
+      <div className="hidden md:block">
         <div
           ref={tableContainerReference}
           className={`overflow-hidden rounded-control border border-border bg-surface shadow-xs ${shouldVirtualize ? "max-h-150 overflow-auto" : ""}`}

--- a/frontend/src/features/macroTracking/components/EntryHistoryPanel.tsx
+++ b/frontend/src/features/macroTracking/components/EntryHistoryPanel.tsx
@@ -327,7 +327,7 @@ const EntryHistoryComponent = function EntryHistory({
   // are the only motion here that carries information.
   return (
     <div>
-      <div className="mb-5 flex items-center justify-between gap-4 lg:hidden">
+      <div className="mb-5 flex items-center justify-between gap-4 md:hidden">
         <div>
           <h2 className="text-xl font-semibold tracking-tight text-foreground">
             Entry History
@@ -362,7 +362,7 @@ const EntryHistoryComponent = function EntryHistory({
         </div>
       </div>
 
-      <div className="mb-6 hidden flex-row items-center justify-between gap-4 lg:flex">
+      <div className="mb-6 hidden flex-row items-center justify-between gap-4 md:flex">
         <div>
           <h2 className="text-xl font-semibold tracking-tight text-foreground">
             Entry History
@@ -417,11 +417,11 @@ const EntryHistoryComponent = function EntryHistory({
       ) : (
         <div className="overflow-hidden rounded-control border border-border bg-transparent">
           <EntryHistoryContext.Provider value={controller}>
-            <div className="hidden lg:block">
+            <div className="hidden md:block">
               <DesktopEntryTable groupedEntries={displayedEntries} />
             </div>
 
-            <div className="lg:hidden">
+            <div className="md:hidden">
               <MobileEntryCards groupedEntries={displayedEntries} />
             </div>
           </EntryHistoryContext.Provider>
@@ -483,10 +483,7 @@ const EntryHistoryComponent = function EntryHistory({
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: 24 }}
               transition={{ duration: DURATIONS.base, ease: EASINGS.modal }}
-              // Sits above the tab bar and clear of the home indicator; it
-              // used to be pinned to bottom-6 with no safe-area padding.
-              style={{ bottom: "calc(5.5rem + var(--sab))" }}
-              className="fixed left-1/2 z-100 flex -translate-x-1/2 items-center gap-3 rounded-full border border-border bg-surface px-4 py-3 md:gap-4 md:px-6 md:py-3.5 lg:bottom-6"
+              className="fixed bottom-[calc(5.5rem+var(--sab))] left-1/2 z-100 flex -translate-x-1/2 items-center gap-3 rounded-full border border-border bg-surface px-4 py-3 md:bottom-6 md:gap-4 md:px-6 md:py-3.5"
             >
               <div className="flex flex-col gap-1 md:flex-row md:items-center md:gap-3">
                 <span className="text-sm font-medium whitespace-nowrap text-foreground">

--- a/frontend/src/features/macroTracking/components/MobileEntryCards.tsx
+++ b/frontend/src/features/macroTracking/components/MobileEntryCards.tsx
@@ -168,7 +168,7 @@ const MobileEntryCards = memo(
       return (
         <div
           ref={containerReference}
-          className="max-h-[70vh] overflow-auto lg:hidden"
+          className="max-h-[70vh] overflow-auto md:hidden"
         >
           <div
             style={{
@@ -211,7 +211,7 @@ const MobileEntryCards = memo(
     }
 
     return (
-      <div className="lg:hidden">
+      <div className="md:hidden">
         <AnimatePresence>
           {groupedEntries.map((group) => (
             <motion.div

--- a/frontend/src/features/settings/pages/SettingsPage.tsx
+++ b/frontend/src/features/settings/pages/SettingsPage.tsx
@@ -7,8 +7,10 @@ import { DashboardPageContainer } from "@/components/layout/DashboardPageContain
 import FeaturePage from "@/components/layout/FeaturePage";
 import {
   AwardIcon,
+  Button,
   LinkIcon,
   LockIcon,
+  LogoutIcon,
   Modal,
   TabBar,
   UserIcon,
@@ -22,6 +24,7 @@ import {
   SettingsLoadingSkeleton,
 } from "@/features/settings/components";
 import { useBeforeUnload, useMutationErrorHandler } from "@/hooks";
+import { useLogout } from "@/hooks/auth/useAuthQueries";
 import { useSaveSettings, useSettings } from "@/hooks/queries/useSettings";
 import { usePageDataSync } from "@/hooks/usePageDataSync";
 import { useStore } from "@/store/store";
@@ -50,6 +53,11 @@ export default function SettingsPage() {
     error: settingsQueryError,
   } = useSettings();
   const saveSettingsMutation = useSaveSettings();
+  const logoutMutation = useLogout();
+
+  const handleLogout = useCallback(() => {
+    logoutMutation.mutate();
+  }, [logoutMutation]);
 
   const {
     settings,
@@ -309,6 +317,26 @@ export default function SettingsPage() {
         ) : (
           <SettingsLoadingSkeleton />
         )}
+
+        <div className="mt-6 flex flex-col items-start justify-between gap-4 border-t border-border pt-6 sm:mt-8 sm:flex-row sm:items-center">
+          <div>
+            <h3 className="text-sm font-medium text-foreground">
+              Account Session
+            </h3>
+            <p className="text-xs text-muted">
+              Sign out of your account on this device
+            </p>
+          </div>
+          <Button
+            variant="danger"
+            buttonSize="sm"
+            onClick={handleLogout}
+            isLoading={logoutMutation.isPending}
+            leftIcon={<LogoutIcon className="h-4 w-4" />}
+            text="Log out"
+          />
+        </div>
+
         <Modal
           isOpen={showConfirmModal}
           onClose={cancelTabChange}


### PR DESCRIPTION
## Summary
- Unify responsive navigation breakpoints at `md` (768px) across `MobileTabBar`, `AppHeader`, `MainLayout`, `InstallPrompt`, `MobileNavSheet`, and `EntryHistoryPanel`.
- Fixes the overlap on half-screen / tablet viewports where both the bottom `+`/tab bar and the on-page Add Meal panel were simultaneously displayed.
- Streamlines mobile app header by removing the redundant top hamburger menu in app mode (navigation is handled by the bottom tab bar).
- Moves the `Log out` action from the top header to `SettingsPage` under Account Session.

## Verification
- All 124 Vitest test files pass (717 tests).
- UI budgets and ESLint checks pass with 0 errors.