### PR TITLE
fix(brand): standardize app name to MacroTrackr across configs and docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-# Macro Tracker - AI Coding Agent Instructions
+# MacroTrackr - AI Coding Agent Instructions
 
 Quick reference for AI agents working in this codebase.
 

--- a/.github/design-system.md
+++ b/.github/design-system.md
@@ -1,4 +1,4 @@
-# Macro Tracker Design System
+# MacroTrackr Design System
 
 A hybrid design language for nutrition tracking applications, combining Memoria-inspired premium aesthetics with brand-specific color coding for macro tracking.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for helping improve Macro Tracker.
+Thanks for helping improve MacroTrackr.
 
 ## Development setup
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Macro Tracker
+# MacroTrackr
 
-Macro Tracker is an AGPLv3 nutrition and macro tracking application designed for self-hosting.
+MacroTrackr is an AGPLv3 nutrition and macro tracking application designed for self-hosting.
 
 The backend uses SQLite with local authentication and billing disabled by default.
 

--- a/TRADEMARK_POLICY.md
+++ b/TRADEMARK_POLICY.md
@@ -1,6 +1,6 @@
 # Trademark Policy
 
-"Macro Tracker" and related logos are trademarks of the project maintainers.
+"MacroTrackr" and related logos are trademarks of the project maintainers.
 
 This repository is licensed under AGPLv3, but trademark rights are not granted
 by that license.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,7 +7,7 @@ HOST=0.0.0.0
 DATABASE_PATH=./macrotrackr.db
 APP_URL=http://localhost:5173
 CORS_ORIGIN=http://localhost:5173
-PUBLIC_APP_NAME=Macro Tracker
+PUBLIC_APP_NAME=MacroTrackr
 SUPPORT_EMAIL=support@local.invalid
 
 # Enable only when a reverse proxy in front of the API overwrites X-Real-IP.

--- a/backend/docs/ALERTING.md
+++ b/backend/docs/ALERTING.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document defines alerting rules, escalation procedures, and runbooks for the Macro Tracker application.
+This document defines alerting rules, escalation procedures, and runbooks for the MacroTrackr application.
 
 ## Alert Channels
 

--- a/backend/docs/SLO.md
+++ b/backend/docs/SLO.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document defines the Service Level Objectives for the Macro Tracker application. SLOs are targets that define the expected level of service quality.
+This document defines the Service Level Objectives for the MacroTrackr application. SLOs are targets that define the expected level of service quality.
 
 ## Service Level Indicators (SLIs)
 

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -12,7 +12,7 @@ services:
       args:
         VITE_API_URL: "${VITE_API_URL:-}"
         VITE_APP_URL: "${VITE_APP_URL:-https://macrotrackr.com}"
-        VITE_PUBLIC_APP_NAME: "${VITE_PUBLIC_APP_NAME:-Macro Tracker}"
+        VITE_PUBLIC_APP_NAME: "${VITE_PUBLIC_APP_NAME:-MacroTrackr}"
         VITE_SUPPORT_EMAIL: "${VITE_SUPPORT_EMAIL:-support@local.invalid}"
         VITE_AUTH_MODE: "${VITE_AUTH_MODE:-clerk}"
         VITE_BILLING_MODE: "${VITE_BILLING_MODE:-managed}"

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,7 +4,7 @@
 # Leave empty to use same-origin `/api` (recommended for Docker Compose)
 VITE_API_URL=
 VITE_APP_URL=http://localhost:5173
-VITE_PUBLIC_APP_NAME=Macro Tracker
+VITE_PUBLIC_APP_NAME=MacroTrackr
 VITE_SUPPORT_EMAIL=support@local.invalid
 
 # --- Public Links (Optional) ---

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -17,7 +17,7 @@ COPY shared /shared
 
 ARG VITE_API_URL=
 ARG VITE_APP_URL=http://localhost:5173
-ARG VITE_PUBLIC_APP_NAME="Macro Tracker"
+ARG VITE_PUBLIC_APP_NAME="MacroTrackr"
 ARG VITE_SUPPORT_EMAIL=support@local.invalid
 ARG VITE_AUTH_MODE=local
 ARG VITE_BILLING_MODE=disabled

--- a/frontend/docs/COLOR_SYSTEM.md
+++ b/frontend/docs/COLOR_SYSTEM.md
@@ -1,6 +1,6 @@
 # Color System
 
-This documents the actual color system used in Macro Tracker, defined via Tailwind CSS 4's `@theme` directive in `src/style.css`.
+This documents the actual color system used in MacroTrackr, defined via Tailwind CSS 4's `@theme` directive in `src/style.css`.
 
 ## Overview
 

--- a/frontend/docs/DEPLOYMENT.md
+++ b/frontend/docs/DEPLOYMENT.md
@@ -9,7 +9,7 @@ Create a `frontend/.env` file (or provide equivalent CI env vars) with:
 ```env
 VITE_API_URL=http://localhost:3000
 VITE_APP_URL=http://localhost:5173
-VITE_PUBLIC_APP_NAME=Macro Tracker
+VITE_PUBLIC_APP_NAME=MacroTrackr
 VITE_SUPPORT_EMAIL=support@local.invalid
 
 # Runtime profile knobs

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,4 +1,4 @@
-# robots.txt for Macro Tracker
+# robots.txt for MacroTrackr
 User-agent: *
 Allow: /
 Disallow: /home


### PR DESCRIPTION
## Summary
- Standardizes `VITE_PUBLIC_APP_NAME` / `PUBLIC_APP_NAME` defaults to `MacroTrackr` across `docker-compose.build.yml`, `frontend/Dockerfile`, and `.env.example` files.
- Updates documentation and config references from `Macro Tracker` to `MacroTrackr`.

## Verification
- All tests passing (`vitest run`).
- Typecheck and ESLint + UI budget checks passing.