### PR TITLE
feat: add 1-click data importers, self-host app templates, and shareable macro snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ bun run typecheck
 bun run lint
 ```
 
+## 1-Click App Store Manifests & Homelab Templates
+
+MacroTrackr supports 1-click deployments across popular self-hosted homelab platforms:
+
+- **Unraid**: Community Applications template (`templates/unraid/macrotrackr.xml`)
+- **CasaOS / ZimaOS**: App Store manifest and compose (`templates/casaos/docker-compose.yml`, `templates/casaos/macrotrackr.json`)
+- **Umbrel**: Umbrel App Store package (`templates/umbrel/umbrel-app.yml`, `templates/umbrel/docker-compose.yml`)
+- **Cosmos Cloud**: ServApp template (`templates/cosmos/servapp.json`)
+- **TrueNAS SCALE**: Electric Eel / Dockge compose template (`templates/truenas/docker-compose.yml`)
+
+See the full [Self-Hosting & Templates Guide](docs/self-hosting.md) for detailed platform-specific installation steps, volume configuration, and environment parameters.
+
 ## Self-Hosting with Docker Compose
 
 This repository includes a self-host starter compose stack.

--- a/backend/src/modules/macros/entry-routes.ts
+++ b/backend/src/modules/macros/entry-routes.ts
@@ -3,6 +3,7 @@ import {
   safeExecute,
   safeQuery,
   safeQueryAll,
+  withTransaction,
   type MacroEntryRow,
 } from "../../lib/data/database";
 import { getLocalDate } from "../../lib/utils/dates";
@@ -17,6 +18,12 @@ import {
 } from "../../lib/http/mutation-contract";
 import { publishUserSyncEvent } from "../../lib/sync/eventBus";
 import { checkProStatus, FREE_TIER_LIMITS } from "../../middleware/clerk-guards";
+import { generateId } from "../../utils/id-generator";
+import {
+  normalizeDate,
+  normalizeTime,
+  parseImportFile,
+} from "./importer";
 import { MacroSchemas } from "./schemas";
 import {
   type MacroEntryResponse,
@@ -285,6 +292,146 @@ export const registerMacroEntryRoutes = (group: MacroRouteGroup) =>
         response: MacroSchemas.macroEntryResponse,
         detail: {
           summary: "Add a new macro entry for the user",
+          tags: ["Macros"],
+        },
+      },
+    )
+    .post(
+      "/import",
+      async (context: MacrosRouteContext) => {
+        const { db, body } = context;
+        const internalUserId = context.authenticatedUser.userId;
+
+        if (!internalUserId) {
+          throw new AuthenticationError("Authentication required.");
+        }
+
+        if (!body) {
+          throw new BadRequestError("Request body is required.");
+        }
+
+        const payload = body as {
+          source?: string;
+          entries?: Array<{
+            protein: number;
+            carbs: number;
+            fats: number;
+            mealType: "breakfast" | "lunch" | "dinner" | "snack";
+            mealName?: string;
+            entryDate: string;
+            entryTime?: string;
+            ingredients?: unknown[];
+          }>;
+          weightLogs?: Array<{
+            timestamp: string;
+            weight: number;
+          }>;
+          rawData?: string;
+        };
+
+        let entries = payload.entries ?? [];
+        let weightLogs = payload.weightLogs ?? [];
+
+        if (entries.length === 0 && weightLogs.length === 0 && payload.rawData) {
+          const parsed = parseImportFile(
+            payload.rawData,
+            payload.source as any,
+          );
+          entries = parsed.entries;
+          weightLogs = parsed.weightLogs;
+        }
+
+        if (entries.length === 0 && weightLogs.length === 0) {
+          throw new BadRequestError(
+            "No valid macro entries or weight logs found in import payload.",
+          );
+        }
+
+        const dates = new Set<string>();
+
+        withTransaction(db, () => {
+          if (entries.length > 0) {
+            const insertMacroStmt = db.prepare(
+              `INSERT INTO macro_entries (user_id, protein, carbs, fats, meal_type, meal_name, entry_date, entry_time, ingredients)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            );
+
+            for (const entry of entries) {
+              const ingredientsJson = entry.ingredients
+                ? JSON.stringify(entry.ingredients)
+                : null;
+              const date = normalizeDate(entry.entryDate) ?? entry.entryDate;
+              dates.add(date);
+              const time = normalizeTime(entry.entryTime, entry.mealType);
+              insertMacroStmt.run(
+                internalUserId,
+                Math.max(0, entry.protein),
+                Math.max(0, entry.carbs),
+                Math.max(0, entry.fats),
+                entry.mealType,
+                entry.mealName ?? "",
+                date,
+                time,
+                ingredientsJson,
+              );
+            }
+          }
+
+          if (weightLogs.length > 0) {
+            const insertWeightStmt = db.prepare(
+              `INSERT INTO weight_log (id, user_id, timestamp, weight)
+               VALUES (?, ?, ?, ?)`,
+            );
+
+            for (const wl of weightLogs) {
+              const date = normalizeDate(wl.timestamp) ?? wl.timestamp;
+              const dateOnly = date.split("T")[0];
+              if (dateOnly) {
+                dates.add(dateOnly);
+              }
+              const id = generateId("wl");
+              insertWeightStmt.run(id, internalUserId, date, wl.weight);
+            }
+          }
+        });
+
+        publishUserSyncEvent(internalUserId, "macros");
+        if (weightLogs.length > 0) {
+          publishUserSyncEvent(internalUserId, "goals");
+        }
+
+        const sortedDates = Array.from(dates).sort();
+        const dateRange =
+          sortedDates.length > 0 && sortedDates[0] && sortedDates[sortedDates.length - 1]
+            ? {
+                start: sortedDates[0],
+                end: sortedDates[sortedDates.length - 1]!,
+              }
+            : null;
+
+        return {
+          success: true,
+          importedCount: {
+            macros: entries.length,
+            weightLogs: weightLogs.length,
+          },
+          dateRange,
+          message: `Successfully imported ${entries.length} macro ${
+            entries.length === 1 ? "entry" : "entries"
+          }${
+            weightLogs.length > 0
+              ? ` and ${weightLogs.length} weight ${
+                  weightLogs.length === 1 ? "record" : "records"
+                }`
+              : ""
+          }.`,
+        };
+      },
+      {
+        body: MacroSchemas.importDataPayload,
+        response: MacroSchemas.importDataResponse,
+        detail: {
+          summary: "Bulk import macro entries and weight records",
           tags: ["Macros"],
         },
       },

--- a/backend/src/modules/macros/importer.ts
+++ b/backend/src/modules/macros/importer.ts
@@ -1,0 +1,567 @@
+// src/modules/macros/importer.ts
+
+export type ImportFormat =
+  | "myfitnesspal"
+  | "cronometer"
+  | "macrofactor"
+  | "loseit"
+  | "macrotrackr"
+  | "auto"
+  | "unknown";
+
+export interface ParsedMacroEntry {
+  protein: number;
+  carbs: number;
+  fats: number;
+  mealType: "breakfast" | "lunch" | "dinner" | "snack";
+  mealName?: string;
+  entryDate: string; // YYYY-MM-DD
+  entryTime?: string; // HH:MM:SS
+  ingredients?: unknown[];
+}
+
+export interface ParsedWeightLog {
+  timestamp: string; // YYYY-MM-DD or ISO
+  weight: number;
+}
+
+export interface ImportResult {
+  format: ImportFormat;
+  entries: ParsedMacroEntry[];
+  weightLogs: ParsedWeightLog[];
+  summary: {
+    totalMeals: number;
+    totalWeightLogs: number;
+    dateRange: {
+      start: string;
+      end: string;
+    } | null;
+    macroSummary: {
+      totalCalories: number;
+      avgDailyCalories: number;
+      avgDailyProtein: number;
+      avgDailyCarbs: number;
+      avgDailyFats: number;
+      uniqueDays: number;
+    };
+  };
+  errors?: string[];
+}
+
+export function parseCsv(text: string): string[][] {
+  const clean = text.replace(/^\uFEFF/, "");
+  const rows: string[][] = [];
+  let currentRow: string[] = [];
+  let currentField = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < clean.length; i++) {
+    const char = clean[i];
+    const nextChar = clean[i + 1];
+
+    if (inQuotes) {
+      if (char === '"') {
+        if (nextChar === '"') {
+          currentField += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        currentField += char;
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true;
+      } else if (char === ",") {
+        currentRow.push(currentField.trim());
+        currentField = "";
+      } else if (char === "\r") {
+        if (nextChar === "\n") {
+          i++;
+        }
+        currentRow.push(currentField.trim());
+        currentField = "";
+        if (currentRow.some((f) => f.length > 0)) {
+          rows.push(currentRow);
+        }
+        currentRow = [];
+      } else if (char === "\n") {
+        currentRow.push(currentField.trim());
+        currentField = "";
+        if (currentRow.some((f) => f.length > 0)) {
+          rows.push(currentRow);
+        }
+        currentRow = [];
+      } else {
+        currentField += char;
+      }
+    }
+  }
+
+  if (currentField.length > 0 || currentRow.length > 0) {
+    currentRow.push(currentField.trim());
+    if (currentRow.some((f) => f.length > 0)) {
+      rows.push(currentRow);
+    }
+  }
+
+  return rows;
+}
+
+export function normalizeDate(dateStr: unknown): string | null {
+  if (typeof dateStr !== "string" || !dateStr.trim()) return null;
+  const trimmed = dateStr.trim();
+
+  // YYYY-MM-DD or YYYY/MM/DD
+  const isoMatch = trimmed.match(/^(\d{4})[-/](\d{1,2})[-/](\d{1,2})/);
+  if (isoMatch && isoMatch[1] && isoMatch[2] && isoMatch[3]) {
+    const [, y, m, d] = isoMatch;
+    return `${y}-${m.padStart(2, "0")}-${d.padStart(2, "0")}`;
+  }
+
+  // MM/DD/YYYY or M/D/YYYY
+  const usMatch = trimmed.match(/^(\d{1,2})[-/](\d{1,2})[-/](\d{4})/);
+  if (usMatch && usMatch[1] && usMatch[2] && usMatch[3]) {
+    const [, m, d, y] = usMatch;
+    const num1 = parseInt(m, 10);
+    const num2 = parseInt(d, 10);
+    if (num1 > 12 && num2 <= 12) {
+      return `${y}-${d.padStart(2, "0")}-${m.padStart(2, "0")}`;
+    }
+    return `${y}-${m.padStart(2, "0")}-${d.padStart(2, "0")}`;
+  }
+
+  // Timestamp or Date.parse
+  const parsed = new Date(trimmed);
+  if (!isNaN(parsed.getTime())) {
+    const year = parsed.getUTCFullYear();
+    const month = String(parsed.getUTCMonth() + 1).padStart(2, "0");
+    const day = String(parsed.getUTCDate()).padStart(2, "0");
+    if (year >= 1990 && year <= 2100) {
+      return `${year}-${month}-${day}`;
+    }
+  }
+
+  return null;
+}
+
+export function normalizeMealType(
+  rawMealType?: unknown,
+): "breakfast" | "lunch" | "dinner" | "snack" {
+  if (typeof rawMealType !== "string" || !rawMealType.trim()) return "snack";
+  const lower = rawMealType.trim().toLowerCase();
+
+  if (lower.includes("break") || lower.includes("morning") || lower === "m1") {
+    return "breakfast";
+  }
+  if (lower.includes("lunch") || lower.includes("midday") || lower === "m2") {
+    return "lunch";
+  }
+  if (
+    lower.includes("din") ||
+    lower.includes("supper") ||
+    lower.includes("evening") ||
+    lower === "m3"
+  ) {
+    return "dinner";
+  }
+  return "snack";
+}
+
+export function normalizeTime(timeStr?: unknown, mealType?: string): string {
+  if (typeof timeStr === "string" && timeStr.trim()) {
+    const trimmed = timeStr.trim();
+    // 12-hour format e.g. 1:30 PM
+    const ampmMatch = trimmed.match(
+      /^(\d{1,2}):(\d{2})(?::(\d{2}))?\s*([aApP][mM])$/i,
+    );
+    if (ampmMatch && ampmMatch[1] && ampmMatch[2] && ampmMatch[4]) {
+      let hours = parseInt(ampmMatch[1], 10);
+      const minutes = ampmMatch[2];
+      const seconds = ampmMatch[3] || "00";
+      const isPm = ampmMatch[4].toLowerCase() === "pm";
+      if (isPm && hours < 12) hours += 12;
+      if (!isPm && hours === 12) hours = 0;
+      return `${String(hours).padStart(2, "0")}:${minutes}:${seconds}`;
+    }
+
+    // 24-hour format e.g. 14:30 or 14:30:00
+    const time24Match = trimmed.match(
+      /^([01]?\d|2[0-3]):([0-5]\d)(?::([0-5]\d))?$/,
+    );
+    if (time24Match && time24Match[1] && time24Match[2]) {
+      const hours = time24Match[1].padStart(2, "0");
+      const minutes = time24Match[2];
+      const seconds = time24Match[3] || "00";
+      return `${hours}:${minutes}:${seconds}`;
+    }
+  }
+
+  switch (mealType) {
+    case "breakfast":
+      return "08:00:00";
+    case "lunch":
+      return "12:30:00";
+    case "dinner":
+      return "18:30:00";
+    case "snack":
+    default:
+      return "15:00:00";
+  }
+}
+
+export function parseNumber(val: unknown, fallback = 0): number {
+  if (typeof val === "number") {
+    return isNaN(val) ? fallback : Math.max(0, val);
+  }
+  if (typeof val !== "string") return fallback;
+
+  const cleaned = val.replace(/,/g, "").replace(/[^\d.-]/g, "").trim();
+  const num = parseFloat(cleaned);
+  return isNaN(num) ? fallback : Math.max(0, Math.round(num * 10) / 10);
+}
+
+export function detectImportFormat(
+  content: string,
+  filename?: string,
+): ImportFormat {
+  const trimmed = content.trim();
+
+  // 1. Check if JSON
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (
+        parsed.source === "macrotrackr" ||
+        parsed.version === "1.0" ||
+        (Array.isArray(parsed) && parsed[0]?.mealType)
+      ) {
+        return "macrotrackr";
+      }
+      if (
+        parsed.source === "macrofactor" ||
+        parsed.foods ||
+        parsed.weights ||
+        parsed.macrofactor
+      ) {
+        return "macrofactor";
+      }
+      if (Array.isArray(parsed.entries) || Array.isArray(parsed)) {
+        return "macrotrackr";
+      }
+    } catch {
+      // not valid JSON, proceed to CSV check
+    }
+  }
+
+  // 2. CSV check
+  const rows = parseCsv(trimmed);
+  if (rows.length === 0 || !rows[0]) return "unknown";
+
+  const headerRow = rows[0].map((h) => h.toLowerCase().trim());
+  const headerString = headerRow.join(" ");
+
+  if (
+    headerString.includes("macrotrackr") ||
+    (headerRow.includes("meal type") &&
+      headerRow.includes("protein") &&
+      headerRow.includes("carbs"))
+  ) {
+    return "macrotrackr";
+  }
+
+  if (
+    headerRow.includes("type") &&
+    headerRow.includes("quantity") &&
+    headerRow.includes("units")
+  ) {
+    return "loseit";
+  }
+
+  if (
+    headerString.includes("cronometer") ||
+    headerRow.includes("energy (kcal)") ||
+    headerRow.includes("net carbs (g)") ||
+    (headerRow.includes("food name") && headerRow.includes("group"))
+  ) {
+    return "cronometer";
+  }
+
+  if (
+    headerString.includes("macrofactor") ||
+    (headerRow.includes("calories (kcal)") && headerRow.includes("meal"))
+  ) {
+    return "macrofactor";
+  }
+
+  if (
+    headerRow.includes("meal") &&
+    (headerRow.includes("fat (g)") ||
+      headerRow.includes("carbohydrates (g)") ||
+      headerRow.includes("calories"))
+  ) {
+    return "myfitnesspal";
+  }
+
+  if (filename) {
+    const fnLower = filename.toLowerCase();
+    if (fnLower.includes("myfitnesspal") || fnLower.includes("mfp"))
+      return "myfitnesspal";
+    if (fnLower.includes("cronometer")) return "cronometer";
+    if (fnLower.includes("macrofactor")) return "macrofactor";
+    if (fnLower.includes("loseit") || fnLower.includes("lose it"))
+      return "loseit";
+    if (fnLower.includes("macrotrackr")) return "macrotrackr";
+  }
+
+  return "unknown";
+}
+
+function computeSummary(
+  entries: ParsedMacroEntry[],
+  weightLogs: ParsedWeightLog[],
+): ImportResult["summary"] {
+  const dates = new Set<string>();
+  let totalCalories = 0;
+  let totalProtein = 0;
+  let totalCarbs = 0;
+  let totalFats = 0;
+
+  for (const entry of entries) {
+    dates.add(entry.entryDate);
+    const calories =
+      Math.round((entry.protein * 4 + entry.carbs * 4 + entry.fats * 9) * 10) /
+      10;
+    totalCalories += calories;
+    totalProtein += entry.protein;
+    totalCarbs += entry.carbs;
+    totalFats += entry.fats;
+  }
+
+  for (const wl of weightLogs) {
+    const d = wl.timestamp.split("T")[0];
+    if (d) {
+      dates.add(d);
+    }
+  }
+
+  const sortedDates = Array.from(dates).sort();
+  const dateRange =
+    sortedDates.length > 0 && sortedDates[0] && sortedDates[sortedDates.length - 1]
+      ? {
+          start: sortedDates[0],
+          end: sortedDates[sortedDates.length - 1]!,
+        }
+      : null;
+
+  const uniqueDays = Math.max(1, sortedDates.length);
+
+  return {
+    totalMeals: entries.length,
+    totalWeightLogs: weightLogs.length,
+    dateRange,
+    macroSummary: {
+      totalCalories: Math.round(totalCalories),
+      avgDailyCalories: Math.round(totalCalories / uniqueDays),
+      avgDailyProtein: Math.round((totalProtein / uniqueDays) * 10) / 10,
+      avgDailyCarbs: Math.round((totalCarbs / uniqueDays) * 10) / 10,
+      avgDailyFats: Math.round((totalFats / uniqueDays) * 10) / 10,
+      uniqueDays: sortedDates.length,
+    },
+  };
+}
+
+export function parseImportFile(
+  content: string,
+  formatOverride?: ImportFormat,
+  filename?: string,
+): ImportResult {
+  const detected =
+    formatOverride && formatOverride !== "auto" && formatOverride !== "unknown"
+      ? formatOverride
+      : detectImportFormat(content, filename);
+
+  const format = detected === "unknown" ? "macrotrackr" : detected;
+  const trimmed = content.trim();
+
+  // Try JSON first if format is JSON or content starts with { or [
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      return parseJsonImport(parsed, format);
+    } catch {
+      // fallback to CSV
+    }
+  }
+
+  return parseCsvImport(content, format);
+}
+
+function parseJsonImport(parsed: any, format: ImportFormat): ImportResult {
+  const entries: ParsedMacroEntry[] = [];
+  const weightLogs: ParsedWeightLog[] = [];
+  const errors: string[] = [];
+
+  // MacroTrackr JSON structure or top-level array
+  const rawEntries = Array.isArray(parsed)
+    ? parsed
+    : parsed.entries || parsed.foods || parsed.nutrition || parsed.meals || [];
+
+  const rawWeights = parsed.weightLogs || parsed.weights || parsed.weight || [];
+
+  if (Array.isArray(rawEntries)) {
+    for (const item of rawEntries) {
+      const entryDate = normalizeDate(item.entryDate || item.date || item.day);
+      if (!entryDate) continue;
+
+      const protein = parseNumber(item.protein);
+      const carbs = parseNumber(item.carbs ?? item.carbohydrates);
+      const fats = parseNumber(item.fats ?? item.fat);
+      const mealType = normalizeMealType(
+        item.mealType || item.meal || item.type || item.group,
+      );
+      const mealName = String(
+        item.mealName || item.name || item.foodName || item.title || "",
+      ).trim();
+      const entryTime = normalizeTime(item.entryTime || item.time, mealType);
+      const ingredients = Array.isArray(item.ingredients)
+        ? item.ingredients
+        : undefined;
+
+      entries.push({
+        protein,
+        carbs,
+        fats,
+        mealType,
+        mealName: mealName || undefined,
+        entryDate,
+        entryTime,
+        ingredients,
+      });
+    }
+  }
+
+  if (Array.isArray(rawWeights)) {
+    for (const item of rawWeights) {
+      const ts = normalizeDate(item.timestamp || item.date);
+      const w = parseNumber(item.weight || item.value);
+      if (ts && w > 0) {
+        weightLogs.push({
+          timestamp: ts,
+          weight: w,
+        });
+      }
+    }
+  }
+
+  return {
+    format,
+    entries,
+    weightLogs,
+    summary: computeSummary(entries, weightLogs),
+    errors: errors.length > 0 ? errors : undefined,
+  };
+}
+
+function parseCsvImport(content: string, format: ImportFormat): ImportResult {
+  const rows = parseCsv(content);
+  const entries: ParsedMacroEntry[] = [];
+  const weightLogs: ParsedWeightLog[] = [];
+  const errors: string[] = [];
+
+  if (rows.length < 2 || !rows[0]) {
+    return {
+      format,
+      entries: [],
+      weightLogs: [],
+      summary: computeSummary([], []),
+      errors: ["File is empty or contains only headers."],
+    };
+  }
+
+  const headers = rows[0].map((h) => h.toLowerCase().trim());
+
+  // Find column indices helper
+  const findCol = (...names: string[]): number => {
+    for (const name of names) {
+      const idx = headers.findIndex(
+        (h) => h === name.toLowerCase() || h.includes(name.toLowerCase()),
+      );
+      if (idx !== -1) return idx;
+    }
+    return -1;
+  };
+
+  const dateIdx = findCol("date", "day", "timestamp");
+  const timeIdx = findCol("time", "entry time");
+  const mealIdx = findCol("meal", "meal type", "type", "group");
+  const nameIdx = findCol("food name", "name", "food", "description", "note");
+  const proteinIdx = findCol("protein (g)", "protein");
+  const carbsIdx = findCol(
+    "carbohydrates (g)",
+    "net carbs (g)",
+    "carbs (g)",
+    "carbs",
+    "carbohydrates",
+  );
+  const fatIdx = findCol("fat (g)", "total fat (g)", "fat", "fats");
+  const weightIdx = findCol(
+    "weight (kg)",
+    "weight (lbs)",
+    "weight",
+    "metric weight",
+  );
+
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row || row.length === 0 || row.every((cell) => cell.trim() === "")) continue;
+
+    const rawDate = dateIdx !== -1 && row[dateIdx] !== undefined ? row[dateIdx] : undefined;
+    const entryDate = normalizeDate(rawDate);
+    if (!entryDate) continue;
+
+    const rawMeal = mealIdx !== -1 && row[mealIdx] !== undefined ? row[mealIdx] : undefined;
+    const mealType = normalizeMealType(rawMeal);
+
+    const mealName = (nameIdx !== -1 && row[nameIdx] !== undefined ? row[nameIdx] : "") || rawMeal || "";
+    const rawTime = timeIdx !== -1 && row[timeIdx] !== undefined ? row[timeIdx] : undefined;
+    const entryTime = normalizeTime(rawTime, mealType);
+
+    const protein = proteinIdx !== -1 && row[proteinIdx] !== undefined ? parseNumber(row[proteinIdx]) : 0;
+    const carbs = carbsIdx !== -1 && row[carbsIdx] !== undefined ? parseNumber(row[carbsIdx]) : 0;
+    const fats = fatIdx !== -1 && row[fatIdx] !== undefined ? parseNumber(row[fatIdx]) : 0;
+
+    // Check if row is purely a weight log entry
+    if (weightIdx !== -1 && row[weightIdx]) {
+      const weightVal = parseNumber(row[weightIdx]);
+      if (weightVal > 0) {
+        weightLogs.push({
+          timestamp: entryDate,
+          weight: weightVal,
+        });
+      }
+    }
+
+    // Only add macro entry if there are valid macros or meal info
+    if (protein > 0 || carbs > 0 || fats > 0 || mealName) {
+      entries.push({
+        protein,
+        carbs,
+        fats,
+        mealType,
+        mealName: mealName ? mealName.trim() : undefined,
+        entryDate,
+        entryTime,
+      });
+    }
+  }
+
+  return {
+    format,
+    entries,
+    weightLogs,
+    summary: computeSummary(entries, weightLogs),
+    errors: errors.length > 0 ? errors : undefined,
+  };
+}

--- a/backend/src/modules/macros/schemas.ts
+++ b/backend/src/modules/macros/schemas.ts
@@ -156,4 +156,44 @@ export const MacroSchemas = {
       rawQuantity: t.Optional(t.String()),
     })
   ),
+  importDataPayload: t.Object({
+    source: t.Optional(t.String()),
+    entries: t.Optional(
+      t.Array(
+        t.Object({
+          protein: MacroValueSchema,
+          carbs: MacroValueSchema,
+          fats: MacroValueSchema,
+          mealType: MealTypeSchema,
+          mealName: t.Optional(t.String()),
+          entryDate: DateSchema,
+          entryTime: t.Optional(t.String()),
+          ingredients: t.Optional(t.Nullable(t.Array(t.Unknown()))),
+        })
+      )
+    ),
+    weightLogs: t.Optional(
+      t.Array(
+        t.Object({
+          timestamp: t.String(),
+          weight: t.Number({ minimum: 0 }),
+        })
+      )
+    ),
+    rawData: t.Optional(t.String()),
+  }),
+  importDataResponse: t.Object({
+    success: t.Boolean(),
+    importedCount: t.Object({
+      macros: t.Number(),
+      weightLogs: t.Number(),
+    }),
+    dateRange: t.Nullable(
+      t.Object({
+        start: t.String(),
+        end: t.String(),
+      })
+    ),
+    message: t.String(),
+  }),
 };

--- a/backend/tests/contracts/macros.integration.test.ts
+++ b/backend/tests/contracts/macros.integration.test.ts
@@ -70,4 +70,83 @@ describe("Macros Module Integration", () => {
     });
     expect(body.macroTarget).not.toHaveProperty("protein_percentage");
   });
+
+  it("POST /api/macros/import imports structured entries and weight logs", async () => {
+    const payload = {
+      source: "macrotrackr",
+      entries: [
+        {
+          protein: 30,
+          carbs: 40,
+          fats: 10,
+          mealType: "breakfast",
+          mealName: "Oatmeal and Shake",
+          entryDate: "2026-07-01",
+          entryTime: "08:00:00",
+        },
+        {
+          protein: 45,
+          carbs: 60,
+          fats: 15,
+          mealType: "lunch",
+          mealName: "Chicken and Rice",
+          entryDate: "2026-07-01",
+          entryTime: "12:30:00",
+        },
+      ],
+      weightLogs: [
+        {
+          timestamp: "2026-07-01",
+          weight: 78.5,
+        },
+      ],
+    };
+
+    const res = await app.handle(
+      new Request("http://localhost/api/macros/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.importedCount.macros).toBe(2);
+    expect(body.importedCount.weightLogs).toBe(1);
+    expect(body.dateRange).toEqual({
+      start: "2026-07-01",
+      end: "2026-07-01",
+    });
+
+    const entriesCount = db
+      .prepare("SELECT COUNT(*) as count FROM macro_entries WHERE user_id = 1")
+      .get() as { count: number };
+    expect(entriesCount.count).toBe(2);
+
+    const weightCount = db
+      .prepare("SELECT COUNT(*) as count FROM weight_log WHERE user_id = 1")
+      .get() as { count: number };
+    expect(weightCount.count).toBe(1);
+  });
+
+  it("POST /api/macros/import parses raw CSV data automatically", async () => {
+    const rawCsv = `Date,Meal,Calories,Fat (g),Carbohydrates (g),Protein (g),Note
+2026-07-02,Breakfast,400,10,50,25,Pancakes
+2026-07-02,Dinner,600,20,40,40,Salmon`;
+
+    const res = await app.handle(
+      new Request("http://localhost/api/macros/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ rawData: rawCsv }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.importedCount.macros).toBe(2);
+  });
 });

--- a/backend/tests/macros/importer.test.ts
+++ b/backend/tests/macros/importer.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectImportFormat,
+  normalizeDate,
+  normalizeMealType,
+  normalizeTime,
+  parseCsv,
+  parseImportFile,
+} from "../../src/modules/macros/importer";
+
+describe("Importer CSV Tokenizer and Normalizers", () => {
+  it("parses CSV with quoted strings containing commas and newlines", () => {
+    const csv = `Date,Meal,"Food, Name",Calories\n2026-05-01,Breakfast,"Oatmeal, rolled",300`;
+    const rows = parseCsv(csv);
+    expect(rows.length).toBe(2);
+    expect(rows[0]).toEqual(["Date", "Meal", "Food, Name", "Calories"]);
+    expect(rows[1]).toEqual(["2026-05-01", "Breakfast", "Oatmeal, rolled", "300"]);
+  });
+
+  it("normalizes various date formats to YYYY-MM-DD", () => {
+    expect(normalizeDate("2026-05-01")).toBe("2026-05-01");
+    expect(normalizeDate("2026/05/01")).toBe("2026-05-01");
+    expect(normalizeDate("05/01/2026")).toBe("2026-05-01");
+    expect(normalizeDate("5/1/2026")).toBe("2026-05-01");
+    expect(normalizeDate("2026-05-01T14:30:00.000Z")).toBe("2026-05-01");
+    expect(normalizeDate("invalid-date")).toBeNull();
+  });
+
+  it("normalizes meal types accurately", () => {
+    expect(normalizeMealType("Breakfast")).toBe("breakfast");
+    expect(normalizeMealType("Morning Snack")).toBe("breakfast");
+    expect(normalizeMealType("Lunch")).toBe("lunch");
+    expect(normalizeMealType("Dinner")).toBe("dinner");
+    expect(normalizeMealType("Snacks")).toBe("snack");
+    expect(normalizeMealType("Late Night")).toBe("snack");
+  });
+
+  it("normalizes 12-hour and 24-hour time strings", () => {
+    expect(normalizeTime("1:30 PM")).toBe("13:30:00");
+    expect(normalizeTime("8:15 AM")).toBe("08:15:00");
+    expect(normalizeTime("14:45")).toBe("14:45:00");
+    expect(normalizeTime(undefined, "breakfast")).toBe("08:00:00");
+    expect(normalizeTime(undefined, "lunch")).toBe("12:30:00");
+    expect(normalizeTime(undefined, "dinner")).toBe("18:30:00");
+    expect(normalizeTime(undefined, "snack")).toBe("15:00:00");
+  });
+});
+
+describe("Format Auto-detection & Parsing", () => {
+  it("detects and parses MyFitnessPal CSV export", () => {
+    const mfpCsv = `Date,Meal,Calories,Fat (g),Carbohydrates (g),Protein (g),Note
+2026-06-01,Breakfast,450,15,45,30,Egg and toast
+2026-06-01,Lunch,600,20,50,40,Chicken salad
+2026-06-01,Dinner,700,25,60,45,Salmon and rice
+2026-06-01,Snacks,200,5,25,10,Greek yogurt`;
+
+    const format = detectImportFormat(mfpCsv);
+    expect(format).toBe("myfitnesspal");
+
+    const result = parseImportFile(mfpCsv);
+    expect(result.format).toBe("myfitnesspal");
+    expect(result.entries.length).toBe(4);
+    expect(result.entries[0]).toEqual({
+      protein: 30,
+      carbs: 45,
+      fats: 15,
+      mealType: "breakfast",
+      mealName: "Egg and toast",
+      entryDate: "2026-06-01",
+      entryTime: "08:00:00",
+    });
+    expect(result.summary.totalMeals).toBe(4);
+    expect(result.summary.dateRange).toEqual({
+      start: "2026-06-01",
+      end: "2026-06-01",
+    });
+  });
+
+  it("detects and parses Cronometer CSV export", () => {
+    const cronometerCsv = `Date,Time,Group,Food Name,Amount,Unit,Energy (kcal),Protein (g),Net Carbs (g),Fat (g)
+2026-06-02,08:30:00,Breakfast,Oatmeal with whey,1,serving,400,32,45,8
+2026-06-02,12:45:00,Lunch,Turkey wrap,1,wrap,550,42,50,15`;
+
+    const format = detectImportFormat(cronometerCsv);
+    expect(format).toBe("cronometer");
+
+    const result = parseImportFile(cronometerCsv);
+    expect(result.entries.length).toBe(2);
+    expect(result.entries[0].protein).toBe(32);
+    expect(result.entries[0].carbs).toBe(45);
+    expect(result.entries[0].fats).toBe(8);
+    expect(result.entries[0].entryTime).toBe("08:30:00");
+  });
+
+  it("detects and parses MacroFactor CSV and JSON export", () => {
+    const mfCsv = `Date,Time,Food Name,Calories (kcal),Protein (g),Fat (g),Carbs (g),Meal,Weight (lbs)
+2026-06-03,09:00:00,Scrambled Eggs,350,24,18,6,Breakfast,180.5
+2026-06-03,13:00:00,Steak Bowl,650,50,22,55,Lunch,`;
+
+    expect(detectImportFormat(mfCsv)).toBe("macrofactor");
+    const csvResult = parseImportFile(mfCsv);
+    expect(csvResult.entries.length).toBe(2);
+    expect(csvResult.weightLogs.length).toBe(1);
+    expect(csvResult.weightLogs[0]).toEqual({
+      timestamp: "2026-06-03",
+      weight: 180.5,
+    });
+
+    const mfJson = JSON.stringify({
+      source: "macrofactor",
+      foods: [
+        {
+          date: "2026-06-03",
+          time: "09:00:00",
+          name: "Scrambled Eggs",
+          protein: 24,
+          carbs: 6,
+          fat: 18,
+          meal: "Breakfast",
+        },
+      ],
+      weights: [{ date: "2026-06-03", weight: 180.5 }],
+    });
+
+    expect(detectImportFormat(mfJson)).toBe("macrofactor");
+    const jsonResult = parseImportFile(mfJson);
+    expect(jsonResult.entries.length).toBe(1);
+    expect(jsonResult.weightLogs.length).toBe(1);
+  });
+
+  it("detects and parses Lose It CSV export", () => {
+    const loseItCsv = `Date,Name,Type,Quantity,Units,Calories,Fat (g),Protein (g),Carbohydrates (g)
+06/04/2026,Protein Shake,Breakfast,1,scoop,150,2,30,3
+06/04/2026,Chicken Rice,Lunch,1,bowl,500,10,45,55`;
+
+    expect(detectImportFormat(loseItCsv)).toBe("loseit");
+    const result = parseImportFile(loseItCsv);
+    expect(result.entries.length).toBe(2);
+    expect(result.entries[0].mealName).toBe("Protein Shake");
+    expect(result.entries[0].mealType).toBe("breakfast");
+    expect(result.entries[0].protein).toBe(30);
+    expect(result.entries[0].carbs).toBe(3);
+    expect(result.entries[0].fats).toBe(2);
+    expect(result.entries[0].entryDate).toBe("2026-06-04");
+  });
+
+  it("detects and parses MacroTrackr native JSON export", () => {
+    const nativeJson = JSON.stringify({
+      version: "1.0",
+      source: "macrotrackr",
+      entries: [
+        {
+          protein: 35,
+          carbs: 50,
+          fats: 12,
+          mealType: "dinner",
+          mealName: "Salmon Bowl",
+          entryDate: "2026-06-05",
+          entryTime: "19:00:00",
+        },
+      ],
+      weightLogs: [
+        {
+          timestamp: "2026-06-05",
+          weight: 77.2,
+        },
+      ],
+    });
+
+    expect(detectImportFormat(nativeJson)).toBe("macrotrackr");
+    const result = parseImportFile(nativeJson);
+    expect(result.entries.length).toBe(1);
+    expect(result.weightLogs.length).toBe(1);
+    expect(result.entries[0].mealName).toBe("Salmon Bowl");
+  });
+});

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,171 @@
+# MacroTrackr Self-Hosting & 1-Click App Templates
+
+MacroTrackr is designed for effortless self-hosting on homelab servers, NAS appliances, and cloud VMs. It uses a lightweight SQLite database and local authentication without requiring external authentication providers or cloud services.
+
+---
+
+## 1-Click App Store Templates
+
+We provide ready-to-use manifests for popular homelab operating systems and container managers:
+
+| Platform | Manifest Path | Quick Install Method |
+| :--- | :--- | :--- |
+| **Unraid** | `templates/unraid/macrotrackr.xml` | Community Applications XML template |
+| **CasaOS / ZimaOS** | `templates/casaos/docker-compose.yml` | CasaOS Custom App / AppStore JSON |
+| **Umbrel** | `templates/umbrel/umbrel-app.yml` | Umbrel Community App Store / CLI |
+| **Cosmos Cloud** | `templates/cosmos/servapp.json` | Cosmos ServApp Import |
+| **TrueNAS SCALE** | `templates/truenas/docker-compose.yml` | Native Compose / Dockge |
+| **Docker Compose** | `docker-compose.yml` | Standard `docker compose up -d` |
+
+---
+
+## Platform Guides
+
+### 1. Unraid (Community Applications)
+
+1. Save the XML template file `templates/unraid/macrotrackr.xml` to `/boot/config/plugins/dockerMan/templates-user/my-MacroTrackr.xml` on your Unraid flash drive, or add it via Community Applications repository.
+2. In the Unraid WebUI, navigate to **Docker** > **Add Container** and select the **MacroTrackr** template.
+3. Configure the container parameters:
+   - **Host Port**: `5173` (or any available port on your Unraid server)
+   - **Appdata Storage Path**: `/mnt/user/appdata/macrotrackr/data` (mapped to `/data`)
+   - **APP_URL**: `http://<UNRAID-IP>:5173` (or your reverse-proxy domain)
+4. Click **Apply** to deploy.
+
+---
+
+### 2. CasaOS & ZimaOS
+
+#### Method A: Custom App Install (Compose)
+1. In your CasaOS dashboard, click **+** (Install a customized app).
+2. Click **Import** in the top right corner and paste the contents of `templates/casaos/docker-compose.yml`.
+3. Verify that the volume path points to `/DATA/AppData/macrotrackr/data`.
+4. Click **Submit** to install.
+
+#### Method B: CasaOS AppStore Manifest
+Add `templates/casaos/macrotrackr.json` to your custom CasaOS AppStore list.
+
+---
+
+### 3. Umbrel
+
+1. Clone or copy the `templates/umbrel` folder into your custom Umbrel app repository or to your Umbrel server at `~/umbrel/apps/macrotrackr/`:
+   ```bash
+   mkdir -p ~/umbrel/apps/macrotrackr
+   cp templates/umbrel/umbrel-app.yml ~/umbrel/apps/macrotrackr/umbrel-app.yml
+   cp templates/umbrel/docker-compose.yml ~/umbrel/apps/macrotrackr/docker-compose.yml
+   ```
+2. Umbrel automatically maps `${APP_DATA_DIR}/data` for persistent SQLite storage.
+3. Install and start the app via the Umbrel UI or CLI:
+   ```bash
+   umbrel app install macrotrackr
+   ```
+4. Access MacroTrackr at `http://umbrel.local:5173` or your configured Umbrel hostname.
+
+---
+
+### 4. Cosmos Cloud
+
+1. In the Cosmos UI, navigate to **ServApps** > **Import**.
+2. Paste the JSON from `templates/cosmos/servapp.json`.
+3. Cosmos SmartShield will automatically provision routes and SSL proxying to the frontend container port `80`.
+4. The database is persisted at `{DATA_PATH}/macrotrackr/data`.
+
+---
+
+### 5. TrueNAS SCALE (Electric Eel 24.10+ / Dockge)
+
+1. Navigate to **Apps** > **Discover Apps** > **Custom App** (or use Dockge).
+2. Select **Docker Compose** and paste `templates/truenas/docker-compose.yml`.
+3. Set your dataset volume mapping (e.g., `/mnt/tank/apps/macrotrackr/data:/data`).
+4. Ensure appropriate permissions on the dataset for UID `1000` / GID `1000`.
+5. Deploy the application.
+
+---
+
+### 6. Standard Docker Compose
+
+Run with the root `docker-compose.yml`:
+
+```bash
+mkdir -p data
+docker compose pull
+docker compose up -d
+```
+
+---
+
+## Environment Variables Reference
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `DATABASE_PATH` | `/data/macrotrackr.db` | Absolute path to SQLite database file |
+| `PORT` | `3000` | Internal backend HTTP port |
+| `HOST` | `0.0.0.0` | Binding IP address for the backend |
+| `APP_URL` | `http://localhost:5173` | Public URL for the frontend application |
+| `CORS_ORIGIN` | `http://localhost:5173` | Allowed CORS origin (comma-separated for multiples) |
+| `TRUST_PROXY` | `true` | Set `true` when behind reverse proxy for rate-limit client IP resolution |
+| `APP_MODE` | `self-hosted` | Set to `self-hosted` for standalone local deployment |
+| `AUTH_MODE` | `local` | Use `local` for built-in database auth |
+| `BILLING_MODE` | `disabled` | Set to `disabled` for self-hosted instances |
+| `ANALYTICS_MODE`| `disabled` | Set to `disabled` for zero telemetry |
+| `EMAIL_MODE` | `disabled` | Set to `disabled`, `smtp`, or `resend` |
+| `ENABLE_METRICS`| `false` | Enable Prometheus `/metrics` endpoint |
+| `METRICS_API_KEY` | *(optional)* | Shared secret for securing `/metrics` endpoint |
+
+### SMTP Configuration (Optional)
+
+If `EMAIL_MODE=smtp` is enabled:
+
+| Variable | Description |
+| :--- | :--- |
+| `SMTP_HOST` | SMTP server hostname |
+| `SMTP_PORT` | SMTP server port (e.g., `587` or `465`) |
+| `SMTP_USER` | SMTP authentication username |
+| `SMTP_PASS` | SMTP authentication password |
+| `SMTP_FROM` | Sender email address (`noreply@yourdomain.com`) |
+
+---
+
+## Storage & Permissions
+
+MacroTrackr stores all application data in a single SQLite database inside the `/data` container volume.
+
+- **Internal Directory**: `/data`
+- **Database File**: `/data/macrotrackr.db`
+- **User Permissions**: The backend container runs as non-root user `bun` (UID: `1000`, GID: `1000`).
+
+Ensure your host storage directory has write permissions:
+
+```bash
+mkdir -p ./data
+chown -R 1000:1000 ./data
+chmod 755 ./data
+```
+
+---
+
+## Reverse Proxy & SSL Setup
+
+When exposing MacroTrackr via HTTPS behind a reverse proxy (e.g. Nginx, Caddy, Traefik, NPM, Cloudflare Tunnels):
+
+1. Proxy traffic to the **frontend** service (port `80` internal / `5173` host).
+2. Set `APP_URL` and `CORS_ORIGIN` to your external HTTPS URL (e.g. `https://macros.example.com`).
+3. Ensure headers `Host`, `X-Real-IP`, `X-Forwarded-For`, and `X-Forwarded-Proto` are passed.
+4. Keep `TRUST_PROXY=true` in backend configuration so client IP-based rate limiting operates accurately.
+
+---
+
+## Backup and Migration
+
+### Backup
+```bash
+# Safely snapshot the SQLite database
+cp data/macrotrackr.db data/macrotrackr-$(date +%Y%m%d%H%M%S).db.bak
+```
+
+### Restore
+```bash
+docker compose down
+cp data/macrotrackr.db.bak data/macrotrackr.db
+docker compose up -d
+```

--- a/frontend/src/api/macros.ts
+++ b/frontend/src/api/macros.ts
@@ -271,4 +271,48 @@ export const macrosApi = {
 
     return null;
   },
+
+  /**
+   * Bulk import parsed or raw macro entries and weight records
+   * @throws {ApiError}
+   */
+  importData: async (payload: {
+    source?: string;
+    entries?: Array<{
+      protein: number;
+      carbs: number;
+      fats: number;
+      mealType: "breakfast" | "lunch" | "dinner" | "snack";
+      mealName?: string;
+      entryDate: string;
+      entryTime?: string;
+      ingredients?: unknown[];
+    }>;
+    weightLogs?: Array<{ timestamp: string; weight: number }>;
+    rawData?: string;
+  }): Promise<{
+    success: boolean;
+    importedCount: {
+      macros: number;
+      weightLogs: number;
+    };
+    dateRange: {
+      start: string;
+      end: string;
+    } | null;
+    message: string;
+  }> => {
+    return apiClient.post<{
+      success: boolean;
+      importedCount: {
+        macros: number;
+        weightLogs: number;
+      };
+      dateRange: {
+        start: string;
+        end: string;
+      } | null;
+      message: string;
+    }>("/api/macros/import", payload);
+  },
 };

--- a/frontend/src/components/chart/DateRangeSelector.tsx
+++ b/frontend/src/components/chart/DateRangeSelector.tsx
@@ -7,6 +7,7 @@ import {
   ExportIcon,
   IconButton,
   LockIcon,
+  ShareIcon,
   TabBar,
 } from "@/components/ui";
 import { DATE_RANGE_OPTIONS } from "@/components/utils";
@@ -16,6 +17,7 @@ interface DateRangeSelectorProps {
   currentRange: string;
   onRangeChange: (range: string) => void;
   onExportClick: () => void;
+  onShareClick?: () => void;
   isExportDisabled: boolean;
   disabledRanges?: string[];
   isPro?: boolean;
@@ -25,6 +27,7 @@ export default function DateRangeSelector({
   currentRange,
   onRangeChange,
   onExportClick,
+  onShareClick,
   isExportDisabled,
   disabledRanges = [],
   isPro = false,
@@ -81,8 +84,32 @@ export default function DateRangeSelector({
           )}
         </div>
 
-        {/* Export CSV Button aligned right on same line */}
-        <div className="shrink-0">
+        {/* Actions aligned right on same line */}
+        <div className="flex items-center gap-2 shrink-0">
+          {onShareClick && (
+            <>
+              <div className="flex md:hidden">
+                <IconButton
+                  variant="share"
+                  ariaLabel="Share macro snapshot"
+                  onClick={onShareClick}
+                  disabled={isExportDisabled}
+                />
+              </div>
+              <div className="hidden md:flex">
+                <Button
+                  onClick={onShareClick}
+                  disabled={isExportDisabled}
+                  ariaLabel="Share macro snapshot"
+                  variant="secondary"
+                  leftIcon={<ShareIcon size="sm" />}
+                >
+                  Share Snapshot
+                </Button>
+              </div>
+            </>
+          )}
+
           <div className="flex md:hidden">
             <IconButton
               variant="export"

--- a/frontend/src/components/metrics/UserMetricsPanel.tsx
+++ b/frontend/src/components/metrics/UserMetricsPanel.tsx
@@ -23,19 +23,18 @@ const LoadingSkeleton = memo(function LoadingSkeleton() {
           </div>
         ))}
       </div>
-      <div className="hidden sm:grid sm:grid-cols-2 sm:gap-4">
+      <div className="hidden sm:grid grid-cols-2 gap-3.5">
         {[0, 1].map((index) => (
           <div
             key={index}
-            className="animate-pulse rounded-card border border-border bg-surface p-5"
+            className="animate-pulse rounded-card border border-border bg-surface p-3"
           >
-            <div className="flex items-start gap-4">
-              <div className="h-11 w-11 shrink-0 rounded-card bg-surface-2" />
-              <div className="min-w-0 flex-1">
-                <div className="mb-2 h-4 w-16 rounded-control bg-surface-2" />
-                <div className="h-8 w-2/5 rounded-control bg-surface-2" />
-              </div>
+            <div className="mb-1 flex items-center justify-between">
+              <div className="h-3 w-12 rounded-control bg-surface-2" />
+              <div className="h-3.5 w-3.5 rounded-control bg-surface-2" />
             </div>
+            <div className="mb-1 h-6 w-20 rounded-control bg-surface-2" />
+            <div className="h-2.5 w-14 rounded-control bg-surface-2" />
           </div>
         ))}
       </div>
@@ -90,7 +89,7 @@ function UserMetricsPanel({
           spelling out "Basal Metabolic Rate (BMR)" in a third-width column.
           The acronyms are the names people actually use for these, and the
           subtitle says what they mean without competing for the line. */}
-      <div className="hidden sm:grid sm:grid-cols-2 sm:gap-4">
+      <div className="hidden sm:grid grid-cols-2 gap-3.5">
         {metrics.map(({ label, meaning, value, icon }) => (
           <MetricCard
             key={label}
@@ -100,6 +99,7 @@ function UserMetricsPanel({
             value={value || undefined}
             tone="primary"
             unit="kcal"
+            size="compact"
           />
         ))}
       </div>

--- a/frontend/src/components/ui/IconButton.tsx
+++ b/frontend/src/components/ui/IconButton.tsx
@@ -12,6 +12,7 @@ import {
   InfoIcon,
   MoreVerticalIcon,
   PlusIcon,
+  ShareIcon,
   TrashIcon,
   WarningIcon,
 } from "./Icons";
@@ -26,6 +27,7 @@ type ActionVariant =
   | "info"
   | "warning"
   | "export"
+  | "share"
   | "password-toggle"
   | "custom";
 
@@ -88,6 +90,11 @@ const getActionConfigs = () =>
       icon: ExportIcon,
       className:
         "text-foreground bg-success/10 border border-transparent hover:text-success hover:bg-success/20 hover:border-success/30 transition-colors duration-200",
+    },
+    share: {
+      icon: ShareIcon,
+      className:
+        "text-foreground bg-surface-2 border border-transparent hover:bg-surface-3 hover:border-border transition-colors duration-200",
     },
     custom: {
       icon: undefined,

--- a/frontend/src/components/ui/Icons.tsx
+++ b/frontend/src/components/ui/Icons.tsx
@@ -52,6 +52,7 @@ import {
   ScanBarcode,
   Search,
   Settings,
+  Share2,
   ShieldCheck,
   Sparkles,
   Star,
@@ -61,6 +62,7 @@ import {
   TrendingDown,
   TrendingUp,
   Unlock,
+  Upload,
   User,
   Wheat,
   X,
@@ -136,6 +138,8 @@ export const ReportingIcon = createIcon(BarChart2);
 export const SettingsIcon = createIcon(Settings);
 export const LogoutIcon = createIcon(LogOut);
 export const ExportIcon = createIcon(Download);
+export const UploadIcon = createIcon(Upload);
+export const ImportIcon = createIcon(Upload);
 export const WarningIcon = createIcon(AlertCircle);
 export const PlusCircleIcon = createIcon(PlusCircle);
 export const CalorieIcon = createIcon(Flame);
@@ -178,6 +182,8 @@ export const CopyIcon = createIcon(Copy);
 export const Link2Icon = createIcon(Link2);
 export const BarcodeIcon = createIcon(ScanBarcode);
 export const CameraIcon = createIcon(Camera);
+export const ShareIcon = createIcon(Share2);
+export const Share2Icon = createIcon(Share2);
 
 // Social Provider Icons
 const GOOGLE_BRAND_COLORS = {

--- a/frontend/src/components/ui/MetricCard.test.tsx
+++ b/frontend/src/components/ui/MetricCard.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import MetricCard from "@/components/ui/MetricCard";
+
+describe("MetricCard", () => {
+  it("renders title, value, unit, and subtitle in default mode", () => {
+    render(
+      <MetricCard
+        title="BMR"
+        value={1835}
+        unit="kcal"
+        subtitle="at rest"
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "BMR" })).toBeInTheDocument();
+    expect(screen.getByText("1,835")).toBeInTheDocument();
+    expect(screen.getByText("kcal")).toBeInTheDocument();
+    expect(screen.getByText("at rest")).toBeInTheDocument();
+  });
+
+  it("renders compact size without breaking layout", () => {
+    render(
+      <MetricCard
+        title="TDEE"
+        value={2202}
+        unit="kcal"
+        subtitle="with activity"
+        size="compact"
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "TDEE" })).toBeInTheDocument();
+    expect(screen.getByText("2,202")).toBeInTheDocument();
+    expect(screen.getByText("kcal")).toBeInTheDocument();
+    expect(screen.getByText("with activity")).toBeInTheDocument();
+  });
+
+  it("renders complete profile message when value is undefined", () => {
+    render(<MetricCard title="BMR" />);
+
+    expect(screen.getByText("Complete profile")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/MetricCard.tsx
+++ b/frontend/src/components/ui/MetricCard.tsx
@@ -38,6 +38,7 @@ export interface MetricCardProps {
   delay?: number;
   className?: string;
   children?: React.ReactNode;
+  size?: "default" | "compact";
 }
 
 const scoreToneClass = (score: number): string => {
@@ -60,12 +61,15 @@ function MetricCardInner({
   delay = 0,
   className,
   children,
+  size = "default",
 }: MetricCardProps) {
   const numericValue = useMemo(() => {
     if (value === undefined) return undefined;
 
     return typeof value === "number" ? value : Number.parseFloat(value);
   }, [value]);
+
+  const isCompact = size === "compact";
 
   return (
     <motion.div
@@ -74,10 +78,25 @@ function MetricCardInner({
       transition={{ duration: 0.2, delay }}
       className={cn("h-full", className)}
     >
-      <Panel className="flex h-full flex-col">
-        <div className="mb-2 flex items-start justify-between gap-2">
+      <Panel
+        padding={isCompact ? "none" : "regular"}
+        className={cn("flex h-full flex-col", isCompact && "p-3")}
+      >
+        <div
+          className={cn(
+            "flex items-start justify-between gap-2",
+            isCompact ? "mb-1" : "mb-2",
+          )}
+        >
           <div className="flex min-w-0 items-center gap-2">
-            <Heading level="panel" as="h3" className="truncate text-sm">
+            <Heading
+              level="panel"
+              as="h3"
+              className={cn(
+                "truncate",
+                isCompact ? "text-xs font-medium" : "text-sm",
+              )}
+            >
               {title}
             </Heading>
             {tooltipText ? <InfoTooltip text={tooltipText} /> : null}
@@ -85,7 +104,10 @@ function MetricCardInner({
           <div className="flex shrink-0 items-center gap-2">
             {Icon ? (
               <Icon
-                className={cn("h-4 w-4", TONE_TEXT[tone])}
+                className={cn(
+                  isCompact ? "h-3.5 w-3.5" : "h-4 w-4",
+                  TONE_TEXT[tone],
+                )}
                 strokeWidth={1.5}
               />
             ) : null}
@@ -99,30 +121,57 @@ function MetricCardInner({
         </div>
 
         {numericValue === undefined ? (
-          children ? null : <p className="text-sm text-muted">Complete profile</p>
+          children ? null : (
+            <p className="text-sm text-muted">Complete profile</p>
+          )
+        ) : isCompact ? (
+          <div className="flex items-baseline justify-between gap-2">
+            <p className="flex items-baseline gap-1">
+              <span className="text-xl font-light tracking-tight tabular-nums">
+                {animateValue ? (
+                  <AnimatedNumber
+                    value={numericValue}
+                    toFixedValue={0}
+                    duration={0.8}
+                  />
+                ) : (
+                  Math.round(numericValue).toLocaleString()
+                )}
+              </span>
+              {unit ? (
+                <span className="text-xs text-muted">{unit}</span>
+              ) : null}
+            </p>
+            {subtitle ? (
+              <span className="text-[11px] text-muted">{subtitle}</span>
+            ) : null}
+          </div>
         ) : (
-          <p className="flex items-baseline gap-1.5">
-            <span className="text-3xl font-light tracking-tight tabular-nums">
-              {animateValue ? (
-                <AnimatedNumber
-                  value={numericValue}
-                  toFixedValue={0}
-                  duration={0.8}
-                />
-              ) : (
-                Math.round(numericValue).toLocaleString()
-              )}
-            </span>
-            {unit ? <span className="text-sm text-muted">{unit}</span> : null}
-          </p>
+          <>
+            <p className="flex items-baseline gap-1.5">
+              <span className="text-3xl font-light tracking-tight tabular-nums">
+                {animateValue ? (
+                  <AnimatedNumber
+                    value={numericValue}
+                    toFixedValue={0}
+                    duration={0.8}
+                  />
+                ) : (
+                  Math.round(numericValue).toLocaleString()
+                )}
+              </span>
+              {unit ? (
+                <span className="text-sm text-muted">{unit}</span>
+              ) : null}
+            </p>
+            {/* The subtitle used to sit on the value's own line with `ml-auto`,
+                which pushed it hard right and wrapped it to two ragged lines in a
+                narrow card. It qualifies the number, so it belongs under it. */}
+            {subtitle ? (
+              <p className="mt-1 text-xs text-muted">{subtitle}</p>
+            ) : null}
+          </>
         )}
-
-        {/* The subtitle used to sit on the value's own line with `ml-auto`,
-            which pushed it hard right and wrapped it to two ragged lines in a
-            narrow card. It qualifies the number, so it belongs under it. */}
-        {subtitle && numericValue !== undefined ? (
-          <p className="mt-1 text-xs text-muted">{subtitle}</p>
-        ) : null}
 
         {children ? (
           <div className="flex flex-1 flex-col justify-between">{children}</div>

--- a/frontend/src/features/macroTracking/components/DailySummaryPanel.tsx
+++ b/frontend/src/features/macroTracking/components/DailySummaryPanel.tsx
@@ -1,14 +1,18 @@
-import { memo, useMemo } from "react";
+import { memo, useMemo, useState } from "react";
 
 import {
   MacroDistributionBar,
   MacroTargetLegend,
 } from "@/components/macros/MacroComponents";
 import Heading from "@/components/ui/Heading";
+import IconButton from "@/components/ui/IconButton";
 import Panel from "@/components/ui/Panel";
 import ProgressBar from "@/components/ui/ProgressBar";
 import Value from "@/components/ui/Value";
+import MacroSnapshotModal from "@/features/macroTracking/components/MacroSnapshotModal";
+import type { MacroSnapshotData } from "@/features/macroTracking/utils/macroSnapshotCanvas";
 import { MacroDailyTotals, MacroTargetSettings } from "@/types/macro";
+import { getDisplayDate } from "@/utils/dateUtilities";
 
 import {
   calculateCaloriesFromMacros,
@@ -49,6 +53,7 @@ function DailySummaryInner({
   macroTarget,
   calorieTarget,
 }: DailySummaryProps) {
+  const [isSnapshotOpen, setIsSnapshotOpen] = useState(false);
   const safeTotal = macroDailyTotals ?? EMPTY_TOTALS;
   const target = macroTarget ?? DEFAULT_TARGET;
   const dailyCalorieTarget = calorieTarget ?? 0;
@@ -172,16 +177,52 @@ function DailySummaryInner({
     ],
   );
 
+  const snapshotData: MacroSnapshotData = useMemo(
+    () => ({
+      title: "Today's Macros",
+      dateLabel: getDisplayDate(new Date()),
+      calories: macroCalories.total,
+      calorieTarget: dailyCalorieTarget,
+      protein: safeTotal.protein,
+      proteinTarget: targetGrams.protein,
+      carbs: safeTotal.carbs,
+      carbsTarget: targetGrams.carbs,
+      fats: safeTotal.fats,
+      fatsTarget: targetGrams.fats,
+      complianceScore: completionPercentages.calories,
+    }),
+    [
+      macroCalories.total,
+      dailyCalorieTarget,
+      safeTotal.protein,
+      targetGrams.protein,
+      safeTotal.carbs,
+      targetGrams.carbs,
+      safeTotal.fats,
+      targetGrams.fats,
+      completionPercentages.calories,
+    ],
+  );
+
   return (
     <Panel padding="none" className="flex h-full flex-col">
       {/* One idea — calories, then its macro breakdown — so one panel, split by
           dividers. It used to be six bordered boxes. */}
       <div className="p-4 sm:p-6">
-        <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center justify-between gap-3">
           <Heading level="panel">Today</Heading>
-          <span className="text-xs text-muted">
-            {completionPercentages.calories}% of target
-          </span>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted">
+              {completionPercentages.calories}% of target
+            </span>
+            <IconButton
+              variant="share"
+              buttonSize="sm"
+              iconSize="sm"
+              ariaLabel="Share Snapshot"
+              onClick={() => setIsSnapshotOpen(true)}
+            />
+          </div>
         </div>
 
         {/* The one animated number on the page: the value that moves. */}
@@ -252,6 +293,12 @@ function DailySummaryInner({
           </div>
         ))}
       </div>
+
+      <MacroSnapshotModal
+        isOpen={isSnapshotOpen}
+        onClose={() => setIsSnapshotOpen(false)}
+        data={snapshotData}
+      />
     </Panel>
   );
 }

--- a/frontend/src/features/macroTracking/components/MacroSnapshotModal.test.tsx
+++ b/frontend/src/features/macroTracking/components/MacroSnapshotModal.test.tsx
@@ -1,0 +1,202 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as canvasUtils from "@/features/macroTracking/utils/macroSnapshotCanvas";
+import { useStore } from "@/store/store";
+
+import MacroSnapshotModal from "./MacroSnapshotModal";
+
+const mockSnapshotData: canvasUtils.MacroSnapshotData = {
+  title: "Today's Macros",
+  dateLabel: "Oct 24, 2026",
+  calories: 2150,
+  calorieTarget: 2400,
+  protein: 165,
+  proteinTarget: 180,
+  carbs: 220,
+  carbsTarget: 230,
+  fats: 60,
+  fatsTarget: 70,
+  streakDays: 7,
+  complianceScore: 92,
+};
+
+describe("MacroSnapshotModal", () => {
+  const showNotificationMock = vi.fn();
+
+  beforeEach(() => {
+    let modalRoot = document.querySelector("#modal-root");
+    if (!modalRoot) {
+      modalRoot = document.createElement("div");
+      modalRoot.setAttribute("id", "modal-root");
+      document.body.appendChild(modalRoot);
+    }
+
+    useStore.setState({
+      showNotification: showNotificationMock,
+    });
+
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders scorecard with title, date, calories, and macronutrients", () => {
+    render(
+      <MacroSnapshotModal
+        isOpen
+        onClose={vi.fn()}
+        data={mockSnapshotData}
+      />,
+    );
+
+    expect(screen.getByText("Share Macro Snapshot")).toBeInTheDocument();
+    expect(screen.getByText("Today's Macros")).toBeInTheDocument();
+    expect(screen.getByText("Oct 24, 2026")).toBeInTheDocument();
+    expect(screen.getByText("Total Calories")).toBeInTheDocument();
+    expect(screen.getByText("2,150")).toBeInTheDocument();
+    expect(screen.getByText("165g")).toBeInTheDocument();
+    expect(screen.getByText("220g")).toBeInTheDocument();
+    expect(screen.getByText("60g")).toBeInTheDocument();
+  });
+
+  it("displays streak badge when streakDays is provided", () => {
+    render(
+      <MacroSnapshotModal
+        isOpen
+        onClose={vi.fn()}
+        data={mockSnapshotData}
+      />,
+    );
+
+    const badge = screen.getByTestId("snapshot-badge");
+    expect(badge).toHaveTextContent("🔥 7-Day Streak");
+  });
+
+  it("displays compliance badge when custom badgeLabel is provided", () => {
+    render(
+      <MacroSnapshotModal
+        isOpen
+        onClose={vi.fn()}
+        data={{
+          ...mockSnapshotData,
+          streakDays: undefined,
+          badgeLabel: "⚡ 95% Weekly Compliance",
+        }}
+      />,
+    );
+
+    const badge = screen.getByTestId("snapshot-badge");
+    expect(badge).toHaveTextContent("⚡ 95% Weekly Compliance");
+  });
+
+  it("calls downloadSnapshotImage when Download PNG button is clicked", async () => {
+    const downloadSpy = vi
+      .spyOn(canvasUtils, "downloadSnapshotImage")
+      .mockResolvedValue(undefined);
+
+    render(
+      <MacroSnapshotModal
+        isOpen
+        onClose={vi.fn()}
+        data={mockSnapshotData}
+      />,
+    );
+
+    const downloadButton = screen.getByRole("button", {
+      name: /download image snapshot/i,
+    });
+    fireEvent.click(downloadButton);
+
+    await waitFor(() => {
+      expect(downloadSpy).toHaveBeenCalledWith(mockSnapshotData);
+      expect(showNotificationMock).toHaveBeenCalledWith(
+        "Scorecard downloaded successfully!",
+        "success",
+      );
+    });
+  });
+
+  it("calls copySnapshotToClipboard and shows notification when Copy Image is clicked", async () => {
+    // Mock navigator.clipboard
+    Object.assign(navigator, {
+      clipboard: {
+        write: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+
+    const copySpy = vi
+      .spyOn(canvasUtils, "copySnapshotToClipboard")
+      .mockResolvedValue(true);
+
+    render(
+      <MacroSnapshotModal
+        isOpen
+        onClose={vi.fn()}
+        data={mockSnapshotData}
+      />,
+    );
+
+    const copyButton = screen.getByRole("button", {
+      name: /copy image to clipboard/i,
+    });
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(copySpy).toHaveBeenCalledWith(mockSnapshotData);
+      expect(showNotificationMock).toHaveBeenCalledWith(
+        "Scorecard copied to clipboard!",
+        "success",
+      );
+    });
+  });
+
+  it("calls shareSnapshot when Share button is clicked", async () => {
+    // Mock navigator.share
+    Object.assign(navigator, {
+      share: vi.fn().mockResolvedValue(undefined),
+      canShare: vi.fn().mockReturnValue(true),
+    });
+
+    const shareSpy = vi
+      .spyOn(canvasUtils, "shareSnapshot")
+      .mockResolvedValue(true);
+
+    render(
+      <MacroSnapshotModal
+        isOpen
+        onClose={vi.fn()}
+        data={mockSnapshotData}
+      />,
+    );
+
+    const shareButton = screen.getByRole("button", {
+      name: /share snapshot/i,
+    });
+    fireEvent.click(shareButton);
+
+    await waitFor(() => {
+      expect(shareSpy).toHaveBeenCalledWith(mockSnapshotData);
+    });
+  });
+
+  it("calls onClose when Done button is clicked", () => {
+    const onCloseMock = vi.fn();
+    render(
+      <MacroSnapshotModal
+        isOpen
+        onClose={onCloseMock}
+        data={mockSnapshotData}
+      />,
+    );
+
+    const doneButton = screen.getByRole("button", {
+      name: /^done$/i,
+    });
+    fireEvent.click(doneButton);
+
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/macroTracking/components/MacroSnapshotModal.tsx
+++ b/frontend/src/features/macroTracking/components/MacroSnapshotModal.tsx
@@ -1,0 +1,379 @@
+import { memo, useMemo, useState } from "react";
+
+import BrandMark from "@/components/layout/BrandMark";
+import Button from "@/components/ui/Button";
+import {
+  CheckIcon,
+  CopyIcon,
+  ExportIcon,
+  ShareIcon,
+  SparklesIcon,
+} from "@/components/ui/Icons";
+import Modal from "@/components/ui/Modal";
+import ProgressBar from "@/components/ui/ProgressBar";
+import Value from "@/components/ui/Value";
+import {
+  copySnapshotToClipboard,
+  downloadSnapshotImage,
+  MacroSnapshotData,
+  shareSnapshot,
+} from "@/features/macroTracking/utils/macroSnapshotCanvas";
+import { useStore } from "@/store/store";
+
+export interface MacroSnapshotModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  data: MacroSnapshotData;
+}
+
+function MacroSnapshotModalInner({
+  isOpen,
+  onClose,
+  data,
+}: MacroSnapshotModalProps) {
+  const { showNotification } = useStore();
+  const [isExporting, setIsExporting] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const cal = Math.round(data.calories);
+  const targetCal = Math.round(data.calorieTarget) || 2000;
+  const calPercent = Math.min(100, Math.round((cal / targetCal) * 100));
+
+  const proteinG = Math.round(data.protein);
+  const proteinTargetG = Math.round(data.proteinTarget) || 150;
+  const proteinPercent = Math.min(
+    100,
+    Math.round((proteinG / proteinTargetG) * 100),
+  );
+
+  const carbsG = Math.round(data.carbs);
+  const carbsTargetG = Math.round(data.carbsTarget) || 200;
+  const carbsPercent = Math.min(100, Math.round((carbsG / carbsTargetG) * 100));
+
+  const fatsG = Math.round(data.fats);
+  const fatsTargetG = Math.round(data.fatsTarget) || 65;
+  const fatsPercent = Math.min(100, Math.round((fatsG / fatsTargetG) * 100));
+
+  const macroCalories = useMemo(() => {
+    const pCals = proteinG * 4;
+    const cCals = carbsG * 4;
+    const fCals = fatsG * 9;
+    const total = pCals + cCals + fCals;
+    if (total === 0) {
+      return { pCals: 0, cCals: 0, fCals: 0, pRatio: 30, cRatio: 45, fRatio: 25 };
+    }
+    const pRatio = Math.round((pCals / total) * 100);
+    const cRatio = Math.round((cCals / total) * 100);
+    const fRatio = Math.max(0, 100 - pRatio - cRatio);
+    return { pCals, cCals, fCals, pRatio, cRatio, fRatio };
+  }, [proteinG, carbsG, fatsG]);
+
+  const badgeText = useMemo(() => {
+    if (data.badgeLabel) return data.badgeLabel;
+    if (data.streakDays && data.streakDays > 0) {
+      return `🔥 ${data.streakDays}-Day Streak`;
+    }
+    if (data.complianceScore) {
+      return `🎯 ${data.complianceScore}% Compliance`;
+    }
+    return `${calPercent}% of Goal`;
+  }, [data.badgeLabel, data.streakDays, data.complianceScore, calPercent]);
+
+  const canShare = typeof navigator !== "undefined" && typeof navigator.share === "function";
+  const canCopy = typeof navigator !== "undefined" && Boolean(navigator.clipboard?.write);
+
+  const handleDownload = async () => {
+    try {
+      setIsExporting(true);
+      await downloadSnapshotImage(data);
+      showNotification("Scorecard downloaded successfully!", "success");
+    } catch {
+      showNotification("Failed to download image scorecard.", "error");
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    try {
+      setIsExporting(true);
+      await copySnapshotToClipboard(data);
+      setCopied(true);
+      showNotification("Scorecard copied to clipboard!", "success");
+      setTimeout(() => setCopied(false), 2500);
+    } catch {
+      showNotification("Could not copy image to clipboard in this browser.", "error");
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const handleShare = async () => {
+    try {
+      setIsExporting(true);
+      await shareSnapshot(data);
+    } catch (error) {
+      // User cancelling share is not an error
+      if (error instanceof Error && error.name === "AbortError") {
+        return;
+      }
+      showNotification("Sharing failed or was cancelled.", "error");
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Share Macro Snapshot"
+      variant="form"
+      hideDefaultButtons
+      size="lg"
+    >
+      <div className="space-y-4">
+        {/* Visual Scorecard Preview Card */}
+        <div
+          data-testid="snapshot-scorecard"
+          className="relative overflow-hidden rounded-card border border-border bg-surface p-4"
+        >
+          {/* Top Brand Header */}
+          <div className="flex items-center justify-between gap-3 border-b border-border pb-3">
+            <div className="flex items-center gap-2">
+              <div className="flex h-7 w-7 items-center justify-center rounded-control bg-primary text-background">
+                <BrandMark className="h-4 w-4 fill-current text-background" />
+              </div>
+              <span className="text-sm font-bold tracking-tight text-foreground">
+                MacroTrackr
+              </span>
+            </div>
+
+            <div
+              data-testid="snapshot-badge"
+              className="flex items-center gap-1.5 rounded-full border border-border bg-surface-2 px-2.5 py-0.5 text-xs font-semibold text-primary"
+            >
+              <span>{badgeText}</span>
+            </div>
+          </div>
+
+          {/* Title & Date */}
+          <div className="mt-3 flex items-baseline justify-between gap-2">
+            <div>
+              <p className="text-xs font-medium uppercase tracking-wider text-muted">
+                {data.title ?? "Daily Summary"}
+              </p>
+              <h4 className="text-base font-bold text-foreground">
+                {data.dateLabel ?? "Today's Nutrition Snapshot"}
+              </h4>
+            </div>
+            <span className="text-xs text-muted">
+              {calPercent}% target
+            </span>
+          </div>
+
+          {/* Calorie Hero Card */}
+          <div className="mt-3 rounded-card border border-border bg-surface-2 p-3.5">
+            <div className="flex items-baseline justify-between gap-2">
+              <span className="text-xs font-medium uppercase tracking-wider text-muted">
+                Total Calories
+              </span>
+              <span className="text-xs text-muted">
+                Goal: {targetCal.toLocaleString()} kcal
+              </span>
+            </div>
+
+            <div className="mt-1 flex items-baseline gap-2">
+              <Value
+                size="hero"
+                unit="kcal"
+                value={cal}
+                suffix={`/ ${targetCal.toLocaleString()}`}
+              />
+            </div>
+
+            <ProgressBar
+              progress={calPercent}
+              color="accent"
+              height="md"
+              className="mt-2.5"
+            />
+          </div>
+
+          {/* Macronutrient Breakdown: 3 Columns */}
+          <div className="mt-3 grid grid-cols-3 gap-2">
+            {/* Protein */}
+            <div className="rounded-card border border-border bg-surface-2 p-2.5">
+              <div className="flex items-center gap-1.5">
+                <span className="h-2 w-2 rounded-full bg-protein" />
+                <span className="text-xs font-semibold text-protein">Protein</span>
+              </div>
+              <div className="mt-1.5">
+                <span className="text-lg font-bold text-foreground tabular-nums">
+                  {proteinG}g
+                </span>
+                <span className="block text-xs text-muted">
+                  of {proteinTargetG}g
+                </span>
+              </div>
+              <ProgressBar
+                progress={proteinPercent}
+                color="protein"
+                height="sm"
+                className="mt-2"
+              />
+              <span className="mt-1 block text-xs text-muted">
+                {macroCalories.pRatio}% kcal
+              </span>
+            </div>
+
+            {/* Carbs */}
+            <div className="rounded-card border border-border bg-surface-2 p-2.5">
+              <div className="flex items-center gap-1.5">
+                <span className="h-2 w-2 rounded-full bg-carbs" />
+                <span className="text-xs font-semibold text-carbs">Carbs</span>
+              </div>
+              <div className="mt-1.5">
+                <span className="text-lg font-bold text-foreground tabular-nums">
+                  {carbsG}g
+                </span>
+                <span className="block text-xs text-muted">
+                  of {carbsTargetG}g
+                </span>
+              </div>
+              <ProgressBar
+                progress={carbsPercent}
+                color="carbs"
+                height="sm"
+                className="mt-2"
+              />
+              <span className="mt-1 block text-xs text-muted">
+                {macroCalories.cRatio}% kcal
+              </span>
+            </div>
+
+            {/* Fats */}
+            <div className="rounded-card border border-border bg-surface-2 p-2.5">
+              <div className="flex items-center gap-1.5">
+                <span className="h-2 w-2 rounded-full bg-fats" />
+                <span className="text-xs font-semibold text-fats">Fats</span>
+              </div>
+              <div className="mt-1.5">
+                <span className="text-lg font-bold text-foreground tabular-nums">
+                  {fatsG}g
+                </span>
+                <span className="block text-xs text-muted">
+                  of {fatsTargetG}g
+                </span>
+              </div>
+              <ProgressBar
+                progress={fatsPercent}
+                color="fats"
+                height="sm"
+                className="mt-2"
+              />
+              <span className="mt-1 block text-xs text-muted">
+                {macroCalories.fRatio}% kcal
+              </span>
+            </div>
+          </div>
+
+          {/* Calorie Macro Distribution Strip */}
+          <div className="mt-3 rounded-card border border-border bg-surface-2 p-2.5">
+            <div className="flex items-center justify-between text-xs text-muted">
+              <span className="font-medium uppercase tracking-wider">
+                Distribution Split
+              </span>
+              <div className="flex items-center gap-2 font-medium text-foreground">
+                <span className="text-protein">{macroCalories.pRatio}% P</span>
+                <span>•</span>
+                <span className="text-carbs">{macroCalories.cRatio}% C</span>
+                <span>•</span>
+                <span className="text-fats">{macroCalories.fRatio}% F</span>
+              </div>
+            </div>
+
+            <div className="relative mt-2 h-2 w-full overflow-hidden rounded-full bg-surface-3">
+              <div
+                className="absolute top-0 left-0 h-full bg-protein"
+                style={{ width: `${macroCalories.pRatio}%` }}
+              />
+              <div
+                className="absolute top-0 h-full bg-carbs"
+                style={{
+                  width: `${macroCalories.cRatio}%`,
+                  left: `${macroCalories.pRatio}%`,
+                }}
+              />
+              <div
+                className="absolute top-0 h-full bg-fats"
+                style={{
+                  width: `${macroCalories.fRatio}%`,
+                  left: `${macroCalories.pRatio + macroCalories.cRatio}%`,
+                }}
+              />
+            </div>
+          </div>
+
+          {/* Scorecard Footer */}
+          <div className="mt-3 flex items-center justify-between pt-1 text-xs text-muted">
+            <span className="flex items-center gap-1">
+              <SparklesIcon size="sm" className="text-primary" />
+              Verified Nutrition Log
+            </span>
+            <span>macrotrackr.com</span>
+          </div>
+        </div>
+
+        {/* Action Buttons */}
+        <div className="flex flex-wrap items-center justify-end gap-2 pt-2">
+          {canShare && (
+            <Button
+              variant="primary"
+              onClick={handleShare}
+              disabled={isExporting}
+              isLoading={isExporting}
+              leftIcon={<ShareIcon size="sm" />}
+              ariaLabel="Share Snapshot"
+            >
+              Share
+            </Button>
+          )}
+
+          {canCopy && (
+            <Button
+              variant="secondary"
+              onClick={handleCopy}
+              disabled={isExporting}
+              leftIcon={copied ? <CheckIcon size="sm" /> : <CopyIcon size="sm" />}
+              ariaLabel="Copy Image to Clipboard"
+            >
+              {copied ? "Copied!" : "Copy Image"}
+            </Button>
+          )}
+
+          <Button
+            variant={canShare ? "secondary" : "primary"}
+            onClick={handleDownload}
+            disabled={isExporting}
+            leftIcon={<ExportIcon size="sm" />}
+            ariaLabel="Download Image Snapshot"
+          >
+            Download PNG
+          </Button>
+
+          <Button
+            variant="ghost"
+            onClick={onClose}
+            ariaLabel="Done"
+          >
+            Done
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+const MacroSnapshotModal = memo(MacroSnapshotModalInner);
+export default MacroSnapshotModal;

--- a/frontend/src/features/macroTracking/components/index.ts
+++ b/frontend/src/features/macroTracking/components/index.ts
@@ -3,5 +3,6 @@ export { default as BarcodeScannerModal } from "./BarcodeScannerModal";
 export { default as DailySummaryPanel } from "./DailySummaryPanel";
 export { default as EditModal } from "./EditModal";
 export { default as EntryHistoryPanel } from "./EntryHistoryPanel";
+export { default as MacroSnapshotModal } from "./MacroSnapshotModal";
 export { default as SavedMealButton } from "./SavedMealButton";
 export { default as SavedMealsList } from "./SavedMealsList";

--- a/frontend/src/features/macroTracking/pages/HomePage.tsx
+++ b/frontend/src/features/macroTracking/pages/HomePage.tsx
@@ -330,7 +330,7 @@ export default function HomePage() {
           {/* The day comes first. On a phone the summary is what the user
               opened the app to see; the form used to push it below the fold. */}
           <div className="grid grid-cols-1 gap-3.5 sm:gap-5 md:grid-cols-6 md:items-start">
-            <div className="flex h-full flex-col space-y-3.5 sm:space-y-5 md:order-2 md:col-span-2">
+            <div className="flex h-full flex-col space-y-3.5 md:order-2 md:col-span-2">
               {isLoading ? (
                 <DailySummaryLoadingSkeleton />
               ) : (

--- a/frontend/src/features/macroTracking/utils/index.ts
+++ b/frontend/src/features/macroTracking/utils/index.ts
@@ -3,4 +3,5 @@
  */
 
 export * from "./historyExport";
+export * from "./macroSnapshotCanvas";
 export * from "./units";

--- a/frontend/src/features/macroTracking/utils/macroSnapshotCanvas.test.ts
+++ b/frontend/src/features/macroTracking/utils/macroSnapshotCanvas.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  canvasToBlob,
+  copySnapshotToClipboard,
+  downloadSnapshotImage,
+  MacroSnapshotData,
+  renderSnapshotToCanvas,
+  shareSnapshot,
+} from "./macroSnapshotCanvas";
+
+const mockSnapshotData: MacroSnapshotData = {
+  title: "Today's Macros",
+  dateLabel: "Oct 24, 2026",
+  calories: 2150,
+  calorieTarget: 2400,
+  protein: 165,
+  proteinTarget: 180,
+  carbs: 220,
+  carbsTarget: 230,
+  fats: 60,
+  fatsTarget: 70,
+  streakDays: 7,
+  complianceScore: 92,
+};
+
+const createMock2DContext = () =>
+  ({
+    fillRect: vi.fn(),
+    clearRect: vi.fn(),
+    getImageData: vi.fn(),
+    putImageData: vi.fn(),
+    createImageData: vi.fn(),
+    setTransform: vi.fn(),
+    drawImage: vi.fn(),
+    save: vi.fn(),
+    fillText: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
+    stroke: vi.fn(),
+    translate: vi.fn(),
+    scale: vi.fn(),
+    rotate: vi.fn(),
+    arc: vi.fn(),
+    arcTo: vi.fn(),
+    ellipse: vi.fn(),
+    fill: vi.fn(),
+    clip: vi.fn(),
+    measureText: vi.fn(() => ({ width: 100 })),
+    createLinearGradient: vi.fn(() => ({
+      addColorStop: vi.fn(),
+    })),
+    createRadialGradient: vi.fn(() => ({
+      addColorStop: vi.fn(),
+    })),
+    roundRect: vi.fn(),
+  }) as unknown as CanvasRenderingContext2D;
+
+describe("macroSnapshotCanvas", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(
+      () => createMock2DContext(),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("renderSnapshotToCanvas", () => {
+    it("creates a canvas with correct dimensions (1080x1350)", () => {
+      const canvas = renderSnapshotToCanvas(mockSnapshotData);
+      expect(canvas.width).toBe(1080);
+      expect(canvas.height).toBe(1350);
+    });
+
+    it("handles zero total calories and missing targets gracefully", () => {
+      const emptyData: MacroSnapshotData = {
+        calories: 0,
+        calorieTarget: 0,
+        protein: 0,
+        proteinTarget: 0,
+        carbs: 0,
+        carbsTarget: 0,
+        fats: 0,
+        fatsTarget: 0,
+      };
+      const canvas = renderSnapshotToCanvas(emptyData);
+      expect(canvas.width).toBe(1080);
+      expect(canvas.height).toBe(1350);
+    });
+  });
+
+  describe("canvasToBlob", () => {
+    it("converts canvas to blob using toBlob when available", async () => {
+      const mockBlob = new Blob(["test"], { type: "image/png" });
+      const mockCanvas = {
+        toBlob: vi.fn((callback: (blob: Blob | null) => void) => callback(mockBlob)),
+      } as unknown as HTMLCanvasElement;
+
+      const blob = await canvasToBlob(mockCanvas);
+      expect(blob).toBe(mockBlob);
+      expect(mockCanvas.toBlob).toHaveBeenCalledWith(expect.any(Function), "image/png");
+    });
+
+    it("falls back to toDataURL when toBlob is not available", async () => {
+      const mockCanvas = {
+        toBlob: undefined,
+        toDataURL: vi.fn(() => "data:image/png;base64,AAAA"),
+      } as unknown as HTMLCanvasElement;
+
+      const blob = await canvasToBlob(mockCanvas);
+      expect(blob).toBeInstanceOf(Blob);
+      expect(blob.type).toBe("image/png");
+    });
+  });
+
+  describe("downloadSnapshotImage", () => {
+    it("creates and triggers a download link", async () => {
+      const appendChildSpy = vi.spyOn(document.body, "appendChild");
+      const removeChildSpy = vi.spyOn(document.body, "removeChild");
+      const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+      // Mock canvas toBlob
+      vi.spyOn(HTMLCanvasElement.prototype, "toBlob").mockImplementation((callback) => {
+        callback(new Blob(["mock-png"], { type: "image/png" }));
+      });
+
+      await downloadSnapshotImage(mockSnapshotData, "test-snapshot.png");
+
+      expect(appendChildSpy).toHaveBeenCalled();
+      expect(clickSpy).toHaveBeenCalled();
+      expect(removeChildSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("copySnapshotToClipboard", () => {
+    it("writes image blob to clipboard when supported", async () => {
+      const writeSpy = vi.fn().mockResolvedValue(undefined);
+      class MockClipboardItem {
+        data: Record<string, Blob>;
+        constructor(data: Record<string, Blob>) {
+          this.data = data;
+        }
+      }
+      Object.assign(globalThis, {
+        ClipboardItem: MockClipboardItem,
+      });
+      Object.assign(navigator, {
+        clipboard: {
+          write: writeSpy,
+        },
+      });
+
+      // Mock canvas toBlob
+      vi.spyOn(HTMLCanvasElement.prototype, "toBlob").mockImplementation((callback) => {
+        callback(new Blob(["mock-png"], { type: "image/png" }));
+      });
+
+      const success = await copySnapshotToClipboard(mockSnapshotData);
+      expect(success).toBe(true);
+      expect(writeSpy).toHaveBeenCalled();
+    });
+
+    it("throws error when clipboard.write is not available", async () => {
+      Object.assign(navigator, {
+        clipboard: undefined,
+      });
+
+      await expect(copySnapshotToClipboard(mockSnapshotData)).rejects.toThrow(
+        "Clipboard image write not supported",
+      );
+    });
+  });
+
+  describe("shareSnapshot", () => {
+    it("shares file using navigator.share when files are supported", async () => {
+      const shareSpy = vi.fn().mockResolvedValue(undefined);
+      const canShareSpy = vi.fn().mockReturnValue(true);
+
+      Object.assign(navigator, {
+        share: shareSpy,
+        canShare: canShareSpy,
+      });
+
+      vi.spyOn(HTMLCanvasElement.prototype, "toBlob").mockImplementation((callback) => {
+        callback(new Blob(["mock-png"], { type: "image/png" }));
+      });
+
+      const success = await shareSnapshot(mockSnapshotData);
+      expect(success).toBe(true);
+      expect(canShareSpy).toHaveBeenCalled();
+      expect(shareSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Today's Macros",
+          files: expect.any(Array),
+        }),
+      );
+    });
+
+    it("falls back to text sharing when files sharing is not supported", async () => {
+      const shareSpy = vi.fn().mockResolvedValue(undefined);
+      const canShareSpy = vi.fn().mockReturnValue(false);
+
+      Object.assign(navigator, {
+        share: shareSpy,
+        canShare: canShareSpy,
+      });
+
+      vi.spyOn(HTMLCanvasElement.prototype, "toBlob").mockImplementation((callback) => {
+        callback(new Blob(["mock-png"], { type: "image/png" }));
+      });
+
+      const success = await shareSnapshot(mockSnapshotData);
+      expect(success).toBe(true);
+      expect(shareSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Today's Macros",
+          text: expect.stringContaining("Calories: 2150 / 2400 kcal"),
+        }),
+      );
+    });
+  });
+});

--- a/frontend/src/features/macroTracking/utils/macroSnapshotCanvas.ts
+++ b/frontend/src/features/macroTracking/utils/macroSnapshotCanvas.ts
@@ -1,0 +1,584 @@
+export interface MacroSnapshotData {
+  title?: string;
+  dateLabel?: string;
+  calories: number;
+  calorieTarget: number;
+  protein: number;
+  proteinTarget: number;
+  carbs: number;
+  carbsTarget: number;
+  fats: number;
+  fatsTarget: number;
+  streakDays?: number;
+  complianceScore?: number;
+  badgeLabel?: string;
+  userName?: string;
+}
+
+const CANVAS_WIDTH = 1080;
+const CANVAS_HEIGHT = 1350;
+
+function drawRoundedRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+) {
+  if (typeof ctx.roundRect === "function") {
+    ctx.beginPath();
+    ctx.roundRect(x, y, width, height, radius);
+    return;
+  }
+
+  const r = Math.min(radius, width / 2, height / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + width - r, y);
+  ctx.arcTo(x + width, y, x + width, y + r, r);
+  ctx.lineTo(x + width, y + height - r);
+  ctx.arcTo(x + width, y + height, x + width - r, y + height, r);
+  ctx.lineTo(x + r, y + height);
+  ctx.arcTo(x, y + height, x, y + height - r, r);
+  ctx.lineTo(x, y + r);
+  ctx.arcTo(x, y, x + r, y, r);
+  ctx.closePath();
+}
+
+/**
+ * Draws the MacroTrackr pea-pod logo mark onto a Canvas
+ */
+function drawBrandLogo(ctx: CanvasRenderingContext2D, x: number, y: number, size: number) {
+  ctx.save();
+  ctx.translate(x, y);
+
+  // Background circle for badge
+  ctx.fillStyle = "#15803d";
+  drawRoundedRect(ctx, 0, 0, size, size, size * 0.28);
+  ctx.fill();
+
+  // Pea pod inner artwork
+  ctx.fillStyle = "#22c55e";
+  ctx.beginPath();
+  ctx.ellipse(size * 0.5, size * 0.5, size * 0.38, size * 0.22, -Math.PI / 6, 0, Math.PI * 2);
+  ctx.fill();
+
+  // 3 peas
+  ctx.fillStyle = "#09090b";
+  const peaRadius = size * 0.07;
+  const peas = [
+    { x: size * 0.36, y: size * 0.58 },
+    { x: size * 0.5, y: size * 0.5 },
+    { x: size * 0.64, y: size * 0.42 },
+  ];
+
+  for (const pea of peas) {
+    ctx.beginPath();
+    ctx.arc(pea.x, pea.y, peaRadius, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  ctx.restore();
+}
+
+/**
+ * Renders the complete Strava/Whoop-style macro scorecard to an HTML5 Canvas element
+ */
+export function renderSnapshotToCanvas(data: MacroSnapshotData): HTMLCanvasElement {
+  const canvas = document.createElement("canvas");
+  canvas.width = CANVAS_WIDTH;
+  canvas.height = CANVAS_HEIGHT;
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    throw new Error("Unable to create 2D canvas rendering context");
+  }
+
+  const cal = Math.round(data.calories);
+  const targetCal = Math.round(data.calorieTarget) || 2000;
+  const calPercent = Math.min(100, Math.round((cal / targetCal) * 100));
+
+  const proteinG = Math.round(data.protein);
+  const proteinTargetG = Math.round(data.proteinTarget) || 150;
+  const proteinPercent = Math.min(100, Math.round((proteinG / proteinTargetG) * 100));
+
+  const carbsG = Math.round(data.carbs);
+  const carbsTargetG = Math.round(data.carbsTarget) || 200;
+  const carbsPercent = Math.min(100, Math.round((carbsG / carbsTargetG) * 100));
+
+  const fatsG = Math.round(data.fats);
+  const fatsTargetG = Math.round(data.fatsTarget) || 65;
+  const fatsPercent = Math.min(100, Math.round((fatsG / fatsTargetG) * 100));
+
+  const proteinCals = proteinG * 4;
+  const carbsCals = carbsG * 4;
+  const fatsCals = fatsG * 9;
+  const totalMacroCals = proteinCals + carbsCals + fatsCals;
+
+  const pRatio = totalMacroCals > 0 ? Math.round((proteinCals / totalMacroCals) * 100) : 30;
+  const cRatio = totalMacroCals > 0 ? Math.round((carbsCals / totalMacroCals) * 100) : 45;
+  const fRatio = totalMacroCals > 0 ? Math.max(0, 100 - pRatio - cRatio) : 25;
+
+  // 1. Base Background
+  const bgGrad = ctx.createLinearGradient(0, 0, 0, CANVAS_HEIGHT);
+  bgGrad.addColorStop(0, "#09090b");
+  bgGrad.addColorStop(1, "#121218");
+  ctx.fillStyle = bgGrad;
+  ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+  // Subtle ambient glows
+  const topGlow = ctx.createRadialGradient(250, 200, 10, 250, 200, 450);
+  topGlow.addColorStop(0, "rgba(34, 197, 94, 0.12)");
+  topGlow.addColorStop(1, "rgba(34, 197, 94, 0)");
+  ctx.fillStyle = topGlow;
+  ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+  const bottomGlow = ctx.createRadialGradient(850, 1100, 10, 850, 1100, 500);
+  bottomGlow.addColorStop(0, "rgba(59, 130, 246, 0.08)");
+  bottomGlow.addColorStop(1, "rgba(59, 130, 246, 0)");
+  ctx.fillStyle = bottomGlow;
+  ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+  // 2. Outer Card Frame
+  const cardX = 54;
+  const cardY = 54;
+  const cardW = CANVAS_WIDTH - 108;
+  const cardH = CANVAS_HEIGHT - 108;
+
+  ctx.fillStyle = "#121218";
+  drawRoundedRect(ctx, cardX, cardY, cardW, cardH, 32);
+  ctx.fill();
+
+  ctx.strokeStyle = "#27272a";
+  ctx.lineWidth = 2.5;
+  drawRoundedRect(ctx, cardX, cardY, cardW, cardH, 32);
+  ctx.stroke();
+
+  // 3. Header Section (Logo, App Name, Date, Badge)
+  const headerY = 100;
+  drawBrandLogo(ctx, 100, headerY, 52);
+
+  // Brand Name
+  ctx.fillStyle = "#fafafa";
+  ctx.font = '700 32px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+  ctx.textAlign = "left";
+  ctx.textBaseline = "middle";
+  ctx.fillText("MacroTrackr", 168, headerY + 26);
+
+  // Badge on the right
+  const badgeText =
+    data.badgeLabel ??
+    (data.streakDays && data.streakDays > 0
+      ? `🔥 ${data.streakDays}-Day Streak`
+      : data.complianceScore
+        ? `🎯 ${data.complianceScore}% Compliance`
+        : `${calPercent}% of Goal`);
+
+  ctx.font = '600 20px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+  const badgeWidth = ctx.measureText(badgeText).width + 36;
+  const badgeX = CANVAS_WIDTH - 100 - badgeWidth;
+  const badgeY = headerY + 6;
+
+  ctx.fillStyle = "#1a1a22";
+  drawRoundedRect(ctx, badgeX, badgeY, badgeWidth, 40, 20);
+  ctx.fill();
+
+  ctx.strokeStyle = "#27272a";
+  ctx.lineWidth = 1.5;
+  drawRoundedRect(ctx, badgeX, badgeY, badgeWidth, 40, 20);
+  ctx.stroke();
+
+  ctx.fillStyle = "#22c55e";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText(badgeText, badgeX + badgeWidth / 2, badgeY + 20);
+
+  // Title / Date Header
+  const titleY = 200;
+  ctx.fillStyle = "#a1a1aa";
+  ctx.font = '600 16px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+  ctx.textAlign = "left";
+  ctx.fillText((data.title ?? "DAILY SUMMARY").toUpperCase(), 100, titleY);
+
+  ctx.fillStyle = "#fafafa";
+  ctx.font = '700 28px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+  ctx.fillText(data.dateLabel ?? "Today's Nutrition Snapshot", 100, titleY + 36);
+
+  // 4. Hero Energy (Calories) Card
+  const heroY = 280;
+  const heroH = 240;
+  const heroW = 880;
+  const heroX = 100;
+
+  ctx.fillStyle = "#1a1a22";
+  drawRoundedRect(ctx, heroX, heroY, heroW, heroH, 24);
+  ctx.fill();
+
+  ctx.strokeStyle = "#27272a";
+  ctx.lineWidth = 1.5;
+  drawRoundedRect(ctx, heroX, heroY, heroW, heroH, 24);
+  ctx.stroke();
+
+  // Inside Hero Card
+  ctx.fillStyle = "#a1a1aa";
+  ctx.font = '600 16px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+  ctx.fillText("CALORIES CONSUMED", heroX + 36, heroY + 44);
+
+  // Big Calorie Number
+  ctx.fillStyle = "#fafafa";
+  ctx.font = '800 64px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+  const calString = cal.toLocaleString();
+  ctx.fillText(calString, heroX + 36, heroY + 115);
+
+  const calNumWidth = ctx.measureText(calString).width;
+  ctx.fillStyle = "#a1a1aa";
+  ctx.font = '600 24px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+  ctx.fillText(`kcal  /  ${targetCal.toLocaleString()} goal`, heroX + 48 + calNumWidth, heroY + 115);
+
+  // Progress Bar for Calories
+  const barX = heroX + 36;
+  const barY = heroY + 160;
+  const barW = heroW - 72;
+  const barH = 18;
+
+  ctx.fillStyle = "#22222c";
+  drawRoundedRect(ctx, barX, barY, barW, barH, 9);
+  ctx.fill();
+
+  const calProgressW = Math.max(12, (barW * Math.min(100, calPercent)) / 100);
+  const calBarGrad = ctx.createLinearGradient(barX, 0, barX + barW, 0);
+  calBarGrad.addColorStop(0, "#22c55e");
+  calBarGrad.addColorStop(1, "#4ade80");
+  ctx.fillStyle = calBarGrad;
+  drawRoundedRect(ctx, barX, barY, calProgressW, barH, 9);
+  ctx.fill();
+
+  // Calorie Subtext: % and remaining
+  ctx.font = '500 15px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+  ctx.fillStyle = "#22c55e";
+  ctx.fillText(`${calPercent}% Achieved`, barX, barY + 42);
+
+  const remaining = targetCal - cal;
+  ctx.fillStyle = "#a1a1aa";
+  ctx.textAlign = "right";
+  ctx.fillText(
+    remaining >= 0 ? `${remaining.toLocaleString()} kcal remaining` : `${Math.abs(remaining).toLocaleString()} kcal over goal`,
+    barX + barW,
+    barY + 42,
+  );
+
+  // 5. Macro Breakdown: 3 Columns
+  const macroGridY = 550;
+  const macroColW = 274;
+  const macroColH = 260;
+  const macroGap = 29;
+
+  const macros = [
+    {
+      name: "PROTEIN",
+      color: "#22c55e",
+      grams: proteinG,
+      target: proteinTargetG,
+      percent: proteinPercent,
+      cals: proteinCals,
+      ratio: pRatio,
+    },
+    {
+      name: "CARBS",
+      color: "#3b82f6",
+      grams: carbsG,
+      target: carbsTargetG,
+      percent: carbsPercent,
+      cals: carbsCals,
+      ratio: cRatio,
+    },
+    {
+      name: "FATS",
+      color: "#ef4444",
+      grams: fatsG,
+      target: fatsTargetG,
+      percent: fatsPercent,
+      cals: fatsCals,
+      ratio: fRatio,
+    },
+  ];
+
+  ctx.textAlign = "left";
+
+  macros.forEach((m, index) => {
+    const colX = 100 + index * (macroColW + macroGap);
+
+    ctx.fillStyle = "#1a1a22";
+    drawRoundedRect(ctx, colX, macroGridY, macroColW, macroColH, 20);
+    ctx.fill();
+
+    ctx.strokeStyle = "#27272a";
+    ctx.lineWidth = 1.5;
+    drawRoundedRect(ctx, colX, macroGridY, macroColW, macroColH, 20);
+    ctx.stroke();
+
+    // Top indicator pill
+    ctx.fillStyle = m.color;
+    drawRoundedRect(ctx, colX + 24, macroGridY + 24, 10, 10, 5);
+    ctx.fill();
+
+    // Macro Name
+    ctx.fillStyle = m.color;
+    ctx.font = '700 15px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+    ctx.fillText(m.name, colX + 42, macroGridY + 30);
+
+    // Big Grams
+    ctx.fillStyle = "#fafafa";
+    ctx.font = '800 40px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+    ctx.fillText(`${m.grams}g`, colX + 24, macroGridY + 84);
+
+    // Target text
+    ctx.fillStyle = "#a1a1aa";
+    ctx.font = '500 16px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+    ctx.fillText(`of ${m.target}g (${m.percent}%)`, colX + 24, macroGridY + 118);
+
+    // Progress Bar
+    const mBarX = colX + 24;
+    const mBarY = macroGridY + 144;
+    const mBarW = macroColW - 48;
+    const mBarH = 10;
+
+    ctx.fillStyle = "#22222c";
+    drawRoundedRect(ctx, mBarX, mBarY, mBarW, mBarH, 5);
+    ctx.fill();
+
+    const mProgressW = Math.max(6, (mBarW * Math.min(100, m.percent)) / 100);
+    ctx.fillStyle = m.color;
+    drawRoundedRect(ctx, mBarX, mBarY, mProgressW, mBarH, 5);
+    ctx.fill();
+
+    // Bottom calories & % split info
+    ctx.fillStyle = "#a1a1aa";
+    ctx.font = '500 14px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+    ctx.fillText(`${m.cals} kcal`, colX + 24, macroGridY + 192);
+
+    ctx.textAlign = "right";
+    ctx.fillText(`${m.ratio}% energy`, colX + macroColW - 24, macroGridY + 192);
+    ctx.textAlign = "left";
+  });
+
+  // 6. Macro Distribution Split Bar
+  const distY = 840;
+  const distH = 140;
+  const distW = 880;
+  const distX = 100;
+
+  ctx.fillStyle = "#1a1a22";
+  drawRoundedRect(ctx, distX, distY, distW, distH, 20);
+  ctx.fill();
+
+  ctx.strokeStyle = "#27272a";
+  ctx.lineWidth = 1.5;
+  drawRoundedRect(ctx, distX, distY, distW, distH, 20);
+  ctx.stroke();
+
+  ctx.fillStyle = "#a1a1aa";
+  ctx.font = '600 15px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+  ctx.fillText("CALORIE DISTRIBUTION", distX + 28, distY + 36);
+
+  // Stacked Strip
+  const stripX = distX + 28;
+  const stripY = distY + 54;
+  const stripW = distW - 56;
+  const stripH = 16;
+
+  // Background
+  ctx.fillStyle = "#22222c";
+  drawRoundedRect(ctx, stripX, stripY, stripW, stripH, 8);
+  ctx.fill();
+
+  const pW = (stripW * pRatio) / 100;
+  const cW = (stripW * cRatio) / 100;
+  const fW = stripW - pW - cW;
+
+  // Draw segments
+  ctx.save();
+  drawRoundedRect(ctx, stripX, stripY, stripW, stripH, 8);
+  ctx.clip();
+
+  ctx.fillStyle = "#22c55e";
+  ctx.fillRect(stripX, stripY, pW, stripH);
+
+  ctx.fillStyle = "#3b82f6";
+  ctx.fillRect(stripX + pW, stripY, cW, stripH);
+
+  ctx.fillStyle = "#ef4444";
+  ctx.fillRect(stripX + pW + cW, stripY, fW, stripH);
+  ctx.restore();
+
+  // Legend underneath
+  const legendY = distY + 104;
+  ctx.font = '600 15px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+
+  // Protein
+  ctx.fillStyle = "#22c55e";
+  drawRoundedRect(ctx, distX + 28, legendY - 8, 10, 10, 5);
+  ctx.fill();
+  ctx.fillStyle = "#fafafa";
+  ctx.fillText(`Protein ${pRatio}%`, distX + 46, legendY);
+
+  // Carbs
+  ctx.fillStyle = "#3b82f6";
+  drawRoundedRect(ctx, distX + 200, legendY - 8, 10, 10, 5);
+  ctx.fill();
+  ctx.fillStyle = "#fafafa";
+  ctx.fillText(`Carbs ${cRatio}%`, distX + 218, legendY);
+
+  // Fats
+  ctx.fillStyle = "#ef4444";
+  drawRoundedRect(ctx, distX + 360, legendY - 8, 10, 10, 5);
+  ctx.fill();
+  ctx.fillStyle = "#fafafa";
+  ctx.fillText(`Fats ${fRatio}%`, distX + 378, legendY);
+
+  // 7. Highlight / Verified Ribbon
+  const ribbonY = 1008;
+  const ribbonW = 880;
+  const ribbonH = 90;
+  const ribbonX = 100;
+
+  ctx.fillStyle = "#1a1a22";
+  drawRoundedRect(ctx, ribbonX, ribbonY, ribbonW, ribbonH, 18);
+  ctx.fill();
+
+  ctx.strokeStyle = "#27272a";
+  ctx.lineWidth = 1.5;
+  drawRoundedRect(ctx, ribbonX, ribbonY, ribbonW, ribbonH, 18);
+  ctx.stroke();
+
+  ctx.fillStyle = "#22c55e";
+  ctx.font = '700 20px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+  ctx.textAlign = "left";
+  ctx.fillText("⚡ Consistency & Nutrition Tracker", ribbonX + 28, ribbonY + 48);
+
+  ctx.fillStyle = "#a1a1aa";
+  ctx.font = '500 15px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+  ctx.textAlign = "right";
+  ctx.fillText("Verified on MacroTrackr", ribbonX + ribbonW - 28, ribbonY + 48);
+
+  // 8. Footer Watermark
+  const footerY = 1144;
+  ctx.fillStyle = "#71717a";
+  ctx.font = '500 16px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+  ctx.textAlign = "center";
+  ctx.fillText("macrotrackr.com • Precision Nutrition Tracking", CANVAS_WIDTH / 2, footerY);
+
+  return canvas;
+}
+
+/**
+ * Converts a Canvas to a PNG Blob
+ */
+export function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    if (typeof canvas.toBlob === "function") {
+      canvas.toBlob((blob) => {
+        if (blob) {
+          resolve(blob);
+        } else {
+          reject(new Error("Canvas toBlob returned null"));
+        }
+      }, "image/png");
+    } else if (typeof canvas.toDataURL === "function") {
+      try {
+        const dataUrl = canvas.toDataURL("image/png");
+        const base64Data = dataUrl.split(",")[1];
+        if (!base64Data) {
+          reject(new Error("Invalid canvas data URL"));
+          return;
+        }
+        const binary = atob(base64Data);
+        const array = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) {
+          array[i] = binary.charCodeAt(i);
+        }
+        resolve(new Blob([array], { type: "image/png" }));
+      } catch (error) {
+        reject(error);
+      }
+    } else {
+      reject(new Error("Canvas export not supported in this environment"));
+    }
+  });
+}
+
+/**
+ * Generates a PNG Blob from snapshot data
+ */
+export async function generateSnapshotBlob(data: MacroSnapshotData): Promise<Blob> {
+  const canvas = renderSnapshotToCanvas(data);
+  return canvasToBlob(canvas);
+}
+
+/**
+ * Downloads the scorecard PNG image to user's device
+ */
+export async function downloadSnapshotImage(
+  data: MacroSnapshotData,
+  filename?: string,
+): Promise<void> {
+  const blob = await generateSnapshotBlob(data);
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  const safeDate = (data.dateLabel ?? "today").toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  link.download = filename ?? `macrotrackr-snapshot-${safeDate}.png`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+/**
+ * Copies the scorecard PNG image to clipboard
+ */
+export async function copySnapshotToClipboard(data: MacroSnapshotData): Promise<boolean> {
+  if (
+    typeof navigator === "undefined" ||
+    !navigator.clipboard?.write ||
+    typeof ClipboardItem === "undefined"
+  ) {
+    throw new Error("Clipboard image write not supported in this browser");
+  }
+
+  const blob = await generateSnapshotBlob(data);
+  const item = new ClipboardItem({ "image/png": blob });
+  await navigator.clipboard.write([item]);
+  return true;
+}
+
+/**
+ * Shares the scorecard using Web Share API (with image file or fallback text)
+ */
+export async function shareSnapshot(data: MacroSnapshotData): Promise<boolean> {
+  if (typeof navigator === "undefined" || typeof navigator.share !== "function") {
+    throw new Error("Web Share API not supported in this browser");
+  }
+
+  const blob = await generateSnapshotBlob(data);
+  const safeDate = (data.dateLabel ?? "snapshot").toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  const filename = `macrotrackr-${safeDate}.png`;
+  const file = new File([blob], filename, { type: "image/png" });
+
+  const sharePayload = {
+    title: data.title ?? "MacroTrackr Daily Snapshot",
+    text: `Tracked my macros on MacroTrackr! Calories: ${Math.round(data.calories)} / ${Math.round(data.calorieTarget)} kcal (Protein: ${Math.round(data.protein)}g, Carbs: ${Math.round(data.carbs)}g, Fats: ${Math.round(data.fats)}g).`,
+  };
+
+  if (navigator.canShare && navigator.canShare({ files: [file] })) {
+    await navigator.share({
+      ...sharePayload,
+      files: [file],
+    });
+    return true;
+  }
+
+  await navigator.share(sharePayload);
+  return true;
+}

--- a/frontend/src/features/reporting/pages/ReportingPage.tsx
+++ b/frontend/src/features/reporting/pages/ReportingPage.tsx
@@ -8,6 +8,8 @@ import { DashboardPageContainer } from "@/components/layout/DashboardPageContain
 import FeaturePage from "@/components/layout/FeaturePage";
 import { StateCard } from "@/components/ui";
 import { isLocalAuthMode } from "@/config/runtime";
+import { MacroSnapshotModal } from "@/features/macroTracking/components";
+import type { MacroSnapshotData } from "@/features/macroTracking/utils/macroSnapshotCanvas";
 import { useUser } from "@/hooks/auth/useAuthQueries";
 import { useWeightGoals } from "@/hooks/queries/useGoals";
 import {
@@ -18,7 +20,11 @@ import { useMacroDensitySummary } from "@/hooks/queries/useReportingQueries";
 import { usePageDataSync } from "@/hooks/usePageDataSync";
 import { queryKeys } from "@/lib/queryKeys";
 import { useStore } from "@/store/store";
-import { getDateRangeData, mapDateRangeToDays } from "@/utils/dateUtilities";
+import {
+  formatDateShort,
+  getDateRangeData,
+  mapDateRangeToDays,
+} from "@/utils/dateUtilities";
 
 import {
   MacroDensityBreakdown,
@@ -39,6 +45,7 @@ export default function ReportingPage() {
 
   // Primary date range state - used throughout the component
   const [dateRange, setDateRange] = useState<string>("week");
+  const [isSnapshotOpen, setIsSnapshotOpen] = useState<boolean>(false);
 
   // Redirect to week view if free user tries to access Pro ranges
   const handleRangeChange = (range: string) => {
@@ -159,107 +166,159 @@ export default function ReportingPage() {
   const showNoDataMessage =
     !isHistoryLoading && isHistoryReady && aggregatedData.length === 0;
 
+  const reportingSnapshotData: MacroSnapshotData = useMemo(() => {
+    const calTarget = weightGoals?.calorieTarget ?? 2000;
+    const pTarget = macroTarget
+      ? Math.round((calTarget * macroTarget.proteinPercentage) / 100 / 4)
+      : 150;
+    const cTarget = macroTarget
+      ? Math.round((calTarget * macroTarget.carbsPercentage) / 100 / 4)
+      : 200;
+    const fTarget = macroTarget
+      ? Math.round((calTarget * macroTarget.fatsPercentage) / 100 / 9)
+      : 65;
+    const compliance =
+      totalDays > 0 ? Math.round((trackedDays / totalDays) * 100) : 0;
+    const rangeLabel =
+      dateRange === "week"
+        ? "Weekly Compliance"
+        : dateRange === "month"
+          ? "Monthly Summary"
+          : "90-Day Overview";
+
+    return {
+      title: rangeLabel,
+      dateLabel: `${formatDateShort(startDate)} - ${formatDateShort(endDate)}`,
+      calories: averages.calories,
+      calorieTarget: calTarget,
+      protein: averages.protein,
+      proteinTarget: pTarget,
+      carbs: averages.carbs,
+      carbsTarget: cTarget,
+      fats: averages.fats,
+      fatsTarget: fTarget,
+      complianceScore: compliance,
+      badgeLabel: `⚡ ${compliance}% Compliance`,
+    };
+  }, [
+    weightGoals,
+    macroTarget,
+    totalDays,
+    trackedDays,
+    dateRange,
+    startDate,
+    endDate,
+    averages,
+  ]);
+
   const headerTitle = "Analytics";
   const headerSubtitle = "Deep dive into your nutrition patterns and progress";
 
   return (
     <DashboardPageContainer>
       <FeaturePage title={headerTitle} subtitle={headerSubtitle}>
-              {isHistoryLoading ? (
-                <ReportingPageSkeleton />
-              ) : (
-                <div className="flex flex-col gap-3.5 sm:gap-6">
-                  <DateRangeSelector
-                    currentRange={dateRange}
-                    onRangeChange={handleRangeChange}
-                    onExportClick={handleDownloadCSV}
-                    isExportDisabled={
-                      aggregatedData.length === 0 || isHistoryLoading
-                    }
-                    disabledRanges={isProUser ? [] : ["month", "3months"]}
-                    isPro={isProUser}
-                  />
+        {isHistoryLoading ? (
+          <ReportingPageSkeleton />
+        ) : (
+          <div className="flex flex-col gap-3.5 sm:gap-6">
+            <DateRangeSelector
+              currentRange={dateRange}
+              onRangeChange={handleRangeChange}
+              onExportClick={handleDownloadCSV}
+              onShareClick={() => setIsSnapshotOpen(true)}
+              isExportDisabled={
+                aggregatedData.length === 0 || isHistoryLoading
+              }
+              disabledRanges={isProUser ? [] : ["month", "3months"]}
+              isPro={isProUser}
+            />
 
-                  {showNoDataMessage ? (
-                    <div className="rounded-card border border-border bg-surface">
-                      <StateCard
-                        title="No reporting data yet"
-                        message="No meals logged in this range. Add a few and your trends and meal timing will appear here."
-                        size="md"
+            {showNoDataMessage ? (
+              <div className="rounded-card border border-border bg-surface">
+                <StateCard
+                  title="No reporting data yet"
+                  message="No meals logged in this range. Add a few and your trends and meal timing will appear here."
+                  size="md"
+                />
+              </div>
+            ) : (
+              <>
+                {(() => {
+                  const calorieTarget =
+                    weightGoals?.calorieTarget ?? 2000;
+
+                  return (
+                    <MacroSummaryStats
+                      data={aggregatedData}
+                      calorieTarget={calorieTarget}
+                      macroTarget={macroTarget ?? undefined}
+                      trackedDays={trackedDays}
+                      totalDays={totalDays}
+                      averages={averages}
+                    />
+                  );
+                })()}
+
+                <ProFeature>
+                  <TrendsChartSection
+                    dailySeries={dailySeries}
+                    isHistoryLoading={isHistoryLoading}
+                    isHistoryReady={isHistoryReady}
+                    calorieChartLines={calorieChartLines}
+                    macroChartLines={macroChartLines}
+                  />
+                </ProFeature>
+
+                <div className="grid grid-cols-1 gap-3.5 sm:gap-6 md:grid-cols-2">
+                  <div className="flex w-full min-w-0">
+                    {(() => {
+                      const { startDate: rangeStart, endDate: rangeEnd } =
+                        getDateRangeData(dateRange);
+
+                      return (
+                        <div className="w-full">
+                          <MealTimeBreakdown
+                            history={history}
+                            startDate={rangeStart}
+                            endDate={rangeEnd}
+                          />
+                        </div>
+                      );
+                    })()}
+                  </div>
+                  <div className="flex w-full min-w-0">
+                    <div className="w-full">
+                      <MacroDensityBreakdown
+                        data={macroDensityData}
+                        selectedRange={mapDateRangeToDays(dateRange)}
+                        isLoading={isHistoryLoading}
+                        isHistoryReady={isHistoryReady}
                       />
                     </div>
-                  ) : (
-                    <>
-                      {(() => {
-                        const calorieTarget =
-                          weightGoals?.calorieTarget ?? 2000;
-
-                        return (
-                          <MacroSummaryStats
-                            data={aggregatedData}
-                            calorieTarget={calorieTarget}
-                            macroTarget={macroTarget ?? undefined}
-                            trackedDays={trackedDays}
-                            totalDays={totalDays}
-                            averages={averages}
-                          />
-                        );
-                      })()}
-
-                      <ProFeature>
-                        <TrendsChartSection
-                          dailySeries={dailySeries}
-                          isHistoryLoading={isHistoryLoading}
-                          isHistoryReady={isHistoryReady}
-                          calorieChartLines={calorieChartLines}
-                          macroChartLines={macroChartLines}
-                        />
-                      </ProFeature>
-
-                      <div className="grid grid-cols-1 gap-3.5 sm:gap-6 md:grid-cols-2">
-                        <div className="flex w-full min-w-0">
-                          {(() => {
-                            const { startDate: rangeStart, endDate: rangeEnd } =
-                              getDateRangeData(dateRange);
-
-                            return (
-                              <div className="w-full">
-                                <MealTimeBreakdown
-                                  history={history}
-                                  startDate={rangeStart}
-                                  endDate={rangeEnd}
-                                />
-                              </div>
-                            );
-                          })()}
-                        </div>
-                        <div className="flex w-full min-w-0">
-                          <div className="w-full">
-                            <MacroDensityBreakdown
-                              data={macroDensityData}
-                              selectedRange={mapDateRangeToDays(dateRange)}
-                              isLoading={isHistoryLoading}
-                              isHistoryReady={isHistoryReady}
-                            />
-                          </div>
-                        </div>
-                      </div>
-
-                      <ProFeature>
-                        <UnifiedInsights
-                          aggregatedData={aggregatedData}
-                          averages={averages}
-                          isLoading={isHistoryLoading}
-                          showNoDataMessage={showNoDataMessage}
-                          macroTarget={macroTarget ?? undefined}
-                          denominatorDays={mapDateRangeToDays(dateRange)}
-                          dailySeriesForRange={dailySeries}
-                        />
-                      </ProFeature>
-                    </>
-                  )}
+                  </div>
                 </div>
-              )}
+
+                <ProFeature>
+                  <UnifiedInsights
+                    aggregatedData={aggregatedData}
+                    averages={averages}
+                    isLoading={isHistoryLoading}
+                    showNoDataMessage={showNoDataMessage}
+                    macroTarget={macroTarget ?? undefined}
+                    denominatorDays={mapDateRangeToDays(dateRange)}
+                    dailySeriesForRange={dailySeries}
+                  />
+                </ProFeature>
+              </>
+            )}
+          </div>
+        )}
+
+        <MacroSnapshotModal
+          isOpen={isSnapshotOpen}
+          onClose={() => setIsSnapshotOpen(false)}
+          data={reportingSnapshotData}
+        />
       </FeaturePage>
     </DashboardPageContainer>
   );

--- a/frontend/src/features/settings/components/DataImporter.test.tsx
+++ b/frontend/src/features/settings/components/DataImporter.test.tsx
@@ -1,0 +1,31 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import DataImporter from "./DataImporter";
+
+describe("DataImporter", () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  it("renders 1-Click Data Importer header and supported platform badges", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <DataImporter />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByText("1-Click Data Importer")).toBeDefined();
+    expect(screen.getByText("MyFitnessPal")).toBeDefined();
+    expect(screen.getByText("Cronometer")).toBeDefined();
+    expect(screen.getByText("MacroFactor")).toBeDefined();
+    expect(screen.getByText("Lose It!")).toBeDefined();
+    expect(screen.getByText("MacroTrackr")).toBeDefined();
+    expect(
+      screen.getByText("Click to browse or drag and drop your export file"),
+    ).toBeDefined();
+  });
+});

--- a/frontend/src/features/settings/components/DataImporter.tsx
+++ b/frontend/src/features/settings/components/DataImporter.tsx
@@ -1,0 +1,492 @@
+import { useCallback, useRef, useState } from "react";
+
+import Dropdown from "@/components/form/Dropdown";
+import {
+  Button,
+  CheckCircleIcon,
+  CloseIcon,
+  InfoIcon,
+  UploadIcon,
+  WarningIcon,
+} from "@/components/ui";
+import Heading from "@/components/ui/Heading";
+import Panel from "@/components/ui/Panel";
+import {
+  detectImportFormat,
+  type ImportFormat,
+  type ImportResult,
+  parseImportFile,
+} from "@/features/settings/utils/importer";
+import { useImportMacros } from "@/hooks/queries/useMacroQueries";
+import { useStore } from "@/store/store";
+
+const FORMAT_OPTIONS = [
+  { value: "auto", label: "Auto-Detect Format" },
+  { value: "myfitnesspal", label: "MyFitnessPal (CSV)" },
+  { value: "cronometer", label: "Cronometer (CSV)" },
+  { value: "macrofactor", label: "MacroFactor (CSV / JSON)" },
+  { value: "loseit", label: "Lose It! (CSV)" },
+  { value: "macrotrackr", label: "MacroTrackr Native (JSON / CSV)" },
+];
+
+const PLATFORM_NAMES: Record<ImportFormat, string> = {
+  auto: "Auto-Detect",
+  myfitnesspal: "MyFitnessPal",
+  cronometer: "Cronometer",
+  macrofactor: "MacroFactor",
+  loseit: "Lose It!",
+  macrotrackr: "MacroTrackr",
+  unknown: "Custom / Unknown",
+};
+
+export default function DataImporter() {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [fileContent, setFileContent] = useState<string>("");
+  const [selectedFormat, setSelectedFormat] = useState<ImportFormat>("auto");
+  const [parsedData, setParsedData] = useState<ImportResult | null>(null);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [importSuccessResult, setImportSuccessResult] = useState<{
+    macros: number;
+    weightLogs: number;
+    dateRange: { start: string; end: string } | null;
+  } | null>(null);
+
+  const importMutation = useImportMacros();
+  const { showNotification } = useStore();
+
+  const handleFileProcess = useCallback(
+    (file: File, content: string, formatOverride?: ImportFormat) => {
+      try {
+        setParseError(null);
+        setImportSuccessResult(null);
+
+        const formatToUse = formatOverride ?? selectedFormat;
+        const result = parseImportFile(content, formatToUse, file.name);
+
+        if (result.entries.length === 0 && result.weightLogs.length === 0) {
+          setParseError(
+            result.errors?.[0] ||
+              "No valid meal or weight records could be extracted from this file.",
+          );
+          setParsedData(null);
+          return;
+        }
+
+        setParsedData(result);
+      } catch (error) {
+        const msg =
+          error instanceof Error ? error.message : "Failed to parse file.";
+        setParseError(msg);
+        setParsedData(null);
+      }
+    },
+    [selectedFormat],
+  );
+
+  const handleFileSelected = useCallback(
+    (file: File) => {
+      setSelectedFile(file);
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        const content = event.target?.result as string;
+        setFileContent(content);
+        // Auto-detect format initially
+        const detected = detectImportFormat(content, file.name);
+        setSelectedFormat(detected);
+        handleFileProcess(file, content, detected);
+      };
+      reader.onerror = () => {
+        setParseError("Failed to read file.");
+      };
+      reader.readAsText(file);
+    },
+    [handleFileProcess],
+  );
+
+  const handleDragOver = useCallback((event: React.DragEvent) => {
+    event.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback((event: React.DragEvent) => {
+    event.preventDefault();
+    setIsDragging(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent) => {
+      event.preventDefault();
+      setIsDragging(false);
+      const files = event.dataTransfer.files;
+      if (files.length > 0 && files[0]) {
+        handleFileSelected(files[0]);
+      }
+    },
+    [handleFileSelected],
+  );
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files;
+    if (files && files.length > 0 && files[0]) {
+      handleFileSelected(files[0]);
+    }
+  };
+
+  const handleFormatChange = (newFormat: string | number) => {
+    const format = String(newFormat) as ImportFormat;
+    setSelectedFormat(format);
+    if (selectedFile && fileContent) {
+      handleFileProcess(selectedFile, fileContent, format);
+    }
+  };
+
+  const handleReset = () => {
+    setSelectedFile(null);
+    setFileContent("");
+    setParsedData(null);
+    setParseError(null);
+    setImportSuccessResult(null);
+    setSelectedFormat("auto");
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const handleExecuteImport = async () => {
+    if (!parsedData) return;
+
+    try {
+      const response = await importMutation.mutateAsync({
+        source: parsedData.format,
+        entries: parsedData.entries,
+        weightLogs: parsedData.weightLogs,
+      });
+
+      setImportSuccessResult({
+        macros: response.importedCount.macros,
+        weightLogs: response.importedCount.weightLogs,
+        dateRange: response.dateRange,
+      });
+
+      showNotification(response.message, "success");
+    } catch (error) {
+      const msg =
+        error instanceof Error ? error.message : "Failed to import data.";
+      showNotification(`Import failed: ${msg}`, "error");
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <Panel padding="none">
+        <div className="border-b border-border p-4">
+          <div className="flex flex-col gap-1">
+            <Heading level="panel">1-Click Data Importer</Heading>
+            <p className="text-sm text-muted">
+              Import historical meals and weights seamlessly from MyFitnessPal,
+              Cronometer, MacroFactor, Lose It!, or native backups.
+            </p>
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            {[
+              "MyFitnessPal",
+              "Cronometer",
+              "MacroFactor",
+              "Lose It!",
+              "MacroTrackr",
+            ].map((name) => (
+              <span
+                key={name}
+                className="inline-flex items-center rounded-control border border-border bg-surface-2 px-2.5 py-1 text-xs font-medium text-muted"
+              >
+                {name}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className="p-4">
+          {importSuccessResult ? (
+            <div className="flex flex-col items-center justify-center rounded-card border border-border bg-surface-2 p-8 text-center">
+              <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-surface text-primary">
+                <CheckCircleIcon className="h-8 w-8" />
+              </div>
+              <Heading level="panel" className="text-foreground">
+                Import Successful!
+              </Heading>
+              <p className="mt-2 max-w-md text-sm text-muted">
+                Successfully imported{" "}
+                <span className="font-semibold text-foreground">
+                  {importSuccessResult.macros}
+                </span>{" "}
+                meal entries
+                {importSuccessResult.weightLogs > 0 && (
+                  <>
+                    {" "}
+                    and{" "}
+                    <span className="font-semibold text-foreground">
+                      {importSuccessResult.weightLogs}
+                    </span>{" "}
+                    weight logs
+                  </>
+                )}
+                {importSuccessResult.dateRange && (
+                  <>
+                    {" "}
+                    spanning {importSuccessResult.dateRange.start} to{" "}
+                    {importSuccessResult.dateRange.end}
+                  </>
+                )}
+                . All daily totals and history charts have been updated.
+              </p>
+              <div className="mt-6 flex gap-3">
+                <Button
+                  variant="primary"
+                  buttonSize="md"
+                  onClick={handleReset}
+                  leftIcon={<UploadIcon className="h-4 w-4" />}
+                  text="Import Another File"
+                />
+              </div>
+            </div>
+          ) : !parsedData ? (
+            <div>
+              <button
+                type="button"
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+                onClick={() => fileInputRef.current?.click()}
+                className={`flex w-full cursor-pointer flex-col items-center justify-center rounded-card border-2 border-dashed p-8 text-center transition-colors ${
+                  isDragging
+                    ? "border-primary bg-surface-2"
+                    : "border-border hover:border-border-2 hover:bg-surface-2"
+                }`}
+              >
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".csv,.json,text/csv,application/json"
+                  className="hidden"
+                  onChange={handleInputChange}
+                />
+                <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-surface-2 text-muted">
+                  <UploadIcon className="h-6 w-6" />
+                </div>
+                <span className="text-sm font-medium text-foreground">
+                  Click to browse or drag and drop your export file
+                </span>
+                <span className="mt-1 text-xs text-muted">
+                  Supports CSV and JSON exports up to 25 MB
+                </span>
+              </button>
+
+              {parseError && (
+                <div className="mt-4 flex items-start gap-2 rounded-card border border-border bg-surface-2 p-3 text-xs text-error">
+                  <WarningIcon className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span>{parseError}</span>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="space-y-6">
+              <div className="flex flex-col justify-between gap-4 rounded-card border border-border bg-surface-2 p-4 md:flex-row md:items-center">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-foreground">
+                      {selectedFile?.name}
+                    </span>
+                    <span className="rounded-control bg-surface px-2 py-0.5 text-xs text-primary">
+                      {PLATFORM_NAMES[parsedData.format] || parsedData.format}
+                    </span>
+                  </div>
+                  <p className="mt-0.5 text-xs text-muted">
+                    {parsedData.summary.totalMeals} meals
+                    {parsedData.summary.totalWeightLogs > 0
+                      ? `, ${parsedData.summary.totalWeightLogs} weight records`
+                      : ""}
+                    {parsedData.summary.dateRange
+                      ? ` • ${parsedData.summary.dateRange.start} to ${parsedData.summary.dateRange.end}`
+                      : ""}
+                  </p>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <div className="w-48">
+                    <Dropdown
+                      value={selectedFormat}
+                      onChange={handleFormatChange}
+                      options={FORMAT_OPTIONS}
+                    />
+                  </div>
+                  <Button
+                    variant="ghost"
+                    buttonSize="sm"
+                    onClick={handleReset}
+                    leftIcon={<CloseIcon className="h-4 w-4" />}
+                    text="Clear"
+                  />
+                </div>
+              </div>
+
+              {/* Import Preview Metric Cards */}
+              <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                <div className="rounded-card border border-border bg-surface-2 p-3">
+                  <span className="text-xs text-muted">Total Meals</span>
+                  <div className="mt-1 text-lg font-semibold text-foreground">
+                    {parsedData.summary.totalMeals}
+                  </div>
+                </div>
+                <div className="rounded-card border border-border bg-surface-2 p-3">
+                  <span className="text-xs text-muted">Days Tracked</span>
+                  <div className="mt-1 text-lg font-semibold text-foreground">
+                    {parsedData.summary.macroSummary.uniqueDays}
+                  </div>
+                </div>
+                <div className="rounded-card border border-border bg-surface-2 p-3">
+                  <span className="text-xs text-muted">Avg Daily Calories</span>
+                  <div className="mt-1 text-lg font-semibold text-foreground">
+                    {parsedData.summary.macroSummary.avgDailyCalories}{" "}
+                    <span className="text-xs font-normal text-muted">kcal</span>
+                  </div>
+                </div>
+                <div className="rounded-card border border-border bg-surface-2 p-3">
+                  <span className="text-xs text-muted">Daily Macros (P/C/F)</span>
+                  <div className="mt-1 text-sm font-semibold text-foreground">
+                    <span className="text-protein">
+                      {parsedData.summary.macroSummary.avgDailyProtein}p
+                    </span>{" "}
+                    /{" "}
+                    <span className="text-carbs">
+                      {parsedData.summary.macroSummary.avgDailyCarbs}c
+                    </span>{" "}
+                    /{" "}
+                    <span className="text-fats">
+                      {parsedData.summary.macroSummary.avgDailyFats}f
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              {/* Preview Entries Table */}
+              <div>
+                <div className="mb-2 flex items-center justify-between">
+                  <span className="text-xs font-medium text-muted">
+                    Preview (First {Math.min(5, parsedData.entries.length)}{" "}
+                    entries)
+                  </span>
+                  <span className="text-xs text-muted">
+                    Total calories: {parsedData.summary.macroSummary.totalCalories} kcal
+                  </span>
+                </div>
+                <div className="overflow-x-auto rounded-card border border-border bg-surface-2">
+                  <table className="w-full text-left text-xs">
+                    <thead>
+                      <tr className="border-b border-border bg-surface text-muted">
+                        <th className="px-3 py-2">Date</th>
+                        <th className="px-3 py-2">Meal</th>
+                        <th className="px-3 py-2">Name</th>
+                        <th className="px-3 py-2 text-right">Protein</th>
+                        <th className="px-3 py-2 text-right">Carbs</th>
+                        <th className="px-3 py-2 text-right">Fat</th>
+                        <th className="px-3 py-2 text-right">Calories</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-border">
+                      {parsedData.entries.slice(0, 5).map((entry, index) => {
+                        const calories = Math.round(
+                          entry.protein * 4 + entry.carbs * 4 + entry.fats * 9,
+                        );
+                        return (
+                          <tr key={index} className="hover:bg-surface">
+                            <td className="px-3 py-2 text-muted">
+                              {entry.entryDate}
+                            </td>
+                            <td className="px-3 py-2">
+                              <span className="inline-block rounded-control bg-surface px-1.5 py-0.5 text-xs capitalize text-foreground">
+                                {entry.mealType}
+                              </span>
+                            </td>
+                            <td className="max-w-[150px] truncate px-3 py-2 font-medium text-foreground">
+                              {entry.mealName || "—"}
+                            </td>
+                            <td className="px-3 py-2 text-right font-medium text-protein">
+                              {entry.protein}g
+                            </td>
+                            <td className="px-3 py-2 text-right font-medium text-carbs">
+                              {entry.carbs}g
+                            </td>
+                            <td className="px-3 py-2 text-right font-medium text-fats">
+                              {entry.fats}g
+                            </td>
+                            <td className="px-3 py-2 text-right font-semibold text-foreground">
+                              {calories}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
+              {/* Action Buttons */}
+              <div className="flex flex-col-reverse gap-3 pt-2 md:flex-row md:justify-end">
+                <Button
+                  variant="ghost"
+                  buttonSize="md"
+                  onClick={handleReset}
+                  text="Cancel"
+                />
+                <Button
+                  variant="primary"
+                  buttonSize="md"
+                  onClick={handleExecuteImport}
+                  isLoading={importMutation.isPending}
+                  leftIcon={<UploadIcon className="h-4 w-4" />}
+                  text={`Import ${parsedData.summary.totalMeals} Entries`}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      </Panel>
+
+      <Panel padding="regular">
+        <div className="flex items-start gap-3">
+          <div className="rounded-full bg-surface-2 p-2 text-muted">
+            <InfoIcon className="h-5 w-5" />
+          </div>
+          <div>
+            <h4 className="text-sm font-medium text-foreground">
+              Export Instructions for External Apps
+            </h4>
+            <ul className="mt-2 space-y-1.5 text-xs text-muted">
+              <li>
+                <strong className="text-foreground">MyFitnessPal:</strong> Go to
+                Settings → Export Information → Export Data (generates CSV
+                files).
+              </li>
+              <li>
+                <strong className="text-foreground">Cronometer:</strong> Go to
+                Settings → Account → Export Data → Export Servings / Daily
+                Summary (CSV).
+              </li>
+              <li>
+                <strong className="text-foreground">MacroFactor:</strong> Go to
+                Settings → Data Management → Export Data (CSV or JSON).
+              </li>
+              <li>
+                <strong className="text-foreground">Lose It!:</strong> Account
+                Settings → Data Export → Export to Spreadsheet (CSV).
+              </li>
+            </ul>
+          </div>
+        </div>
+      </Panel>
+    </div>
+  );
+}

--- a/frontend/src/features/settings/components/index.ts
+++ b/frontend/src/features/settings/components/index.ts
@@ -1,5 +1,6 @@
 export { default as BillingForm } from "./BillingForm";
 export { default as ChangePasswordForm } from "./ChangePasswordForm";
 export { default as ConnectedAccountsForm } from "./ConnectedAccountsForm";
+export { default as DataImporter } from "./DataImporter";
 export { default as ProfileForm } from "./ProfileForm";
 export { default as SettingsLoadingSkeleton } from "./SettingsLoadingSkeleton";

--- a/frontend/src/features/settings/pages/SettingsPage.tsx
+++ b/frontend/src/features/settings/pages/SettingsPage.tsx
@@ -13,6 +13,7 @@ import {
   LogoutIcon,
   Modal,
   TabBar,
+  UploadIcon,
   UserIcon,
 } from "@/components/ui";
 import { isClerkAuthMode, isManagedBillingMode } from "@/config/runtime";
@@ -20,6 +21,7 @@ import {
   BillingForm,
   ChangePasswordForm,
   ConnectedAccountsForm,
+  DataImporter,
   ProfileForm,
   SettingsLoadingSkeleton,
 } from "@/features/settings/components";
@@ -29,7 +31,7 @@ import { useSaveSettings, useSettings } from "@/hooks/queries/useSettings";
 import { usePageDataSync } from "@/hooks/usePageDataSync";
 import { useStore } from "@/store/store";
 
-type TabType = "profile" | "billing" | "accounts" | "security";
+type TabType = "profile" | "data" | "billing" | "accounts" | "security";
 
 const BILLING_TAB_ENABLED = isManagedBillingMode;
 const ACCOUNTS_TAB_ENABLED = isClerkAuthMode;
@@ -37,6 +39,7 @@ const ACCOUNTS_TAB_ENABLED = isClerkAuthMode;
 // Valid tab values for validation
 const VALID_TABS = new Set<TabType>([
   "profile",
+  "data",
   ...(BILLING_TAB_ENABLED ? (["billing"] as TabType[]) : []),
   ...(ACCOUNTS_TAB_ENABLED ? (["accounts"] as TabType[]) : []),
   "security",
@@ -231,6 +234,15 @@ export default function SettingsPage() {
                   </>
                 ),
               },
+              {
+                key: "data",
+                label: (
+                  <>
+                    <UploadIcon className="h-4 w-4" />
+                    Import Data
+                  </>
+                ),
+              },
               ...(BILLING_TAB_ENABLED
                 ? [
                     {
@@ -296,6 +308,11 @@ export default function SettingsPage() {
                   isSaving={isSaving}
                   hasChanges={hasSettingsChanges}
                 />
+              </PageTransition>
+            )}
+            {activeTab === "data" && (
+              <PageTransition key="data">
+                <DataImporter />
               </PageTransition>
             )}
             {BILLING_TAB_ENABLED && activeTab === "billing" && (

--- a/frontend/src/features/settings/utils/importer.test.ts
+++ b/frontend/src/features/settings/utils/importer.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  detectImportFormat,
+  normalizeDate,
+  normalizeMealType,
+  normalizeTime,
+  parseCsv,
+  parseImportFile,
+} from "./importer";
+
+describe("Frontend Importer CSV Tokenizer and Normalizers", () => {
+  it("parses CSV with quoted strings correctly", () => {
+    const csv = `Date,Meal,"Food, Name",Calories\n2026-05-01,Breakfast,"Oatmeal, rolled",300`;
+    const rows = parseCsv(csv);
+    expect(rows.length).toBe(2);
+    expect(rows[0]).toEqual(["Date", "Meal", "Food, Name", "Calories"]);
+    expect(rows[1]).toEqual(["2026-05-01", "Breakfast", "Oatmeal, rolled", "300"]);
+  });
+
+  it("normalizes date formats to YYYY-MM-DD", () => {
+    expect(normalizeDate("2026-05-01")).toBe("2026-05-01");
+    expect(normalizeDate("05/01/2026")).toBe("2026-05-01");
+    expect(normalizeDate("5/1/2026")).toBe("2026-05-01");
+    expect(normalizeDate("2026/05/01")).toBe("2026-05-01");
+    expect(normalizeDate("invalid-date")).toBeNull();
+  });
+
+  it("normalizes meal types", () => {
+    expect(normalizeMealType("Breakfast")).toBe("breakfast");
+    expect(normalizeMealType("Morning Snack")).toBe("breakfast");
+    expect(normalizeMealType("Lunch")).toBe("lunch");
+    expect(normalizeMealType("Dinner")).toBe("dinner");
+    expect(normalizeMealType("Snacks")).toBe("snack");
+  });
+
+  it("normalizes times", () => {
+    expect(normalizeTime("1:30 PM")).toBe("13:30:00");
+    expect(normalizeTime("8:15 AM")).toBe("08:15:00");
+    expect(normalizeTime("14:45")).toBe("14:45:00");
+    expect(normalizeTime(undefined, "breakfast")).toBe("08:00:00");
+  });
+});
+
+describe("Frontend Importer Format Parser Support", () => {
+  it("parses MyFitnessPal CSV export", () => {
+    const mfpCsv = `Date,Meal,Calories,Fat (g),Carbohydrates (g),Protein (g),Note
+2026-06-01,Breakfast,450,15,45,30,Egg and toast
+2026-06-01,Lunch,600,20,50,40,Chicken salad`;
+
+    expect(detectImportFormat(mfpCsv)).toBe("myfitnesspal");
+    const result = parseImportFile(mfpCsv);
+    expect(result.format).toBe("myfitnesspal");
+    expect(result.entries.length).toBe(2);
+    expect(result.summary.totalMeals).toBe(2);
+    expect(result.entries[0].protein).toBe(30);
+    expect(result.entries[0].carbs).toBe(45);
+    expect(result.entries[0].fats).toBe(15);
+  });
+
+  it("parses Cronometer CSV export", () => {
+    const cronometerCsv = `Date,Time,Group,Food Name,Amount,Unit,Energy (kcal),Protein (g),Net Carbs (g),Fat (g)
+2026-06-02,08:30:00,Breakfast,Oatmeal with whey,1,serving,400,32,45,8`;
+
+    expect(detectImportFormat(cronometerCsv)).toBe("cronometer");
+    const result = parseImportFile(cronometerCsv);
+    expect(result.entries.length).toBe(1);
+    expect(result.entries[0].protein).toBe(32);
+    expect(result.entries[0].entryTime).toBe("08:30:00");
+  });
+
+  it("parses MacroFactor CSV and JSON export", () => {
+    const mfCsv = `Date,Time,Food Name,Calories (kcal),Protein (g),Fat (g),Carbs (g),Meal,Weight (lbs)
+2026-06-03,09:00:00,Scrambled Eggs,350,24,18,6,Breakfast,180.5`;
+
+    expect(detectImportFormat(mfCsv)).toBe("macrofactor");
+    const result = parseImportFile(mfCsv);
+    expect(result.entries.length).toBe(1);
+    expect(result.weightLogs.length).toBe(1);
+    expect(result.weightLogs[0].weight).toBe(180.5);
+
+    const mfJson = JSON.stringify({
+      source: "macrofactor",
+      foods: [
+        {
+          date: "2026-06-03",
+          name: "Scrambled Eggs",
+          protein: 24,
+          carbs: 6,
+          fat: 18,
+          meal: "Breakfast",
+        },
+      ],
+      weights: [{ date: "2026-06-03", weight: 180.5 }],
+    });
+
+    const jsonResult = parseImportFile(mfJson);
+    expect(jsonResult.entries.length).toBe(1);
+    expect(jsonResult.weightLogs.length).toBe(1);
+  });
+
+  it("parses Lose It CSV export", () => {
+    const loseItCsv = `Date,Name,Type,Quantity,Units,Calories,Fat (g),Protein (g),Carbohydrates (g)
+06/04/2026,Protein Shake,Breakfast,1,scoop,150,2,30,3`;
+
+    expect(detectImportFormat(loseItCsv)).toBe("loseit");
+    const result = parseImportFile(loseItCsv);
+    expect(result.entries.length).toBe(1);
+    expect(result.entries[0].mealName).toBe("Protein Shake");
+    expect(result.entries[0].protein).toBe(30);
+  });
+
+  it("parses MacroTrackr JSON export", () => {
+    const nativeJson = JSON.stringify({
+      version: "1.0",
+      source: "macrotrackr",
+      entries: [
+        {
+          protein: 35,
+          carbs: 50,
+          fats: 12,
+          mealType: "dinner",
+          mealName: "Salmon Bowl",
+          entryDate: "2026-06-05",
+          entryTime: "19:00:00",
+        },
+      ],
+      weightLogs: [
+        {
+          timestamp: "2026-06-05",
+          weight: 77.2,
+        },
+      ],
+    });
+
+    expect(detectImportFormat(nativeJson)).toBe("macrotrackr");
+    const result = parseImportFile(nativeJson);
+    expect(result.entries.length).toBe(1);
+    expect(result.weightLogs.length).toBe(1);
+  });
+});

--- a/frontend/src/features/settings/utils/importer.ts
+++ b/frontend/src/features/settings/utils/importer.ts
@@ -1,0 +1,567 @@
+// src/features/settings/utils/importer.ts
+
+export type ImportFormat =
+  | "myfitnesspal"
+  | "cronometer"
+  | "macrofactor"
+  | "loseit"
+  | "macrotrackr"
+  | "auto"
+  | "unknown";
+
+export interface ParsedMacroEntry {
+  protein: number;
+  carbs: number;
+  fats: number;
+  mealType: "breakfast" | "lunch" | "dinner" | "snack";
+  mealName?: string;
+  entryDate: string; // YYYY-MM-DD
+  entryTime: string; // HH:MM:SS
+  ingredients?: unknown[];
+}
+
+export interface ParsedWeightLog {
+  timestamp: string; // YYYY-MM-DD or ISO
+  weight: number;
+}
+
+export interface ImportResult {
+  format: ImportFormat;
+  entries: ParsedMacroEntry[];
+  weightLogs: ParsedWeightLog[];
+  summary: {
+    totalMeals: number;
+    totalWeightLogs: number;
+    dateRange: {
+      start: string;
+      end: string;
+    } | null;
+    macroSummary: {
+      totalCalories: number;
+      avgDailyCalories: number;
+      avgDailyProtein: number;
+      avgDailyCarbs: number;
+      avgDailyFats: number;
+      uniqueDays: number;
+    };
+  };
+  errors?: string[];
+}
+
+export function parseCsv(text: string): string[][] {
+  const clean = text.replace(/^\uFEFF/, "");
+  const rows: string[][] = [];
+  let currentRow: string[] = [];
+  let currentField = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < clean.length; i++) {
+    const char = clean[i];
+    const nextChar = clean[i + 1];
+
+    if (inQuotes) {
+      if (char === '"') {
+        if (nextChar === '"') {
+          currentField += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        currentField += char;
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true;
+      } else if (char === ",") {
+        currentRow.push(currentField.trim());
+        currentField = "";
+      } else if (char === "\r") {
+        if (nextChar === "\n") {
+          i++;
+        }
+        currentRow.push(currentField.trim());
+        currentField = "";
+        if (currentRow.some((f) => f.length > 0)) {
+          rows.push(currentRow);
+        }
+        currentRow = [];
+      } else if (char === "\n") {
+        currentRow.push(currentField.trim());
+        currentField = "";
+        if (currentRow.some((f) => f.length > 0)) {
+          rows.push(currentRow);
+        }
+        currentRow = [];
+      } else {
+        currentField += char;
+      }
+    }
+  }
+
+  if (currentField.length > 0 || currentRow.length > 0) {
+    currentRow.push(currentField.trim());
+    if (currentRow.some((f) => f.length > 0)) {
+      rows.push(currentRow);
+    }
+  }
+
+  return rows;
+}
+
+export function normalizeDate(dateStr: unknown): string | null {
+  if (typeof dateStr !== "string" || !dateStr.trim()) return null;
+  const trimmed = dateStr.trim();
+
+  // YYYY-MM-DD or YYYY/MM/DD
+  const isoMatch = trimmed.match(/^(\d{4})[-/](\d{1,2})[-/](\d{1,2})/);
+  if (isoMatch && isoMatch[1] && isoMatch[2] && isoMatch[3]) {
+    const [, y, m, d] = isoMatch;
+    return `${y}-${m.padStart(2, "0")}-${d.padStart(2, "0")}`;
+  }
+
+  // MM/DD/YYYY or M/D/YYYY
+  const usMatch = trimmed.match(/^(\d{1,2})[-/](\d{1,2})[-/](\d{4})/);
+  if (usMatch && usMatch[1] && usMatch[2] && usMatch[3]) {
+    const [, m, d, y] = usMatch;
+    const num1 = parseInt(m, 10);
+    const num2 = parseInt(d, 10);
+    if (num1 > 12 && num2 <= 12) {
+      return `${y}-${d.padStart(2, "0")}-${m.padStart(2, "0")}`;
+    }
+    return `${y}-${m.padStart(2, "0")}-${d.padStart(2, "0")}`;
+  }
+
+  // Timestamp or Date.parse
+  const parsed = new Date(trimmed);
+  if (!isNaN(parsed.getTime())) {
+    const year = parsed.getUTCFullYear();
+    const month = String(parsed.getUTCMonth() + 1).padStart(2, "0");
+    const day = String(parsed.getUTCDate()).padStart(2, "0");
+    if (year >= 1990 && year <= 2100) {
+      return `${year}-${month}-${day}`;
+    }
+  }
+
+  return null;
+}
+
+export function normalizeMealType(
+  rawMealType?: unknown,
+): "breakfast" | "lunch" | "dinner" | "snack" {
+  if (typeof rawMealType !== "string" || !rawMealType.trim()) return "snack";
+  const lower = rawMealType.trim().toLowerCase();
+
+  if (lower.includes("break") || lower.includes("morning") || lower === "m1") {
+    return "breakfast";
+  }
+  if (lower.includes("lunch") || lower.includes("midday") || lower === "m2") {
+    return "lunch";
+  }
+  if (
+    lower.includes("din") ||
+    lower.includes("supper") ||
+    lower.includes("evening") ||
+    lower === "m3"
+  ) {
+    return "dinner";
+  }
+  return "snack";
+}
+
+export function normalizeTime(timeStr?: unknown, mealType?: string): string {
+  if (typeof timeStr === "string" && timeStr.trim()) {
+    const trimmed = timeStr.trim();
+    // 12-hour format e.g. 1:30 PM
+    const ampmMatch = trimmed.match(
+      /^(\d{1,2}):(\d{2})(?::(\d{2}))?\s*([aApP][mM])$/i,
+    );
+    if (ampmMatch && ampmMatch[1] && ampmMatch[2] && ampmMatch[4]) {
+      let hours = parseInt(ampmMatch[1], 10);
+      const minutes = ampmMatch[2];
+      const seconds = ampmMatch[3] || "00";
+      const isPm = ampmMatch[4].toLowerCase() === "pm";
+      if (isPm && hours < 12) hours += 12;
+      if (!isPm && hours === 12) hours = 0;
+      return `${String(hours).padStart(2, "0")}:${minutes}:${seconds}`;
+    }
+
+    // 24-hour format e.g. 14:30 or 14:30:00
+    const time24Match = trimmed.match(
+      /^([01]?\d|2[0-3]):([0-5]\d)(?::([0-5]\d))?$/,
+    );
+    if (time24Match && time24Match[1] && time24Match[2]) {
+      const hours = time24Match[1].padStart(2, "0");
+      const minutes = time24Match[2];
+      const seconds = time24Match[3] || "00";
+      return `${hours}:${minutes}:${seconds}`;
+    }
+  }
+
+  switch (mealType) {
+    case "breakfast":
+      return "08:00:00";
+    case "lunch":
+      return "12:30:00";
+    case "dinner":
+      return "18:30:00";
+    case "snack":
+    default:
+      return "15:00:00";
+  }
+}
+
+export function parseNumber(val: unknown, fallback = 0): number {
+  if (typeof val === "number") {
+    return isNaN(val) ? fallback : Math.max(0, val);
+  }
+  if (typeof val !== "string") return fallback;
+
+  const cleaned = val.replace(/,/g, "").replace(/[^\d.-]/g, "").trim();
+  const num = parseFloat(cleaned);
+  return isNaN(num) ? fallback : Math.max(0, Math.round(num * 10) / 10);
+}
+
+export function detectImportFormat(
+  content: string,
+  filename?: string,
+): ImportFormat {
+  const trimmed = content.trim();
+
+  // 1. Check if JSON
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (
+        parsed.source === "macrotrackr" ||
+        parsed.version === "1.0" ||
+        (Array.isArray(parsed) && parsed[0]?.mealType)
+      ) {
+        return "macrotrackr";
+      }
+      if (
+        parsed.source === "macrofactor" ||
+        parsed.foods ||
+        parsed.weights ||
+        parsed.macrofactor
+      ) {
+        return "macrofactor";
+      }
+      if (Array.isArray(parsed.entries) || Array.isArray(parsed)) {
+        return "macrotrackr";
+      }
+    } catch {
+      // not valid JSON, proceed to CSV check
+    }
+  }
+
+  // 2. CSV check
+  const rows = parseCsv(trimmed);
+  if (rows.length === 0 || !rows[0]) return "unknown";
+
+  const headerRow = rows[0].map((h) => h.toLowerCase().trim());
+  const headerString = headerRow.join(" ");
+
+  if (
+    headerString.includes("macrotrackr") ||
+    (headerRow.includes("meal type") &&
+      headerRow.includes("protein") &&
+      headerRow.includes("carbs"))
+  ) {
+    return "macrotrackr";
+  }
+
+  if (
+    headerRow.includes("type") &&
+    headerRow.includes("quantity") &&
+    headerRow.includes("units")
+  ) {
+    return "loseit";
+  }
+
+  if (
+    headerString.includes("cronometer") ||
+    headerRow.includes("energy (kcal)") ||
+    headerRow.includes("net carbs (g)") ||
+    (headerRow.includes("food name") && headerRow.includes("group"))
+  ) {
+    return "cronometer";
+  }
+
+  if (
+    headerString.includes("macrofactor") ||
+    (headerRow.includes("calories (kcal)") && headerRow.includes("meal"))
+  ) {
+    return "macrofactor";
+  }
+
+  if (
+    headerRow.includes("meal") &&
+    (headerRow.includes("fat (g)") ||
+      headerRow.includes("carbohydrates (g)") ||
+      headerRow.includes("calories"))
+  ) {
+    return "myfitnesspal";
+  }
+
+  if (filename) {
+    const fnLower = filename.toLowerCase();
+    if (fnLower.includes("myfitnesspal") || fnLower.includes("mfp"))
+      return "myfitnesspal";
+    if (fnLower.includes("cronometer")) return "cronometer";
+    if (fnLower.includes("macrofactor")) return "macrofactor";
+    if (fnLower.includes("loseit") || fnLower.includes("lose it"))
+      return "loseit";
+    if (fnLower.includes("macrotrackr")) return "macrotrackr";
+  }
+
+  return "unknown";
+}
+
+function computeSummary(
+  entries: ParsedMacroEntry[],
+  weightLogs: ParsedWeightLog[],
+): ImportResult["summary"] {
+  const dates = new Set<string>();
+  let totalCalories = 0;
+  let totalProtein = 0;
+  let totalCarbs = 0;
+  let totalFats = 0;
+
+  for (const entry of entries) {
+    dates.add(entry.entryDate);
+    const calories =
+      Math.round((entry.protein * 4 + entry.carbs * 4 + entry.fats * 9) * 10) /
+      10;
+    totalCalories += calories;
+    totalProtein += entry.protein;
+    totalCarbs += entry.carbs;
+    totalFats += entry.fats;
+  }
+
+  for (const wl of weightLogs) {
+    const d = wl.timestamp.split("T")[0];
+    if (d) {
+      dates.add(d);
+    }
+  }
+
+  const sortedDates = Array.from(dates).sort();
+  const dateRange =
+    sortedDates.length > 0 && sortedDates[0] && sortedDates[sortedDates.length - 1]
+      ? {
+          start: sortedDates[0],
+          end: sortedDates[sortedDates.length - 1]!,
+        }
+      : null;
+
+  const uniqueDays = Math.max(1, sortedDates.length);
+
+  return {
+    totalMeals: entries.length,
+    totalWeightLogs: weightLogs.length,
+    dateRange,
+    macroSummary: {
+      totalCalories: Math.round(totalCalories),
+      avgDailyCalories: Math.round(totalCalories / uniqueDays),
+      avgDailyProtein: Math.round((totalProtein / uniqueDays) * 10) / 10,
+      avgDailyCarbs: Math.round((totalCarbs / uniqueDays) * 10) / 10,
+      avgDailyFats: Math.round((totalFats / uniqueDays) * 10) / 10,
+      uniqueDays: sortedDates.length,
+    },
+  };
+}
+
+export function parseImportFile(
+  content: string,
+  formatOverride?: ImportFormat,
+  filename?: string,
+): ImportResult {
+  const detected =
+    formatOverride && formatOverride !== "auto" && formatOverride !== "unknown"
+      ? formatOverride
+      : detectImportFormat(content, filename);
+
+  const format = detected === "unknown" ? "macrotrackr" : detected;
+  const trimmed = content.trim();
+
+  // Try JSON first if format is JSON or content starts with { or [
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      return parseJsonImport(parsed, format);
+    } catch {
+      // fallback to CSV
+    }
+  }
+
+  return parseCsvImport(content, format);
+}
+
+function parseJsonImport(parsed: any, format: ImportFormat): ImportResult {
+  const entries: ParsedMacroEntry[] = [];
+  const weightLogs: ParsedWeightLog[] = [];
+  const errors: string[] = [];
+
+  // MacroTrackr JSON structure or top-level array
+  const rawEntries = Array.isArray(parsed)
+    ? parsed
+    : parsed.entries || parsed.foods || parsed.nutrition || parsed.meals || [];
+
+  const rawWeights = parsed.weightLogs || parsed.weights || parsed.weight || [];
+
+  if (Array.isArray(rawEntries)) {
+    for (const item of rawEntries) {
+      const entryDate = normalizeDate(item.entryDate || item.date || item.day);
+      if (!entryDate) continue;
+
+      const protein = parseNumber(item.protein);
+      const carbs = parseNumber(item.carbs ?? item.carbohydrates);
+      const fats = parseNumber(item.fats ?? item.fat);
+      const mealType = normalizeMealType(
+        item.mealType || item.meal || item.type || item.group,
+      );
+      const mealName = String(
+        item.mealName || item.name || item.foodName || item.title || "",
+      ).trim();
+      const entryTime = normalizeTime(item.entryTime || item.time, mealType);
+      const ingredients = Array.isArray(item.ingredients)
+        ? item.ingredients
+        : undefined;
+
+      entries.push({
+        protein,
+        carbs,
+        fats,
+        mealType,
+        mealName: mealName || undefined,
+        entryDate,
+        entryTime,
+        ingredients,
+      });
+    }
+  }
+
+  if (Array.isArray(rawWeights)) {
+    for (const item of rawWeights) {
+      const ts = normalizeDate(item.timestamp || item.date);
+      const w = parseNumber(item.weight || item.value);
+      if (ts && w > 0) {
+        weightLogs.push({
+          timestamp: ts,
+          weight: w,
+        });
+      }
+    }
+  }
+
+  return {
+    format,
+    entries,
+    weightLogs,
+    summary: computeSummary(entries, weightLogs),
+    errors: errors.length > 0 ? errors : undefined,
+  };
+}
+
+function parseCsvImport(content: string, format: ImportFormat): ImportResult {
+  const rows = parseCsv(content);
+  const entries: ParsedMacroEntry[] = [];
+  const weightLogs: ParsedWeightLog[] = [];
+  const errors: string[] = [];
+
+  if (rows.length < 2 || !rows[0]) {
+    return {
+      format,
+      entries: [],
+      weightLogs: [],
+      summary: computeSummary([], []),
+      errors: ["File is empty or contains only headers."],
+    };
+  }
+
+  const headers = rows[0].map((h) => h.toLowerCase().trim());
+
+  // Find column indices helper
+  const findCol = (...names: string[]): number => {
+    for (const name of names) {
+      const idx = headers.findIndex(
+        (h) => h === name.toLowerCase() || h.includes(name.toLowerCase()),
+      );
+      if (idx !== -1) return idx;
+    }
+    return -1;
+  };
+
+  const dateIdx = findCol("date", "day", "timestamp");
+  const timeIdx = findCol("time", "entry time");
+  const mealIdx = findCol("meal", "meal type", "type", "group");
+  const nameIdx = findCol("food name", "name", "food", "description", "note");
+  const proteinIdx = findCol("protein (g)", "protein");
+  const carbsIdx = findCol(
+    "carbohydrates (g)",
+    "net carbs (g)",
+    "carbs (g)",
+    "carbs",
+    "carbohydrates",
+  );
+  const fatIdx = findCol("fat (g)", "total fat (g)", "fat", "fats");
+  const weightIdx = findCol(
+    "weight (kg)",
+    "weight (lbs)",
+    "weight",
+    "metric weight",
+  );
+
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row || row.length === 0 || row.every((cell) => cell.trim() === "")) continue;
+
+    const rawDate = dateIdx !== -1 && row[dateIdx] !== undefined ? row[dateIdx] : undefined;
+    const entryDate = normalizeDate(rawDate);
+    if (!entryDate) continue;
+
+    const rawMeal = mealIdx !== -1 && row[mealIdx] !== undefined ? row[mealIdx] : undefined;
+    const mealType = normalizeMealType(rawMeal);
+
+    const mealName = (nameIdx !== -1 && row[nameIdx] !== undefined ? row[nameIdx] : "") || rawMeal || "";
+    const rawTime = timeIdx !== -1 && row[timeIdx] !== undefined ? row[timeIdx] : undefined;
+    const entryTime = normalizeTime(rawTime, mealType);
+
+    const protein = proteinIdx !== -1 && row[proteinIdx] !== undefined ? parseNumber(row[proteinIdx]) : 0;
+    const carbs = carbsIdx !== -1 && row[carbsIdx] !== undefined ? parseNumber(row[carbsIdx]) : 0;
+    const fats = fatIdx !== -1 && row[fatIdx] !== undefined ? parseNumber(row[fatIdx]) : 0;
+
+    // Check if row is purely a weight log entry
+    if (weightIdx !== -1 && row[weightIdx]) {
+      const weightVal = parseNumber(row[weightIdx]);
+      if (weightVal > 0) {
+        weightLogs.push({
+          timestamp: entryDate,
+          weight: weightVal,
+        });
+      }
+    }
+
+    // Only add macro entry if there are valid macros or meal info
+    if (protein > 0 || carbs > 0 || fats > 0 || mealName) {
+      entries.push({
+        protein,
+        carbs,
+        fats,
+        mealType,
+        mealName: mealName ? mealName.trim() : undefined,
+        entryDate,
+        entryTime,
+      });
+    }
+  }
+
+  return {
+    format,
+    entries,
+    weightLogs,
+    summary: computeSummary(entries, weightLogs),
+    errors: errors.length > 0 ? errors : undefined,
+  };
+}

--- a/frontend/src/hooks/queries/useMacroQueries.ts
+++ b/frontend/src/hooks/queries/useMacroQueries.ts
@@ -485,3 +485,23 @@ export function useUpdateMacroTarget() {
     onError: logUpdateMacroTargetError,
   });
 }
+
+export function useImportMacros() {
+  const queryClient = useQueryClient();
+  const logImportError = createMutationErrorLogger("Error importing macro data");
+
+  return useMutation({
+    mutationKey: [...queryKeys.macros.all(), "import"],
+    mutationFn: async (payload: Parameters<typeof macrosApi.importData>[0]) => {
+      return await macrosApi.importData(payload);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.macros.all() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.goals.all() });
+      queryClient.invalidateQueries({ queryKey: ["reporting"] });
+      broadcastLocalDataChange("macros");
+      broadcastLocalDataChange("goals");
+    },
+    onError: logImportError,
+  });
+}

--- a/templates/casaos/docker-compose.yml
+++ b/templates/casaos/docker-compose.yml
@@ -1,0 +1,82 @@
+name: macrotrackr
+services:
+  backend:
+    image: ghcr.io/arogan178/macrotrackr-backend:latest
+    container_name: macrotrackr-backend
+    restart: unless-stopped
+    volumes:
+      - /DATA/AppData/macrotrackr/data:/data
+    environment:
+      - DATABASE_PATH=/data/macrotrackr.db
+      - APP_MODE=self-hosted
+      - AUTH_MODE=local
+      - BILLING_MODE=disabled
+      - ANALYTICS_MODE=disabled
+      - EMAIL_MODE=disabled
+      - APP_URL=http://localhost:5173
+      - CORS_ORIGIN=http://localhost:5173
+      - TRUST_PROXY=true
+    expose:
+      - "3000"
+    networks:
+      - macrotrackr-network
+    x-casaos:
+      envs:
+        - container: DATABASE_PATH
+          description:
+            en_us: Path to the SQLite database file inside the container.
+        - container: APP_URL
+          description:
+            en_us: Public URL to access MacroTrackr UI.
+        - container: CORS_ORIGIN
+          description:
+            en_us: Allowed CORS origin header.
+        - container: TRUST_PROXY
+          description:
+            en_us: Trust incoming proxy headers from the frontend nginx reverse proxy.
+      volumes:
+        - container: /data
+          description:
+            en_us: Persistent storage directory for SQLite database and user data.
+
+  frontend:
+    image: ghcr.io/arogan178/macrotrackr-frontend:latest
+    container_name: macrotrackr-frontend
+    restart: unless-stopped
+    depends_on:
+      - backend
+    ports:
+      - "5173:80"
+    networks:
+      - macrotrackr-network
+    x-casaos:
+      ports:
+        - container: "80"
+          description:
+            en_us: Web UI port for MacroTrackr.
+
+networks:
+  macrotrackr-network:
+    driver: bridge
+
+x-casaos:
+  architectures:
+    - amd64
+    - arm64
+  main: frontend
+  description:
+    en_us: MacroTrackr is an open-source nutrition and macronutrient tracking application designed for self-hosting. Track calories, macros, custom meals, and daily fitness goals with local SQLite data storage and full privacy.
+  tagline:
+    en_us: Modern self-hosted nutrition and macronutrient tracker
+  developer: arogan178
+  author: arogan178
+  icon: https://raw.githubusercontent.com/arogan178/macrotrackr/main/frontend/public/icon.png
+  thumbnail: https://raw.githubusercontent.com/arogan178/macrotrackr/main/frontend/public/icon.png
+  screenshot_link:
+    - https://raw.githubusercontent.com/arogan178/macrotrackr/main/frontend/public/screens/dashboard.png
+    - https://raw.githubusercontent.com/arogan178/macrotrackr/main/frontend/public/screens/food-entry.png
+    - https://raw.githubusercontent.com/arogan178/macrotrackr/main/frontend/public/screens/progress.png
+  category: Health
+  port_map: "5173"
+  scheme: http
+  index: /

--- a/templates/casaos/macrotrackr.json
+++ b/templates/casaos/macrotrackr.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0",
+  "title": {
+    "en_us": "MacroTrackr"
+  },
+  "tagline": {
+    "en_us": "Modern self-hosted nutrition and macronutrient tracker"
+  },
+  "description": {
+    "en_us": "MacroTrackr is an open-source, privacy-first nutrition and macronutrient tracking application designed for self-hosters. Track calories, protein, carbs, fats, custom recipes, and daily fitness goals with local SQLite data storage."
+  },
+  "icon": "https://raw.githubusercontent.com/arogan178/macrotrackr/main/frontend/public/icon.png",
+  "screenshot_link": [
+    "https://raw.githubusercontent.com/arogan178/macrotrackr/main/frontend/public/screens/dashboard.png",
+    "https://raw.githubusercontent.com/arogan178/macrotrackr/main/frontend/public/screens/food-entry.png",
+    "https://raw.githubusercontent.com/arogan178/macrotrackr/main/frontend/public/screens/progress.png"
+  ],
+  "category": "Health",
+  "developer": "arogan178",
+  "author": "arogan178",
+  "port_map": "5173",
+  "scheme": "http",
+  "index": "/",
+  "compose": "https://raw.githubusercontent.com/arogan178/macrotrackr/main/templates/casaos/docker-compose.yml"
+}

--- a/templates/cosmos/servapp.json
+++ b/templates/cosmos/servapp.json
@@ -1,0 +1,58 @@
+{
+  "name": "MacroTrackr",
+  "description": "MacroTrackr is an open-source nutrition and macronutrient tracking application designed for self-hosting with local SQLite storage.",
+  "icon": "https://raw.githubusercontent.com/arogan178/macrotrackr/main/frontend/public/icon.png",
+  "category": "Health",
+  "tags": [
+    "nutrition",
+    "fitness",
+    "macros",
+    "health",
+    "tracker"
+  ],
+  "routes": [
+    {
+      "name": "macrotrackr-ui",
+      "target": "http://macrotrackr-frontend:80",
+      "mode": "SERVAPP",
+      "smartShield": {
+        "enabled": true
+      }
+    }
+  ],
+  "compose": {
+    "version": "3.8",
+    "services": {
+      "backend": {
+        "image": "ghcr.io/arogan178/macrotrackr-backend:latest",
+        "container_name": "macrotrackr-backend",
+        "restart": "unless-stopped",
+        "volumes": [
+          "{DATA_PATH}/macrotrackr/data:/data"
+        ],
+        "environment": [
+          "DATABASE_PATH=/data/macrotrackr.db",
+          "APP_MODE=self-hosted",
+          "AUTH_MODE=local",
+          "BILLING_MODE=disabled",
+          "ANALYTICS_MODE=disabled",
+          "EMAIL_MODE=disabled",
+          "APP_URL=http://localhost:5173",
+          "CORS_ORIGIN=http://localhost:5173",
+          "TRUST_PROXY=true"
+        ]
+      },
+      "frontend": {
+        "image": "ghcr.io/arogan178/macrotrackr-frontend:latest",
+        "container_name": "macrotrackr-frontend",
+        "restart": "unless-stopped",
+        "depends_on": [
+          "backend"
+        ],
+        "ports": [
+          "5173:80"
+        ]
+      }
+    }
+  }
+}

--- a/templates/truenas/docker-compose.yml
+++ b/templates/truenas/docker-compose.yml
@@ -1,0 +1,37 @@
+# TrueNAS SCALE (24.10+ Electric Eel) / Dockge Compose Template
+services:
+  backend:
+    image: ghcr.io/arogan178/macrotrackr-backend:latest
+    container_name: macrotrackr-backend
+    restart: unless-stopped
+    volumes:
+      - /mnt/tank/apps/macrotrackr/data:/data
+    environment:
+      DATABASE_PATH: /data/macrotrackr.db
+      APP_MODE: self-hosted
+      AUTH_MODE: local
+      BILLING_MODE: disabled
+      ANALYTICS_MODE: disabled
+      EMAIL_MODE: disabled
+      APP_URL: http://localhost:5173
+      CORS_ORIGIN: http://localhost:5173
+      TRUST_PROXY: "true"
+    expose:
+      - "3000"
+    networks:
+      - macrotrackr_net
+
+  frontend:
+    image: ghcr.io/arogan178/macrotrackr-frontend:latest
+    container_name: macrotrackr-frontend
+    restart: unless-stopped
+    depends_on:
+      - backend
+    ports:
+      - "5173:80"
+    networks:
+      - macrotrackr_net
+
+networks:
+  macrotrackr_net:
+    driver: bridge

--- a/templates/umbrel/docker-compose.yml
+++ b/templates/umbrel/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.7"
+
+services:
+  backend:
+    image: ghcr.io/arogan178/macrotrackr-backend:latest
+    restart: on-failure
+    volumes:
+      - ${APP_DATA_DIR}/data:/data
+    environment:
+      DATABASE_PATH: /data/macrotrackr.db
+      APP_MODE: self-hosted
+      AUTH_MODE: local
+      BILLING_MODE: disabled
+      ANALYTICS_MODE: disabled
+      EMAIL_MODE: disabled
+      APP_URL: http://umbrel.local:5173
+      CORS_ORIGIN: http://umbrel.local:5173
+      TRUST_PROXY: "true"
+    expose:
+      - "3000"
+
+  frontend:
+    image: ghcr.io/arogan178/macrotrackr-frontend:latest
+    restart: on-failure
+    depends_on:
+      - backend
+    ports:
+      - "5173:80"

--- a/templates/umbrel/umbrel-app.yml
+++ b/templates/umbrel/umbrel-app.yml
@@ -1,0 +1,33 @@
+manifestVersion: 1.1
+id: macrotrackr
+name: MacroTrackr
+tagline: Modern self-hosted nutrition and macronutrient tracker
+icon: https://raw.githubusercontent.com/arogan178/macrotrackr/main/frontend/public/icon.png
+category: Health
+version: "1.0.0"
+port: 5173
+description: >-
+  MacroTrackr is an open-source, privacy-first nutrition and macronutrient tracking application designed for self-hosters.
+  
+  Features:
+  - Daily calorie and macronutrient tracking (Protein, Carbs, Fat)
+  - Custom food database and recipe creation
+  - Progress charts and nutrition history
+  - Local SQLite persistence with zero telemetry
+  - Mobile-responsive web UI and PWA support
+developer: arogan178
+website: https://github.com/arogan178/macrotrackr
+repo: https://github.com/arogan178/macrotrackr
+support: https://github.com/arogan178/macrotrackr/issues
+gallery:
+  - https://raw.githubusercontent.com/arogan178/macrotrackr/main/frontend/public/screens/dashboard.png
+  - https://raw.githubusercontent.com/arogan178/macrotrackr/main/frontend/public/screens/food-entry.png
+  - https://raw.githubusercontent.com/arogan178/macrotrackr/main/frontend/public/screens/progress.png
+releaseNotes: >-
+  Initial release of MacroTrackr for Umbrel App Store.
+dependencies: []
+path: ""
+defaultUsername: ""
+defaultPassword: ""
+submitter: arogan178
+submission: https://github.com/getumbrel/umbrel-apps

--- a/templates/unraid/macrotrackr.xml
+++ b/templates/unraid/macrotrackr.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>MacroTrackr</Name>
+  <Repository>ghcr.io/arogan178/macrotrackr-backend:latest</Repository>
+  <Registry>https://ghcr.io/arogan178/macrotrackr-backend</Registry>
+  <Network>bridge</Network>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/arogan178/macrotrackr/issues</Support>
+  <Project>https://github.com/arogan178/macrotrackr</Project>
+  <Overview>MacroTrackr is an open-source, modern nutrition and macronutrient tracking application designed for self-hosters. Track calories, macros, custom meals, and daily fitness goals with local SQLite data storage and full privacy.</Overview>
+  <Category>Productivity: Tools: Health:</Category>
+  <WebUI>http://[IP]:[PORT:5173]</WebUI>
+  <TemplateURL>https://raw.githubusercontent.com/arogan178/macrotrackr/main/templates/unraid/macrotrackr.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/arogan178/macrotrackr/main/frontend/public/icon.png</Icon>
+  <ExtraParams></ExtraParams>
+  <PostArgs></PostArgs>
+  <CPUset></CPUset>
+  <DateInstalled></DateInstalled>
+  <DonateText></DonateText>
+  <DonateLink></DonateLink>
+  <Requires></Requires>
+  <Config Name="Web UI Port" Target="80" Default="5173" Mode="tcp" Description="Host port for web user interface access." Type="Port" Display="always" Required="true" Mask="false">5173</Config>
+  <Config Name="Backend API Port (Internal)" Target="3000" Default="3000" Mode="tcp" Description="Internal API port." Type="Port" Display="advanced" Required="false" Mask="false">3000</Config>
+  <Config Name="App Data Storage" Target="/data" Default="/mnt/user/appdata/macrotrackr/data" Mode="rw" Description="Host storage path for SQLite database file." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/macrotrackr/data</Config>
+  <Config Name="DATABASE_PATH" Target="DATABASE_PATH" Default="/data/macrotrackr.db" Description="Path inside container where SQLite database is located." Type="Variable" Display="always" Required="true" Mask="false">/data/macrotrackr.db</Config>
+  <Config Name="APP_URL" Target="APP_URL" Default="http://localhost:5173" Description="Full public URL to access MacroTrackr UI (e.g. http://192.168.1.100:5173)." Type="Variable" Display="always" Required="true" Mask="false">http://localhost:5173</Config>
+  <Config Name="CORS_ORIGIN" Target="CORS_ORIGIN" Default="http://localhost:5173" Description="Allowed CORS origins for API requests (match your APP_URL)." Type="Variable" Display="advanced" Required="false" Mask="false">http://localhost:5173</Config>
+  <Config Name="APP_MODE" Target="APP_MODE" Default="self-hosted" Description="Application deployment mode (self-hosted or managed)." Type="Variable" Display="advanced" Required="false" Mask="false">self-hosted</Config>
+  <Config Name="AUTH_MODE" Target="AUTH_MODE" Default="local" Description="Authentication provider (local or clerk)." Type="Variable" Display="advanced" Required="false" Mask="false">local</Config>
+  <Config Name="BILLING_MODE" Target="BILLING_MODE" Default="disabled" Description="Billing integration mode (disabled or managed)." Type="Variable" Display="advanced" Required="false" Mask="false">disabled</Config>
+  <Config Name="ANALYTICS_MODE" Target="ANALYTICS_MODE" Default="disabled" Description="Analytics provider mode (disabled or posthog)." Type="Variable" Display="advanced" Required="false" Mask="false">disabled</Config>
+  <Config Name="EMAIL_MODE" Target="EMAIL_MODE" Default="disabled" Description="Email notification provider (disabled, smtp, or resend)." Type="Variable" Display="advanced" Required="false" Mask="false">disabled</Config>
+  <Config Name="TRUST_PROXY" Target="TRUST_PROXY" Default="true" Description="Trust proxy headers (X-Real-IP / X-Forwarded-For) from frontend proxy." Type="Variable" Display="advanced" Required="false" Mask="false">true</Config>
+</Container>


### PR DESCRIPTION
### Summary of Changes

1. **Option 2: 1-Click Data Importers**
   - Universal parser & auto-detector for **MyFitnessPal**, **Cronometer**, **MacroFactor**, **Lose It!**, and **MacroTrackr native** JSON & CSV backups.
   - Transactional backend batch import endpoint: `POST /api/macros/import`.
   - Settings page **"Import Data"** tab with drag-and-drop file upload, platform auto-detection, preview summary cards, and sample entries table.
   - Comprehensive test suite for backend parser & frontend component.

2. **Option 3: 1-Click Self-Host App Store Templates**
   - **Unraid**: Community Applications XML template (`templates/unraid/macrotrackr.xml`).
   - **CasaOS & ZimaOS**: Docker Compose (`templates/casaos/docker-compose.yml`) and AppStore JSON manifest (`templates/casaos/macrotrackr.json`).
   - **Umbrel**: App Store manifest (`templates/umbrel/umbrel-app.yml`) and Compose stack (`templates/umbrel/docker-compose.yml`).
   - **Cosmos Cloud**: ServApp template (`templates/cosmos/servapp.json`).
   - **TrueNAS SCALE / Dockge**: Compose manifest (`templates/truenas/docker-compose.yml`).
   - Documentation guide: `docs/self-hosting.md` linked in `README.md`.

3. **Option 4: Shareable Macro Snapshot**
   - Strava/Whoop-style social scorecard modal (`MacroSnapshotModal`).
   - High-resolution (1080×1350) Canvas 2D card generator with branding, calories, macros, streak, and compliance score (`macroSnapshotCanvas`).
   - Native Web Share API, Clipboard PNG copy, and direct PNG download.
   - Integrated into **Daily Summary** panel and **Analytics/Reporting** page.