### PR TITLE
Fix SEO fallback flash on refresh

### DIFF
--- a/frontend/scripts/prerender.mjs
+++ b/frontend/scripts/prerender.mjs
@@ -23,7 +23,12 @@ if (!fs.existsSync(templatePath)) {
   process.exit(1);
 }
 
-const baseTemplate = fs.readFileSync(templatePath, "utf8");
+const baseTemplate = fs
+  .readFileSync(templatePath, "utf8")
+  .replace(
+    /<script(?![^>]*\bdata-cfasync=)([^>]*\btype=["']module["'])/i,
+    '<script data-cfasync="false"$1'
+  );
 
 // Load comparisons catalog
 const comparisons = [
@@ -427,11 +432,12 @@ for (const page of pages) {
     html = html.replace("</head>", `${page.extraHead}\n</head>`);
   }
 
-  // Inject Pre-rendered Body into #root for crawlers
+  // Keep crawler copy available when JavaScript is disabled without letting it
+  // flash before the client-rendered app mounts.
   if (page.bodyHtml) {
     html = html.replace(
-      '<div id="root"></div>',
-      `<div id="root">${page.bodyHtml}</div>`
+      "</noscript>",
+      `${page.bodyHtml}\n    </noscript>`
     );
   }
 

--- a/frontend/src/lib/prerenderOutput.test.ts
+++ b/frontend/src/lib/prerenderOutput.test.ts
@@ -1,0 +1,88 @@
+import { execFileSync } from "node:child_process";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const FRONTEND_ROOT = process.cwd();
+const PRERENDER_SCRIPT = path.join(
+  FRONTEND_ROOT,
+  "scripts",
+  "prerender.mjs",
+);
+const temporaryDirectories: string[] = [];
+
+const htmlTemplate = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta name="description" content="Default description" />
+    <meta property="og:title" content="Default title" />
+    <meta property="og:description" content="Default description" />
+    <meta name="twitter:title" content="Default title" />
+    <meta name="twitter:description" content="Default description" />
+    <title>MacroTrackr</title>
+  </head>
+  <body>
+    <noscript>MacroTrackr requires JavaScript to run.</noscript>
+    <div id="root"></div>
+    <script type="module" src="/assets/index.js"></script>
+  </body>
+</html>`;
+
+function prerenderHomepage(): string {
+  const fixtureRoot = mkdtempSync(path.join(tmpdir(), "macrotrackr-prerender-"));
+  temporaryDirectories.push(fixtureRoot);
+
+  const scriptsDirectory = path.join(fixtureRoot, "scripts");
+  const distributionDirectory = path.join(fixtureRoot, "dist");
+  const dataDirectory = path.join(fixtureRoot, "src", "data");
+  mkdirSync(scriptsDirectory, { recursive: true });
+  mkdirSync(distributionDirectory, { recursive: true });
+  mkdirSync(dataDirectory, { recursive: true });
+
+  const fixtureScript = path.join(scriptsDirectory, "prerender.mjs");
+  copyFileSync(PRERENDER_SCRIPT, fixtureScript);
+  writeFileSync(path.join(distributionDirectory, "index.html"), htmlTemplate);
+  writeFileSync(path.join(dataDirectory, "blog-posts.json"), "[]");
+
+  execFileSync(process.execPath, [fixtureScript], {
+    cwd: fixtureRoot,
+    env: { ...process.env, VITE_APP_URL: "https://macrotrackr.test" },
+  });
+
+  return readFileSync(path.join(distributionDirectory, "index.html"), "utf8");
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("pre-rendered HTML", () => {
+  it("keeps crawler copy inside noscript and leaves the React root empty", () => {
+    const html = prerenderHomepage();
+    const noscript = html.match(/<noscript>([\S\s]*?)<\/noscript>/)?.[1];
+
+    expect(html).toContain('<div id="root"></div>');
+    expect(noscript).toContain(
+      "MacroTrackr — Fast, Open Source Macro Tracking",
+    );
+  });
+
+  it("exempts the Vite entry module from Cloudflare Rocket Loader", () => {
+    const html = prerenderHomepage();
+
+    expect(html).toContain(
+      '<script data-cfasync="false" type="module" src="/assets/index.js"></script>',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- keep route-specific SEO fallback copy inside `noscript` so React mounts into an empty root
- add the Cloudflare Rocket Loader exemption to the final generated module script
- cover both behaviors with a post-build regression test

## Root cause

The SEO pre-renderer inserted visible fallback markup into `#root`. Browsers painted it before `createRoot().render()` replaced it, and Cloudflare Rocket Loader delayed that replacement.

## Verification

- `bun run --cwd frontend test -- src/lib/prerenderOutput.test.ts`
- `bun run --cwd frontend test` (136 files, 769 tests)
- `bun run --cwd frontend typecheck`
- `bun run --cwd frontend lint`
- `bun run build`
- served `dist` and confirmed an empty root, fallback copy inside `noscript`, retained `data-cfasync="false"`, and no visible bare fallback in the browser