### PR TITLE
fix(ui): align home grid items to start to prevent empty space in add meal card

### DIFF
--- a/frontend/src/features/macroTracking/pages/HomePage.tsx
+++ b/frontend/src/features/macroTracking/pages/HomePage.tsx
@@ -329,7 +329,7 @@ export default function HomePage() {
         <div className="space-y-3.5 sm:space-y-6">
           {/* The day comes first. On a phone the summary is what the user
               opened the app to see; the form used to push it below the fold. */}
-          <div className="grid grid-cols-1 gap-3.5 sm:gap-5 md:grid-cols-6">
+          <div className="grid grid-cols-1 gap-3.5 sm:gap-5 md:grid-cols-6 md:items-start">
             <div className="flex h-full flex-col space-y-3.5 sm:space-y-5 md:order-2 md:col-span-2">
               {isLoading ? (
                 <DailySummaryLoadingSkeleton />


### PR DESCRIPTION
## Summary
- Adds `md:items-start` to the top grid on `HomePage` so the Add Meal card hugs its content naturally.
- Eliminates the empty gap at the bottom of the card when the date/time disclosure is collapsed, while keeping the clean collapsed default state intact.

## Verification
- All 124 Vitest test files pass (717 tests).
- Typecheck and ESLint + UI budget checks pass.