### PR TITLE
fix(compare): standardize competitor comparison row to monthly pricing

### DIFF
--- a/frontend/src/features/landing/comparisons/comparisonsCatalog.ts
+++ b/frontend/src/features/landing/comparisons/comparisonsCatalog.ts
@@ -53,7 +53,7 @@ export const MASTER_COMPARISON_MATRIX: readonly MasterComparisonRow[] = [
     myfitnesspal: "$19.99/mo",
     macrofactor: "$11.99/mo",
     cronometer: "$9.99/mo",
-    loseIt: "$39.99/yr",
+    loseIt: "$9.99/mo",
     highlight: true,
   },
   {


### PR DESCRIPTION
Standardize all values in the Cloud / Premium row of the comparison matrix to monthly equivalents (.99/mo for Lose It).