### PR TITLE
Automate growth funnel verification

### DIFF
--- a/.cursor/skills/verify-macrotrackr/SKILL.md
+++ b/.cursor/skills/verify-macrotrackr/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: verify-macrotrackr
+description: Drive MacroTrackr through its public and authenticated user journeys, capture durable evidence, and clean up disposable test state.
+---
+
+# Verify MacroTrackr
+
+Use this skill after changing a user-visible MacroTrackr journey or its analytics.
+
+## Launch
+
+For a public production check, use `https://macrotrackr.com` directly.
+
+For a local production build:
+
+```sh
+bun run build
+bunx --cwd frontend vite preview --host 127.0.0.1 --port 4173
+```
+
+Record the preview process ID. Do not kill processes by name.
+
+Authenticated managed checks require the secrets documented by
+`.github/workflows/growth-health.yml`. Run them with:
+
+```sh
+GROWTH_CANARY=true bun run --cwd frontend test:growth-canary
+```
+
+## Doctor
+
+Before driving the UI:
+
+```sh
+curl --fail --silent --show-error "$BASE_URL/" >/dev/null
+```
+
+For the managed canary, also run:
+
+```sh
+bun run --cwd frontend test:growth-canary -- --list
+```
+
+If either command fails, fix launch or configuration before interacting with
+the application.
+
+## Drive
+
+Use the smallest feature file in `features/` that covers the change. Prefer
+roles, labels, and visible names over CSS selectors. Never send analytics
+events directly when the user journey can produce them.
+
+Public landing verification:
+
+```sh
+bun .cursor/skills/verify-macrotrackr/scripts/verify-public-landing.mjs \
+  --base-url "${BASE_URL:-https://macrotrackr.com}" \
+  --output-dir .artifacts/verify-macrotrackr/public-landing
+```
+
+## Evidence
+
+Keep screenshots, traces, and machine-readable results under
+`.artifacts/verify-macrotrackr/` locally or as GitHub Actions artifacts. Each
+result must state the URL, timestamp, assertions, and outcome.
+
+For analytics checks, the managed canary writes `posthog-events.json` beside
+the Playwright trace. A passing page interaction without its expected event is
+not a passing analytics check.
+
+## Cleanup
+
+Close the browser context. If a local preview was started, kill only the
+recorded process ID and confirm the port is closed. The managed canary deletes
+the exact disposable Clerk user it created; the Clerk deletion webhook removes
+the matching application account. Never bulk-delete users or database rows.
+
+Do not delete `.artifacts/verify-macrotrackr/` until the evidence has been
+reviewed. It is ignored by Git.
+
+## Helpers
+
+- `scripts/verify-public-landing.mjs`: verifies the rendered public landing
+  headline and primary CTA, then saves a screenshot and JSON result.
+- `frontend/e2e/growth-canary.test.ts`: drives disposable managed-account and
+  importer journeys, checks PostHog, and cleans up Clerk users.

--- a/.cursor/skills/verify-macrotrackr/features/README.md
+++ b/.cursor/skills/verify-macrotrackr/features/README.md
@@ -1,0 +1,12 @@
+# MacroTrackr verification map
+
+Start with the feature closest to the change:
+
+- `public-landing.md`: anonymous landing and registration entry point.
+- `profile-onboarding.md`: managed signup handoff and profile completion.
+- `meal-tracking.md`: first manual meal and activation.
+- `data-import.md`: importer preview, execution, and activation events.
+- `billing.md`: paywall and checkout-session creation.
+
+Authenticated features use the disposable-user managed canary. Public pages
+use the lightweight landing helper.

--- a/.cursor/skills/verify-macrotrackr/features/billing.md
+++ b/.cursor/skills/verify-macrotrackr/features/billing.md
@@ -1,0 +1,24 @@
+# Billing
+
+## Sub-features
+
+- Pro paywall impression
+- Pricing plan choice
+- Checkout-session request
+
+## How to get to it (user POV)
+
+As a free user, open Analytics, select a locked 30-day range, choose `Upgrade
+to Pro`, and then choose a plan on `/pricing`.
+
+## Driving it with Playwright
+
+The managed canary asserts the upgrade modal, waits for the real
+`/api/billing/checkout` response, and verifies both `paywall_viewed` and
+`checkout_started` in PostHog.
+
+## Gotchas
+
+- Enabling this against production creates a live Stripe checkout session but
+  does not submit payment.
+- Prefer a managed staging URL backed by a Stripe sandbox when one exists.

--- a/.cursor/skills/verify-macrotrackr/features/data-import.md
+++ b/.cursor/skills/verify-macrotrackr/features/data-import.md
@@ -1,0 +1,26 @@
+# Data import
+
+## Sub-features
+
+- Format detection
+- Import preview
+- Import execution
+- Import activation events
+
+## How to get to it (user POV)
+
+Open `/settings?tab=data`, select an export file, review the preview, and
+confirm the import.
+
+## Driving it with Playwright
+
+Create the minimal MyFitnessPal CSV in the current test output directory, set
+it on the file input, assert the preview row, confirm import, and assert `Import
+Successful!`. Verify `import_previewed`, `import_completed`, and
+`first_meal_logged` in PostHog.
+
+## Gotchas
+
+- Keep fixtures free of real nutrition or health data.
+- The test output directory is disposable, but the PostHog evidence is kept as
+  an artifact.

--- a/.cursor/skills/verify-macrotrackr/features/meal-tracking.md
+++ b/.cursor/skills/verify-macrotrackr/features/meal-tracking.md
@@ -1,0 +1,22 @@
+# Meal tracking
+
+## Sub-features
+
+- Manual meal fields
+- Entry submission
+- First-meal activation event
+
+## How to get to it (user POV)
+
+Finish onboarding and use `Log a Meal` on `/home`.
+
+## Driving it with Playwright
+
+Fill the labelled meal name, protein, carbs, and fats inputs, choose `Add
+Entry`, and assert that the meal appears in history. The managed canary then
+requires `first_meal_logged` in PostHog.
+
+## Gotchas
+
+- Do not call the macro API directly; that misses the form and client journey.
+- Use a unique meal name when debugging repeated runs.

--- a/.cursor/skills/verify-macrotrackr/features/profile-onboarding.md
+++ b/.cursor/skills/verify-macrotrackr/features/profile-onboarding.md
@@ -1,0 +1,28 @@
+# Profile onboarding
+
+## Sub-features
+
+- Registration entry
+- Clerk account handoff
+- Basic profile
+- Activity level
+- Switching source
+- Initial weight goal
+
+## How to get to it (user POV)
+
+Choose `Start free`, continue with email, and finish the three onboarding
+steps.
+
+## Driving it with Playwright
+
+Use `registerThroughUi` and `completeProfile` in
+`frontend/e2e/growth-canary.test.ts`. The canary provisions a verified,
+disposable Clerk user first so production email verification is not required.
+
+## Gotchas
+
+- The test email local part must contain `+clerk_test` so analytics classifies
+  it as synthetic.
+- `What are you switching from?` is required and uses fixed values.
+- Wait for `/home`; a button click alone does not prove backend sync completed.

--- a/.cursor/skills/verify-macrotrackr/features/public-landing.md
+++ b/.cursor/skills/verify-macrotrackr/features/public-landing.md
@@ -1,0 +1,25 @@
+# Public landing
+
+## Sub-features
+
+- Initial rendered headline
+- Primary registration CTA
+- Calculator secondary path
+- UTM-bearing entry URLs
+
+## How to get to it (user POV)
+
+Open `/` while signed out. The primary action is `Start free`.
+
+## Driving it with Playwright
+
+Run `scripts/verify-public-landing.mjs`. It loads the page, asserts the real
+headline and primary CTA, checks that the CTA targets registration, and saves
+evidence.
+
+## Gotchas
+
+- Use a hard navigation so the server-delivered HTML and startup path are
+  exercised.
+- The service worker may cache a previous build in a long-lived browser. The
+  helper uses a fresh browser context.

--- a/.cursor/skills/verify-macrotrackr/scripts/verify-public-landing.mjs
+++ b/.cursor/skills/verify-macrotrackr/scripts/verify-public-landing.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { chromium } from "@playwright/test";
+
+function readArgument(name, fallback) {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? fallback : process.argv[index + 1];
+}
+
+const baseUrl = readArgument("--base-url", "https://macrotrackr.com");
+const outputDirectory = readArgument(
+  "--output-dir",
+  ".artifacts/verify-macrotrackr/public-landing",
+);
+
+if (!baseUrl || !outputDirectory) {
+  throw new Error("--base-url and --output-dir require values");
+}
+
+await mkdir(outputDirectory, { recursive: true });
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext();
+const page = await context.newPage();
+const assertions = [];
+
+try {
+  await page.goto(baseUrl, { waitUntil: "networkidle" });
+  const headline = page.getByRole("heading", {
+    name: /Know what you ate\. Without the admin\./u,
+  });
+  await headline.waitFor({ state: "visible" });
+  assertions.push("landing headline is visible");
+
+  const hero = page.locator("section").filter({ has: headline }).first();
+  const startFree = hero.getByRole("link", {
+    name: "Start free",
+    exact: true,
+  });
+  await startFree.waitFor({ state: "visible" });
+  const href = await startFree.getAttribute("href");
+  if (!href?.startsWith("/register")) {
+    throw new Error(`Start free points to ${href ?? "no URL"}`);
+  }
+  assertions.push("primary CTA points to registration");
+
+  await page.screenshot({
+    fullPage: true,
+    path: `${outputDirectory}/landing.png`,
+  });
+  await writeFile(
+    `${outputDirectory}/result.json`,
+    JSON.stringify(
+      {
+        assertions,
+        checkedAt: new Date().toISOString(),
+        outcome: "passed",
+        url: page.url(),
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  await context.close();
+  await browser.close();
+}

--- a/.github/workflows/growth-health.yml
+++ b/.github/workflows/growth-health.yml
@@ -1,0 +1,94 @@
+name: Growth Health
+
+concurrency:
+  group: growth-health
+  cancel-in-progress: false
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      run_canary:
+        description: Run the managed UI journey before the report
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  baseline:
+    if: vars.GROWTH_REPORT_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Capture 30-day customer baseline
+        env:
+          POSTHOG_API_HOST: https://eu.posthog.com
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_PROJECT_ID: "83196"
+        run: |
+          bun run growth:report --days 30 | tee growth-report.txt
+          {
+            echo '## 30-day customer growth report'
+            echo '```text'
+            cat growth-report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload baseline
+        uses: actions/upload-artifact@v6
+        with:
+          name: growth-report-${{ github.run_id }}
+          path: growth-report.txt
+          retention-days: 90
+
+  managed-canary:
+    if: >-
+      vars.GROWTH_CANARY_ENABLED == 'true' &&
+      (github.event_name == 'schedule' || inputs.run_canary)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install browser
+        run: bunx playwright install --with-deps chromium
+
+      - name: Drive managed growth journey
+        env:
+          CLERK_PUBLISHABLE_KEY: ${{ secrets.GROWTH_CANARY_CLERK_PUBLISHABLE_KEY }}
+          CLERK_SECRET_KEY: ${{ secrets.GROWTH_CANARY_CLERK_SECRET_KEY }}
+          GROWTH_CANARY_EMAIL_DOMAIN: ${{ secrets.GROWTH_CANARY_EMAIL_DOMAIN }}
+          GROWTH_CANARY_USER_PASSWORD: ${{ secrets.GROWTH_CANARY_USER_PASSWORD }}
+          FRONTEND_URL: https://macrotrackr.com
+          GROWTH_CANARY: "true"
+          POSTHOG_API_HOST: https://eu.posthog.com
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_PROJECT_ID: "83196"
+        run: bun run test:growth-canary
+
+      - name: Upload browser evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: growth-canary-${{ github.run_id }}
+          path: frontend/test-results/growth-canary/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ frontend/.github/instructions/tanstack-react-router_guide.instructions.md
 frontend/.github/instructions/tanstack-react-router_routing.instructions.md
 frontend/.github/instructions/tanstack-react-router_setup-and-architecture.instructions.md
 frontend/test-results/
+.artifacts/
 .desloppify/
 .codex
 .opencode/

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,6 +26,8 @@ EMAIL_MODE=disabled
 # Managed-only analytics (self-hosted mode requires analytics to stay disabled)
 # POSTHOG_KEY=phc_...
 # POSTHOG_HOST=https://eu.i.posthog.com
+# Comma-separated team/admin emails excluded from customer growth reporting.
+# ANALYTICS_INTERNAL_EMAILS=owner@example.com
 
 # --- Telemetry & Metrics (Optional) ---
 ENABLE_METRICS=false

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -68,6 +68,15 @@ const BaseEnvSchema = z.object({
 
   POSTHOG_KEY: z.string().optional(),
   POSTHOG_HOST: z.string().url("POSTHOG_HOST must be a valid URL").optional(),
+  ANALYTICS_INTERNAL_EMAILS: z
+    .string()
+    .default("")
+    .transform((value) =>
+      value
+        .split(",")
+        .map((email) => email.trim().toLowerCase())
+        .filter(Boolean),
+    ),
 
   SMTP_HOST: z.string().optional(),
   SMTP_PORT: z.coerce.number().int().positive().optional(),

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -28,6 +28,7 @@ const SCHEMA_SQL = `
             weight REAL,
             gender TEXT CHECK(gender IN ('male', 'female')),
             activity_level INTEGER CHECK(activity_level BETWEEN 1 AND 5),
+            switching_source TEXT CHECK(switching_source IN ('cronometer', 'loseit', 'macrofactor', 'myfitnesspal', 'new_to_tracking', 'other', 'spreadsheet', 'unknown')),
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
             updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
@@ -169,25 +170,23 @@ function checkAndAddColumn(
   tableName: string,
   columnName: string,
   columnDefinition: string,
-  updateLogic?: string
+  updateLogic?: string,
 ) {
   const columnExists = db
     .prepare(
-      `SELECT COUNT(*) as count FROM pragma_table_info(?) WHERE name = ?`
+      `SELECT COUNT(*) as count FROM pragma_table_info(?) WHERE name = ?`,
     )
     .get(tableName, columnName) as { count: number };
 
   if (columnExists.count === 0) {
-    logger.info(
-      `    Adding column '${columnName}' to table '${tableName}'...`
-    );
+    logger.info(`    Adding column '${columnName}' to table '${tableName}'...`);
     try {
       db.exec(
-        `ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${columnDefinition}`
+        `ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${columnDefinition}`,
       );
       if (updateLogic) {
         logger.info(
-          `       Running update logic for new column '${columnName}'...`
+          `       Running update logic for new column '${columnName}'...`,
         );
         db.exec(updateLogic);
       }
@@ -199,7 +198,7 @@ function checkAndAddColumn(
           tableName,
           columnName,
         },
-        `Failed to add column '${columnName}' to '${tableName}'`
+        `Failed to add column '${columnName}' to '${tableName}'`,
       );
     }
   }
@@ -212,9 +211,15 @@ function applyMigrations(db: Database) {
   checkAndAddColumn(db, "users", "clerk_id", "TEXT");
   checkAndAddColumn(
     db,
+    "user_details",
+    "switching_source",
+    "TEXT CHECK(switching_source IN ('cronometer', 'loseit', 'macrofactor', 'myfitnesspal', 'new_to_tracking', 'other', 'spreadsheet', 'unknown'))",
+  );
+  checkAndAddColumn(
+    db,
     "macro_entries",
     "meal_type",
-    "TEXT DEFAULT 'snack' CHECK(meal_type IN ('breakfast', 'lunch', 'dinner', 'snack'))"
+    "TEXT DEFAULT 'snack' CHECK(meal_type IN ('breakfast', 'lunch', 'dinner', 'snack'))",
   );
   checkAndAddColumn(db, "macro_entries", "meal_name", "TEXT DEFAULT ''");
   checkAndAddColumn(
@@ -222,14 +227,14 @@ function applyMigrations(db: Database) {
     "macro_entries",
     "entry_date",
     "TEXT",
-    "UPDATE macro_entries SET entry_date = DATE(created_at) WHERE entry_date IS NULL"
+    "UPDATE macro_entries SET entry_date = DATE(created_at) WHERE entry_date IS NULL",
   );
   checkAndAddColumn(
     db,
     "macro_entries",
     "entry_time",
     "TEXT",
-    "UPDATE macro_entries SET entry_time = '12:00:00' WHERE entry_time IS NULL"
+    "UPDATE macro_entries SET entry_time = '12:00:00' WHERE entry_time IS NULL",
   );
 
   // Apply subscription-related column additions to users table
@@ -237,9 +242,14 @@ function applyMigrations(db: Database) {
     db,
     "users",
     "subscription_status",
-    "subscription_status TEXT DEFAULT 'free'"
+    "subscription_status TEXT DEFAULT 'free'",
   );
-  checkAndAddColumn(db, "users", "stripe_customer_id", "stripe_customer_id TEXT");
+  checkAndAddColumn(
+    db,
+    "users",
+    "stripe_customer_id",
+    "stripe_customer_id TEXT",
+  );
   checkAndAddColumn(db, "users", "updated_at", "updated_at DATETIME");
   // Backfill updated_at for existing rows
   try {
@@ -263,16 +273,20 @@ function applyMigrations(db: Database) {
   // Habits migration
   try {
     const habitsCreate = db
-      .prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'habits'")
+      .prepare(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'habits'",
+      )
       .get() as { sql?: string } | undefined;
 
     const hasOldCheck =
       habitsCreate?.sql?.includes(
-        "accent_color TEXT CHECK(accent_color IN ('indigo', 'blue', 'green', 'purple'))"
+        "accent_color TEXT CHECK(accent_color IN ('indigo', 'blue', 'green', 'purple'))",
       ) ?? false;
 
     if (hasOldCheck) {
-      logger.info("    Migrating habits table to remove accent_color CHECK constraint...");
+      logger.info(
+        "    Migrating habits table to remove accent_color CHECK constraint...",
+      );
       db.exec("BEGIN IMMEDIATE TRANSACTION;");
       db.exec(`
         CREATE TABLE IF NOT EXISTS habits_new (
@@ -303,7 +317,10 @@ function applyMigrations(db: Database) {
       logger.info("    habits table migrated successfully.");
     }
   } catch (error) {
-    logger.error({ error }, "    Failed migrating habits table; continuing with initialization");
+    logger.error(
+      { error },
+      "    Failed migrating habits table; continuing with initialization",
+    );
     try {
       db.exec("ROLLBACK;");
     } catch {
@@ -318,38 +335,94 @@ function applyMigrations(db: Database) {
 
 function createIndexes(db: Database) {
   logger.info("    Creating indexes...");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_macro_entries_user_date ON macro_entries(user_id, entry_date)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_macro_entries_user_id ON macro_entries(user_id)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_macro_entries_date ON macro_entries(entry_date)");
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_macro_entries_user_date ON macro_entries(user_id, entry_date)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_macro_entries_user_id ON macro_entries(user_id)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_macro_entries_date ON macro_entries(entry_date)",
+  );
   db.exec("CREATE INDEX IF NOT EXISTS idx_users_email ON users(email)");
-  db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_users_clerk_id ON users(clerk_id)");
+  db.exec(
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_users_clerk_id ON users(clerk_id)",
+  );
   db.exec("CREATE INDEX IF NOT EXISTS idx_habits_user_id ON habits(user_id)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_habits_user_active ON habits(user_id, is_complete)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_weight_goals_user ON weight_goals(user_id)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_goals_user_id ON weight_goals(user_id)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_macro_targets_user ON macro_targets(user_id)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_weight_log_user_timestamp ON weight_log(user_id, timestamp)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_weight_log_user_created_at ON weight_log(user_id, created_at)");
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_habits_user_active ON habits(user_id, is_complete)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_weight_goals_user ON weight_goals(user_id)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_goals_user_id ON weight_goals(user_id)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_macro_targets_user ON macro_targets(user_id)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_weight_log_user_timestamp ON weight_log(user_id, timestamp)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_weight_log_user_created_at ON weight_log(user_id, created_at)",
+  );
 
   logger.info("    Creating compound performance indexes...");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_macro_entries_user_date_meal ON macro_entries(user_id, entry_date, meal_type)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_macro_entries_user_date_desc ON macro_entries(user_id, entry_date DESC, created_at DESC)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_weight_log_user_timestamp_desc ON weight_log(user_id, timestamp DESC)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_habits_user_complete ON habits(user_id, is_complete)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_habits_user_created ON habits(user_id, created_at DESC)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_user_details_user ON user_details(user_id)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_users_subscription_status ON users(subscription_status)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_users_stripe_customer_id ON users(stripe_customer_id)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_subscriptions_user_id ON subscriptions(user_id)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_subscriptions_stripe_subscription_id ON subscriptions(stripe_subscription_id)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_subscriptions_status ON subscriptions(status)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_subscriptions_active_until ON subscriptions(current_period_end)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_saved_meals_user_created ON saved_meals(user_id, created_at DESC)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user_id ON password_reset_tokens(user_id)");
-  db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_password_reset_tokens_hash ON password_reset_tokens(token_hash)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_expires ON password_reset_tokens(expires_at)");
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_macro_entries_user_date_meal ON macro_entries(user_id, entry_date, meal_type)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_macro_entries_user_date_desc ON macro_entries(user_id, entry_date DESC, created_at DESC)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_weight_log_user_timestamp_desc ON weight_log(user_id, timestamp DESC)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_habits_user_complete ON habits(user_id, is_complete)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_habits_user_created ON habits(user_id, created_at DESC)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_user_details_user ON user_details(user_id)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_users_subscription_status ON users(subscription_status)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_users_stripe_customer_id ON users(stripe_customer_id)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_subscriptions_user_id ON subscriptions(user_id)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_subscriptions_stripe_subscription_id ON subscriptions(stripe_subscription_id)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_subscriptions_status ON subscriptions(status)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_subscriptions_active_until ON subscriptions(current_period_end)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_saved_meals_user_created ON saved_meals(user_id, created_at DESC)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user_id ON password_reset_tokens(user_id)",
+  );
+  db.exec(
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_password_reset_tokens_hash ON password_reset_tokens(token_hash)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_expires ON password_reset_tokens(expires_at)",
+  );
 }
 
 /**

--- a/backend/src/modules/user/routes.ts
+++ b/backend/src/modules/user/routes.ts
@@ -19,6 +19,10 @@ import { loggerHelpers, logger } from "../../lib/observability/logger";
 import { publishUserSyncEvent } from "../../lib/sync/eventBus";
 import { getConfig } from "../../config";
 import { captureProductEvent } from "../../lib/analytics/product-analytics";
+import {
+  resolveAnalyticsTrafficType,
+  type SwitchingSource,
+} from "@shared/product-analytics";
 
 type UserRouteContext = AuthenticatedRouteContextWithUser<
   Record<string, unknown>
@@ -46,6 +50,7 @@ interface UserDetailsResult {
   weight: number | null;
   gender: "male" | "female" | null;
   activity_level: number | null;
+  switching_source: SwitchingSource | null;
 }
 
 function normalizeSubscriptionStatus(
@@ -93,7 +98,8 @@ export const userRoutes = (app: Elysia) =>
               db,
               `SELECT u.id, u.email, u.first_name, u.last_name, u.created_at,
                     u.subscription_status,
-                      ud.date_of_birth, ud.height, ud.weight, ud.gender, ud.activity_level
+                      ud.date_of_birth, ud.height, ud.weight, ud.gender, ud.activity_level,
+                      ud.switching_source
                FROM users u
                LEFT JOIN user_details ud ON u.id = ud.user_id
                WHERE u.id = ?
@@ -116,6 +122,11 @@ export const userRoutes = (app: Elysia) =>
               weight: dbResult.weight,
               gender: dbResult.gender,
               activityLevel: dbResult.activity_level,
+              switchingSource: dbResult.switching_source ?? null,
+              analyticsTrafficType: resolveAnalyticsTrafficType(
+                dbResult.email,
+                getConfig().ANALYTICS_INTERNAL_EMAILS,
+              ),
               isProfileComplete: !!dbResult.date_of_birth,
               subscription: {
                 status: normalizeSubscriptionStatus(
@@ -351,14 +362,21 @@ export const userRoutes = (app: Elysia) =>
               },
             );
 
-            const { dateOfBirth, height, weight, gender, activityLevel } =
-              body as {
-                dateOfBirth?: string;
-                height?: number;
-                weight?: number;
-                gender?: "male" | "female";
-                activityLevel?: number;
-              };
+            const {
+              dateOfBirth,
+              height,
+              weight,
+              gender,
+              activityLevel,
+              switchingSource,
+            } = body as {
+              dateOfBirth?: string;
+              height?: number;
+              weight?: number;
+              gender?: "male" | "female";
+              activityLevel?: number;
+              switchingSource?: SwitchingSource;
+            };
 
             const { profileCompleted, response } = await withTransactionAsync(
               db,
@@ -375,15 +393,16 @@ export const userRoutes = (app: Elysia) =>
                 safeExecute(
                   db,
                   `INSERT INTO user_details (
-                   user_id, date_of_birth, height, weight, gender, activity_level, updated_at
+                   user_id, date_of_birth, height, weight, gender, activity_level, switching_source, updated_at
                  )
-                 VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
                  ON CONFLICT(user_id) DO UPDATE SET
                    date_of_birth = COALESCE(excluded.date_of_birth, user_details.date_of_birth),
                    height = COALESCE(excluded.height, user_details.height),
                    weight = COALESCE(excluded.weight, user_details.weight),
                    gender = COALESCE(excluded.gender, user_details.gender),
                    activity_level = COALESCE(excluded.activity_level, user_details.activity_level),
+                   switching_source = COALESCE(excluded.switching_source, user_details.switching_source),
                    updated_at = CURRENT_TIMESTAMP`,
                   [
                     internalUserId,
@@ -392,6 +411,7 @@ export const userRoutes = (app: Elysia) =>
                     nullify(weight),
                     nullify(gender),
                     nullify(activityLevel),
+                    nullify(switchingSource),
                   ],
                 );
 
@@ -431,7 +451,7 @@ export const userRoutes = (app: Elysia) =>
               void captureProductEvent({
                 distinctId: internalUserId,
                 event: "profile_completed",
-                properties: {},
+                properties: { switchingSource: switchingSource ?? "unknown" },
               });
             }
 

--- a/backend/src/modules/user/schemas.ts
+++ b/backend/src/modules/user/schemas.ts
@@ -5,17 +5,27 @@ import { EmailSchema } from "../../lib/http/schemas";
 
 // Reusable optional types for updates
 const OptionalDateString = t.Optional(
-  t.Union([t.String({ format: "date" }), t.Null()])
+  t.Union([t.String({ format: "date" }), t.Null()]),
 );
 const OptionalPositiveNumber = t.Optional(
-  t.Union([t.Numeric({ minimum: 0 }), t.Null()])
+  t.Union([t.Numeric({ minimum: 0 }), t.Null()]),
 );
 const OptionalGender = t.Optional(
-  t.Union([t.Literal("male"), t.Literal("female"), t.Null()])
+  t.Union([t.Literal("male"), t.Literal("female"), t.Null()]),
 );
 const OptionalActivityLevel = t.Optional(
-  t.Union([t.Numeric({ minimum: 1, maximum: 5 }), t.Null()])
+  t.Union([t.Numeric({ minimum: 1, maximum: 5 }), t.Null()]),
 );
+const SwitchingSource = t.Union([
+  t.Literal("cronometer"),
+  t.Literal("loseit"),
+  t.Literal("macrofactor"),
+  t.Literal("myfitnesspal"),
+  t.Literal("new_to_tracking"),
+  t.Literal("other"),
+  t.Literal("spreadsheet"),
+  t.Literal("unknown"),
+]);
 
 export const UserSchemas = {
   userDetailsResponse: t.Object({
@@ -29,6 +39,12 @@ export const UserSchemas = {
     weight: t.Nullable(t.Number()),
     gender: t.Nullable(t.Union([t.Literal("male"), t.Literal("female")])),
     activityLevel: t.Nullable(t.Integer({ minimum: 1, maximum: 5 })),
+    switchingSource: t.Nullable(SwitchingSource),
+    analyticsTrafficType: t.Union([
+      t.Literal("customer"),
+      t.Literal("internal"),
+      t.Literal("synthetic"),
+    ]),
     isProfileComplete: t.Boolean(),
     subscription: t.Object({
       status: t.Union([
@@ -60,6 +76,7 @@ export const UserSchemas = {
     weight: OptionalPositiveNumber,
     gender: OptionalGender,
     activityLevel: OptionalActivityLevel,
+    switchingSource: t.Optional(SwitchingSource),
   }),
 
   // Schema for changing a user's password

--- a/backend/tests/db/schema.test.ts
+++ b/backend/tests/db/schema.test.ts
@@ -1,1 +1,25 @@
-import { describe, it, expect } from "vitest"; describe("schema", () => { it("works", () => { expect(1).toBe(1); }); });
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+describe("database schema", () => {
+  it("stores a fixed switching source on user details", () => {
+    const output = execFileSync(
+      "bun",
+      [
+        "--eval",
+        [
+          'import { Database } from "bun:sqlite";',
+          'import { initializeSchema } from "./src/db/schema.ts";',
+          'const database = new Database(":memory:");',
+          "initializeSchema(database);",
+          'const columns = database.query("PRAGMA table_info(user_details)").all();',
+          'console.log(columns.some((column) => column.name === "switching_source"));',
+          "database.close();",
+        ].join(""),
+      ],
+      { cwd: process.cwd(), encoding: "utf8" },
+    );
+
+    expect(output.trim().endsWith("true")).toBe(true);
+  });
+});

--- a/backend/tests/lib/product-analytics.test.ts
+++ b/backend/tests/lib/product-analytics.test.ts
@@ -2,6 +2,41 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { setConfigOverrides } from "../../src/config";
 import { captureProductEvent } from "../../src/lib/analytics/product-analytics";
+import {
+  resolveAnalyticsTrafficType,
+  serializeProductProperties,
+} from "../../../shared/product-analytics";
+
+describe("product analytics contract", () => {
+  it("serializes the switching source without health details", () => {
+    expect(
+      serializeProductProperties({
+        event: "profile_completed",
+        properties: { switchingSource: "myfitnesspal" },
+      }),
+    ).toEqual({ switching_source: "myfitnesspal" });
+  });
+
+  it("classifies Clerk test aliases as synthetic traffic", () => {
+    expect(
+      resolveAnalyticsTrafficType("growth+clerk_test@example.com", []),
+    ).toBe("synthetic");
+  });
+
+  it("classifies configured team addresses as internal traffic", () => {
+    expect(
+      resolveAnalyticsTrafficType("Owner@Example.com", [" owner@example.com "]),
+    ).toBe("internal");
+  });
+
+  it("treats every other address as customer traffic", () => {
+    expect(
+      resolveAnalyticsTrafficType("customer@example.com", [
+        "owner@example.com",
+      ]),
+    ).toBe("customer");
+  });
+});
 
 describe("captureProductEvent", () => {
   afterEach(() => {
@@ -17,7 +52,7 @@ describe("captureProductEvent", () => {
     await captureProductEvent({
       distinctId: 42,
       event: "profile_completed",
-      properties: {},
+      properties: { switchingSource: "unknown" },
     });
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -72,7 +107,7 @@ describe("captureProductEvent", () => {
         $distinct_id: "42",
         app_mode: "managed",
         plan: "yearly",
-        schema_version: 1,
+        schema_version: 2,
         source: "pricing_page",
       },
     });

--- a/backend/tests/modules/user/profile-analytics.test.ts
+++ b/backend/tests/modules/user/profile-analytics.test.ts
@@ -44,7 +44,10 @@ function createApp() {
 async function completeProfile(app: ReturnType<typeof createApp>) {
   return app.handle(
     new Request("http://localhost/api/user/complete-profile", {
-      body: JSON.stringify({ dateOfBirth: "1990-01-01" }),
+      body: JSON.stringify({
+        dateOfBirth: "1990-01-01",
+        switchingSource: "cronometer",
+      }),
       headers: { "Content-Type": "application/json" },
       method: "POST",
     }),
@@ -71,8 +74,13 @@ describe("profile completion analytics", () => {
     expect(captureProductEventMock).toHaveBeenCalledWith({
       distinctId: 7,
       event: "profile_completed",
-      properties: {},
+      properties: { switchingSource: "cronometer" },
     });
+    expect(safeExecuteMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining("switching_source"),
+      expect.arrayContaining(["cronometer"]),
+    );
   });
 
   it("does not recapture an already complete profile", async () => {

--- a/bun.lock
+++ b/bun.lock
@@ -78,6 +78,7 @@
       },
       "devDependencies": {
         "@capacitor/cli": "^8.4.2",
+        "@clerk/backend": "3.16.4",
         "@clerk/testing": "^2.2.22",
         "@eslint/js": "^9.39.4",
         "@playwright/test": "^1.59.1",

--- a/frontend/e2e/growth-canary.config.ts
+++ b/frontend/e2e/growth-canary.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const baseURL = process.env.FRONTEND_URL ?? "https://macrotrackr.com";
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: /growth-canary\.test\.ts/,
+  outputDir: "../test-results/growth-canary",
+  fullyParallel: false,
+  forbidOnly: true,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [
+    ["list"],
+    ["json", { outputFile: "../test-results/growth-canary/report.json" }],
+  ],
+  globalSetup: "./growth-canary.global-setup.ts",
+  use: {
+    ...devices["Desktop Chrome"],
+    baseURL,
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+  },
+});

--- a/frontend/e2e/growth-canary.global-setup.ts
+++ b/frontend/e2e/growth-canary.global-setup.ts
@@ -1,0 +1,5 @@
+import { clerkSetup } from "@clerk/testing/playwright";
+
+export default async function growthCanarySetup(): Promise<void> {
+  await clerkSetup();
+}

--- a/frontend/e2e/growth-canary.test.ts
+++ b/frontend/e2e/growth-canary.test.ts
@@ -1,0 +1,255 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { createClerkClient } from "@clerk/backend";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import { expect, test, type Page, type TestInfo } from "@playwright/test";
+
+const MANUAL_EVENTS = [
+  "landing_cta_clicked",
+  "signup_started",
+  "signup_completed",
+  "profile_completed",
+  "first_meal_logged",
+  "paywall_viewed",
+  "checkout_started",
+] as const;
+
+const IMPORT_EVENTS = [
+  "landing_cta_clicked",
+  "signup_started",
+  "signup_completed",
+  "profile_completed",
+  "import_previewed",
+  "import_completed",
+  "first_meal_logged",
+] as const;
+
+interface ManagedUser {
+  email: string;
+  clerkUserId: string;
+}
+
+interface PostHogQueryResponse {
+  results?: Array<[string, number]>;
+}
+
+function requireEnvironment(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function escapeHogQlString(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll("'", "\\'");
+}
+
+async function createManagedUser(label: string): Promise<ManagedUser> {
+  const domain = requireEnvironment("GROWTH_CANARY_EMAIL_DOMAIN");
+  const password = requireEnvironment("GROWTH_CANARY_USER_PASSWORD");
+  const secretKey = requireEnvironment("CLERK_SECRET_KEY");
+  const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const email = `macrotrackr-${label}+clerk_test_${runId}@${domain}`;
+  const clerk = createClerkClient({ secretKey });
+  const user = await clerk.users.createUser({
+    emailAddress: [email],
+    firstName: "Growth",
+    lastName: "Canary",
+    password,
+    skipLegalChecks: true,
+  });
+
+  return { clerkUserId: user.id, email };
+}
+
+async function deleteManagedUser(user: ManagedUser): Promise<void> {
+  const clerk = createClerkClient({
+    secretKey: requireEnvironment("CLERK_SECRET_KEY"),
+  });
+  await clerk.users.deleteUser(user.clerkUserId);
+}
+
+async function registerThroughUi(page: Page, user: ManagedUser): Promise<void> {
+  await setupClerkTestingToken({ page });
+  await page.goto("/?utm_source=growth_canary&utm_medium=synthetic");
+  const headline = page.getByRole("heading", {
+    name: /Know what you ate\. Without the admin\./u,
+  });
+  await page
+    .locator("section")
+    .filter({ has: headline })
+    .first()
+    .getByRole("link", { name: "Start free", exact: true })
+    .click();
+  await expect(page).toHaveURL(/\/register/u);
+  await page.getByRole("button", { name: "Continue with email" }).click();
+  await page.getByLabel("First Name").fill("Growth");
+  await page.getByLabel("Last Name").fill("Canary");
+  await page.getByLabel("Email").fill(user.email);
+  await page
+    .getByLabel("Password")
+    .fill(requireEnvironment("GROWTH_CANARY_USER_PASSWORD"));
+  await page.getByRole("button", { name: "Create Account" }).click();
+  await expect(page).toHaveURL(/\/profile-setup/u, { timeout: 30_000 });
+}
+
+async function completeProfile(
+  page: Page,
+  switchingSource: "myfitnesspal" | "new_to_tracking",
+): Promise<void> {
+  await page.getByLabel("Date of Birth").fill("1990-01-01");
+  await page.getByLabel("Gender").selectOption("male");
+  await page.getByLabel(/Height/u).fill("180");
+  await page.getByLabel(/Weight/u).fill("80");
+  await page.getByRole("button", { name: "Continue" }).click();
+  await page
+    .getByLabel("How active are you on a typical week?")
+    .selectOption("3");
+  await page.getByRole("button", { name: "Continue" }).click();
+  await page
+    .getByLabel("What are you switching from?")
+    .selectOption(switchingSource);
+  await page.getByRole("radio", { name: "Maintain" }).click();
+  await page.getByRole("button", { name: "Finish setup" }).click();
+  await expect(page).toHaveURL(/\/home/u, { timeout: 30_000 });
+}
+
+async function logManualMeal(page: Page): Promise<void> {
+  await page.getByLabel("Meal Name").fill("Growth canary meal");
+  await page.getByLabel("Protein").fill("30");
+  await page.getByLabel("Carbs").fill("40");
+  await page.getByLabel("Fats").fill("10");
+  await page.getByRole("button", { name: "Add Entry" }).click();
+  await expect(page.getByText("Growth canary meal").first()).toBeVisible();
+}
+
+async function openPaywallAndCheckout(page: Page): Promise<void> {
+  await page.goto("/reporting");
+  await page.getByRole("tab", { name: /30 Days/u }).click();
+  await expect(
+    page.getByRole("heading", { name: "Unlock Pro Features" }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Upgrade to Pro" }).click();
+  await expect(page).toHaveURL(/\/pricing/u);
+
+  const checkoutRequest = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/billing/checkout") &&
+      response.request().method() === "POST",
+  );
+  await page.getByRole("button", { name: "Upgrade to Pro" }).click();
+  const response = await checkoutRequest;
+  expect(response.ok()).toBe(true);
+}
+
+async function importMyFitnessPal(
+  page: Page,
+  testInfo: TestInfo,
+): Promise<void> {
+  const fixturePath = testInfo.outputPath("myfitnesspal-canary.csv");
+  await mkdir(testInfo.outputDir, { recursive: true });
+  await writeFile(
+    fixturePath,
+    [
+      "Date,Meal,Calories,Fat (g),Carbohydrates (g),Protein (g),Note",
+      "2026-08-18,Breakfast,450,15,45,30,Growth canary oats",
+    ].join("\n"),
+  );
+
+  await page.goto("/settings?tab=data");
+  await expect(page.getByText("1-Click Data Importer")).toBeVisible();
+  await page.locator('input[type="file"]').setInputFiles(fixturePath);
+  await expect(page.getByText("Growth canary oats")).toBeVisible();
+  await page.getByRole("button", { name: "Import 1 Entries" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Import Successful!" }),
+  ).toBeVisible();
+}
+
+async function queryPostHogEvents(email: string): Promise<Map<string, number>> {
+  const apiKey = requireEnvironment("POSTHOG_PERSONAL_API_KEY");
+  const projectId = requireEnvironment("POSTHOG_PROJECT_ID");
+  const host = (
+    process.env.POSTHOG_API_HOST ?? "https://eu.posthog.com"
+  ).replace(/\/$/u, "");
+  const query = `
+    SELECT event, count() AS events
+    FROM events
+    WHERE timestamp >= now() - INTERVAL 1 HOUR
+      AND person.properties.email = '${escapeHogQlString(email)}'
+    GROUP BY event
+    ORDER BY event
+  `;
+  const response = await fetch(
+    `${host}/api/projects/${encodeURIComponent(projectId)}/query/`,
+    {
+      body: JSON.stringify({ query: { kind: "HogQLQuery", query } }),
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`PostHog query failed with ${response.status}`);
+  }
+  const body = (await response.json()) as PostHogQueryResponse;
+  return new Map(
+    (body.results ?? []).map(([event, count]) => [event, Number(count)]),
+  );
+}
+
+async function expectPostHogEvents(
+  expectedEvents: readonly string[],
+  user: ManagedUser,
+  testInfo: TestInfo,
+): Promise<void> {
+  let observed = new Map<string, number>();
+  await expect
+    .poll(
+      async () => {
+        observed = await queryPostHogEvents(user.email);
+        return expectedEvents.filter((event) => !observed.has(event));
+      },
+      { intervals: [2_000, 5_000, 10_000], timeout: 60_000 },
+    )
+    .toEqual([]);
+
+  await writeFile(
+    testInfo.outputPath("posthog-events.json"),
+    JSON.stringify(Object.fromEntries(observed), null, 2),
+  );
+}
+
+test.skip(
+  process.env.GROWTH_CANARY !== "true",
+  "Set GROWTH_CANARY=true to run against a managed environment",
+);
+
+test("fresh account reaches checkout and emits the managed funnel", async ({
+  page,
+}, testInfo) => {
+  const user = await createManagedUser("manual");
+  try {
+    await registerThroughUi(page, user);
+    await completeProfile(page, "new_to_tracking");
+    await logManualMeal(page);
+    await openPaywallAndCheckout(page);
+    await expectPostHogEvents(MANUAL_EVENTS, user, testInfo);
+  } finally {
+    await deleteManagedUser(user);
+  }
+});
+
+test("fresh importer account activates through historical data", async ({
+  page,
+}, testInfo) => {
+  const user = await createManagedUser("import");
+  try {
+    await registerThroughUi(page, user);
+    await completeProfile(page, "myfitnesspal");
+    await importMyFitnessPal(page, testInfo);
+    await expectPostHogEvents(IMPORT_EVENTS, user, testInfo);
+  } finally {
+    await deleteManagedUser(user);
+  }
+});

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -88,6 +88,10 @@ server {
   }
 
   location / {
-    try_files $uri $uri/ /index.html;
+    # Pre-rendered public routes are directories containing index.html. Test
+    # that file directly so nginx serves the canonical no-slash URL instead of
+    # issuing a scheme-downgrading directory redirect behind TLS-terminating
+    # reverse proxies such as Traefik or Cloudflare.
+    try_files $uri/index.html $uri /index.html;
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "test:e2e:ui": "playwright test --config ./playwright.config.ts --ui",
     "test:e2e:debug": "playwright test --config ./playwright.config.ts --debug",
     "test:e2e:headed": "playwright test --config ./playwright.config.ts --headed",
+    "test:growth-canary": "playwright test --config ./e2e/growth-canary.config.ts",
     "cap:sync": "CAPACITOR=true bun run build && bunx cap sync",
     "cap:sync:local": "CAPACITOR_HOSTNAME=\"localhost\" VITE_API_URL=\"http://192.168.0.166:3000\" CAPACITOR=true bun run build && bunx cap sync",
     "cap:sync:prod": "CAPACITOR_HOSTNAME=\"app.macrotrackr.com\" VITE_API_URL=\"https://macrotrackr.com\" CAPACITOR=true bun run build && bunx cap sync",
@@ -66,6 +67,7 @@
   },
   "devDependencies": {
     "@capacitor/cli": "^8.4.2",
+    "@clerk/backend": "3.16.4",
     "@clerk/testing": "^2.2.22",
     "@eslint/js": "^9.39.4",
     "@playwright/test": "^1.59.1",

--- a/frontend/src/api/contracts.test.ts
+++ b/frontend/src/api/contracts.test.ts
@@ -91,6 +91,8 @@ describe("apiServices contracts", () => {
       weight: undefined,
       gender: undefined,
       activityLevel: 3,
+      switchingSource: undefined,
+      analyticsTrafficType: "customer",
       isProfileComplete: true,
       subscription: {
         status: "pro",

--- a/frontend/src/api/user.test.ts
+++ b/frontend/src/api/user.test.ts
@@ -42,6 +42,7 @@ describe("userApi", () => {
         weight: 77,
         gender: "male",
         activity_level: 4,
+        analyticsTrafficType: "internal",
         isProfileComplete: true,
         subscription: {
           status: "pro",
@@ -60,6 +61,7 @@ describe("userApi", () => {
       weight: 77,
       gender: "male",
       activityLevel: 4,
+      analyticsTrafficType: "internal",
       isProfileComplete: true,
       subscription: {
         status: "pro",
@@ -135,6 +137,27 @@ describe("userApi", () => {
         body: JSON.stringify({
           firstName: "Ari",
           activityLevel: 3,
+        }),
+      }),
+    );
+  });
+
+  it("sends the fixed switching source with profile completion", async () => {
+    fetchMock.mockResolvedValueOnce(
+      createJsonResponse({ success: true, message: "Profile updated" }),
+    );
+
+    await userApi.completeProfile({
+      dateOfBirth: "1990-01-01",
+      switchingSource: "macrofactor",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3000/api/user/complete-profile",
+      expect.objectContaining({
+        body: JSON.stringify({
+          dateOfBirth: "1990-01-01",
+          switchingSource: "macrofactor",
         }),
       }),
     );

--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -1,5 +1,11 @@
+import {
+  type AnalyticsTrafficType,
+  isSwitchingSource,
+  type SwitchingSource,
+} from "@shared/product-analytics";
+
 import { authApi } from "@/api/auth";
-import { apiClient,ApiError } from "@/api/core";
+import { apiClient, ApiError } from "@/api/core";
 import type { ActivityLevel } from "@/types/activity";
 import { getActivityLevelFromString } from "@/utils/userConstants";
 
@@ -14,6 +20,8 @@ export interface UserDetailsResponse {
   weight?: number;
   gender?: string;
   activityLevel?: number;
+  switchingSource?: SwitchingSource;
+  analyticsTrafficType: AnalyticsTrafficType;
   isProfileComplete: boolean;
   subscription: {
     status: "free" | "pro" | "canceled";
@@ -34,7 +42,9 @@ function isUserDetailsResponse(value: unknown): value is UserDetailsResponse {
   );
 }
 
-function normalizeUserDetailsResponse(value: unknown): UserDetailsResponse | null {
+function normalizeUserDetailsResponse(
+  value: unknown,
+): UserDetailsResponse | null {
   if (!value || typeof value !== "object") {
     return null;
   }
@@ -48,6 +58,8 @@ function normalizeUserDetailsResponse(value: unknown): UserDetailsResponse | nul
     createdAt: candidateRaw.createdAt ?? candidateRaw.created_at,
     dateOfBirth: candidateRaw.dateOfBirth ?? candidateRaw.date_of_birth,
     activityLevel: candidateRaw.activityLevel ?? candidateRaw.activity_level,
+    switchingSource:
+      candidateRaw.switchingSource ?? candidateRaw.switching_source,
   };
 
   if (!isUserDetailsResponse(candidate)) {
@@ -72,6 +84,14 @@ function normalizeUserDetailsResponse(value: unknown): UserDetailsResponse | nul
       typeof candidate.activityLevel === "number"
         ? candidate.activityLevel
         : undefined,
+    switchingSource: isSwitchingSource(candidate.switchingSource)
+      ? candidate.switchingSource
+      : undefined,
+    analyticsTrafficType:
+      candidate.analyticsTrafficType === "internal" ||
+      candidate.analyticsTrafficType === "synthetic"
+        ? candidate.analyticsTrafficType
+        : "customer",
     isProfileComplete:
       typeof candidate.isProfileComplete === "boolean"
         ? candidate.isProfileComplete
@@ -92,6 +112,7 @@ export type UserSettingsPayload = Partial<{
   weight: number;
   gender: string;
   activityLevel: string | number;
+  switchingSource: SwitchingSource;
 }>;
 
 export const userApi = {
@@ -116,7 +137,9 @@ export const userApi = {
   /**
    * @throws {ApiError}
    */
-  syncAndGetUserDetails: async ({ token }: { token?: string } = {}): Promise<UserDetailsResponse> => {
+  syncAndGetUserDetails: async ({
+    token,
+  }: { token?: string } = {}): Promise<UserDetailsResponse> => {
     await authApi.syncUser({ token });
 
     return userApi.getUserDetails();
@@ -157,7 +180,12 @@ export const userApi = {
     profileData: Partial<
       Pick<
         UserSettingsPayload,
-        "dateOfBirth" | "height" | "weight" | "gender" | "activityLevel"
+        | "dateOfBirth"
+        | "height"
+        | "weight"
+        | "gender"
+        | "activityLevel"
+        | "switchingSource"
       >
     >,
   ): Promise<{ success: boolean; message: string }> => {
@@ -170,7 +198,9 @@ export const userApi = {
     return {
       success: result.data?.success ?? result.success ?? false,
       message:
-        result.data?.message ?? result.message ?? "Profile updated successfully.",
+        result.data?.message ??
+        result.message ??
+        "Profile updated successfully.",
     };
   },
 };

--- a/frontend/src/features/auth/components/ProfileCreationForm.tsx
+++ b/frontend/src/features/auth/components/ProfileCreationForm.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
 import { useAuth, useUser } from "@clerk/react";
+import {
+  isSwitchingSource,
+  SWITCHING_SOURCE_OPTIONS,
+  type SwitchingSource,
+} from "@shared/product-analytics";
 import { useNavigate } from "@tanstack/react-router";
 
 import { authApi } from "@/api/auth";
@@ -91,6 +96,9 @@ export function ProfileCreationForm() {
   // Goal data
   const [weightGoal, setWeightGoal] = useState<WeightGoalChoice | "">("");
   const [targetWeight, setTargetWeight] = useState<number | null>(null);
+  const [switchingSource, setSwitchingSource] = useState<
+    Exclude<SwitchingSource, "unknown"> | ""
+  >("");
 
   // Validation errors
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -110,7 +118,12 @@ export function ProfileCreationForm() {
   };
 
   const validateGoalStep = (): Record<string, string> => {
-    const newErrors = checkGoalStep(weightGoal, targetWeight, weight);
+    const newErrors = {
+      ...checkGoalStep(weightGoal, targetWeight, weight),
+      ...(switchingSource
+        ? {}
+        : { switchingSource: "Choose the option that fits best" }),
+    };
     setErrors(newErrors);
 
     return newErrors;
@@ -208,11 +221,12 @@ export function ProfileCreationForm() {
         weight: weight ?? undefined,
         gender,
         activityLevel: activityLevel ?? undefined,
+        switchingSource: switchingSource || undefined,
       });
 
       // Step 3: Record the weight goal so the dashboard opens with a real
       // calorie target instead of falling back to bare TDEE. A failure here
-      // must not strand the user mid-onboarding — the goal is editable later.
+      // must not strand the user mid-onboarding. The goal is editable later.
       if (goalCalculations) {
         try {
           await goalsApi.createWeightGoal({
@@ -276,9 +290,7 @@ export function ProfileCreationForm() {
       <div className="space-y-6">
         <StepIndicator step={1} />
         <div className="text-center">
-          <h2 className="text-2xl font-bold text-foreground">
-            About you
-          </h2>
+          <h2 className="text-2xl font-bold text-foreground">About you</h2>
           <p className="mt-2 text-muted">
             Hi {displayName} — these details set your calorie baseline.
           </p>
@@ -444,6 +456,31 @@ export function ProfileCreationForm() {
       </div>
 
       <div className="space-y-4">
+        <div>
+          <Dropdown
+            label="What are you switching from?"
+            value={switchingSource}
+            onChange={(value: string | number) => {
+              const source = String(value);
+              setSwitchingSource(
+                isSwitchingSource(source) && source !== "unknown" ? source : "",
+              );
+              if (errors.switchingSource) {
+                setErrors((previous) => ({
+                  ...previous,
+                  switchingSource: "",
+                }));
+              }
+            }}
+            options={[
+              { value: "", label: "Choose one" },
+              ...SWITCHING_SOURCE_OPTIONS,
+            ]}
+            required
+          />
+          <FieldError message={errors.switchingSource} />
+        </div>
+
         <div
           className="grid grid-cols-1 gap-2 sm:grid-cols-3"
           role="radiogroup"

--- a/frontend/src/lib/posthogIntegration.tsx
+++ b/frontend/src/lib/posthogIntegration.tsx
@@ -31,6 +31,8 @@ export default function PostHogUserSync(): undefined {
             last_name: user.lastName,
             subscription_status: user.subscription.status,
             created_at: user.createdAt,
+            traffic_type: user.analyticsTrafficType,
+            switching_source: user.switchingSource ?? "unknown",
           });
         } catch (error) {
           // Don't throw in UI if analytics fails

--- a/frontend/src/lib/productAnalytics.test.ts
+++ b/frontend/src/lib/productAnalytics.test.ts
@@ -41,7 +41,7 @@ describe("createBrowserProductAnalytics", () => {
     expect(capture).toHaveBeenCalledWith("signup_started", {
       app_mode: "managed",
       auth_method: "email",
-      schema_version: 1,
+      schema_version: 2,
       source: "pricing",
     });
   });

--- a/scripts/posthog-growth-report.ts
+++ b/scripts/posthog-growth-report.ts
@@ -10,6 +10,9 @@ const FUNNEL_STAGES = [
   "subscription_started",
 ] as const;
 
+const CUSTOMER_TRAFFIC_FILTER =
+  "coalesce(person.properties.traffic_type, 'customer') = 'customer'";
+
 interface QueryResponse {
   columns?: string[];
   results?: unknown[][];
@@ -106,35 +109,46 @@ async function main(): Promise<void> {
 
   const [funnel, acquisition, monetization, imports] = await Promise.all([
     runHogQl(`
-      SELECT event, count(DISTINCT distinct_id) AS users, count() AS events
+      SELECT event, uniq(person_id) AS users, count() AS events
       FROM events
-      WHERE ${dateFilter} AND event IN (${events})
+      WHERE ${dateFilter}
+        AND ${CUSTOMER_TRAFFIC_FILTER}
+        AND event IN (${events})
       GROUP BY event
       ORDER BY event
     `),
     runHogQl(`
-      SELECT event, coalesce(properties.source, 'unknown') AS segment,
-             count(DISTINCT distinct_id) AS users
+      SELECT event,
+             coalesce(
+               person.properties['$initial_utm_source'],
+               properties.source,
+               'direct'
+             ) AS segment,
+             uniq(person_id) AS users
       FROM events
-      WHERE ${dateFilter} AND event IN ('landing_cta_clicked', 'signup_started')
+      WHERE ${dateFilter}
+        AND ${CUSTOMER_TRAFFIC_FILTER}
+        AND event IN ('landing_cta_clicked', 'signup_started')
       GROUP BY event, segment
       ORDER BY event, users DESC
     `),
     runHogQl(`
       SELECT event,
              coalesce(properties.plan, properties.feature_name, properties.source, 'unknown') AS segment,
-             count(DISTINCT distinct_id) AS users
+             uniq(person_id) AS users
       FROM events
       WHERE ${dateFilter}
+        AND ${CUSTOMER_TRAFFIC_FILTER}
         AND event IN ('paywall_viewed', 'checkout_started', 'subscription_started')
       GROUP BY event, segment
       ORDER BY event, users DESC
     `),
     runHogQl(`
       SELECT event, coalesce(properties.import_source, 'unknown') AS segment,
-             count(DISTINCT distinct_id) AS users
+             uniq(person_id) AS users
       FROM events
       WHERE ${dateFilter}
+        AND ${CUSTOMER_TRAFFIC_FILTER}
         AND (event IN ('import_previewed', 'import_completed')
              OR (event = 'first_meal_logged' AND properties.entry_method = 'import'))
       GROUP BY event, segment
@@ -148,7 +162,7 @@ async function main(): Promise<void> {
   printBreakdown("Monetization", monetization);
   printBreakdown("Imports", imports);
   console.log(
-    "\nNote: stage volume is not an ordered cohort funnel. Build the saved PostHog funnel after the new events reach production.",
+    "\nNote: customer traffic only. Stage volume is directional, not an ordered cohort funnel; use the saved PostHog dashboard for ordered conversion.",
   );
 }
 

--- a/shared/product-analytics.ts
+++ b/shared/product-analytics.ts
@@ -1,9 +1,39 @@
 import type { ImportFormat } from "./importer";
 
-export const PRODUCT_ANALYTICS_SCHEMA_VERSION = 1;
+export const PRODUCT_ANALYTICS_SCHEMA_VERSION = 2;
 
 export type AppMode = "managed" | "self-hosted";
 export type BillingPlan = "monthly" | "yearly";
+export type AnalyticsTrafficType = "customer" | "internal" | "synthetic";
+export const SWITCHING_SOURCES = [
+  "cronometer",
+  "loseit",
+  "macrofactor",
+  "myfitnesspal",
+  "new_to_tracking",
+  "other",
+  "spreadsheet",
+  "unknown",
+] as const;
+export type SwitchingSource = (typeof SWITCHING_SOURCES)[number];
+
+export const SWITCHING_SOURCE_OPTIONS: ReadonlyArray<{
+  label: string;
+  value: Exclude<SwitchingSource, "unknown">;
+}> = [
+  { label: "I'm new to macro tracking", value: "new_to_tracking" },
+  { label: "MyFitnessPal", value: "myfitnesspal" },
+  { label: "Cronometer", value: "cronometer" },
+  { label: "MacroFactor", value: "macrofactor" },
+  { label: "Lose It!", value: "loseit" },
+  { label: "A spreadsheet", value: "spreadsheet" },
+  { label: "Another app", value: "other" },
+];
+
+export function isSwitchingSource(value: unknown): value is SwitchingSource {
+  return SWITCHING_SOURCES.some((source) => source === value);
+}
+
 export type SignupSource =
   | "blog"
   | "calculator"
@@ -42,7 +72,7 @@ export type ProductEvent =
     }
   | {
       event: "profile_completed";
-      properties: Record<string, never>;
+      properties: { switchingSource: SwitchingSource };
     }
   | {
       event: "first_meal_logged";
@@ -94,6 +124,25 @@ export type SerializedProductProperties = Record<
   boolean | number | string
 >;
 
+export function resolveAnalyticsTrafficType(
+  email: string,
+  internalEmails: readonly string[],
+): AnalyticsTrafficType {
+  const normalizedEmail = email.trim().toLowerCase();
+  const localPart = normalizedEmail.split("@", 1)[0] ?? "";
+
+  if (localPart.includes("+clerk_test")) return "synthetic";
+  if (
+    internalEmails.some(
+      (internalEmail) => internalEmail.trim().toLowerCase() === normalizedEmail,
+    )
+  ) {
+    return "internal";
+  }
+
+  return "customer";
+}
+
 export function resolveSignupSource(redirectTo?: string): SignupSource {
   if (!redirectTo || redirectTo === "/home") return "direct";
   if (redirectTo.startsWith("/pricing")) return "pricing";
@@ -117,7 +166,7 @@ export function serializeProductProperties(
     case "signup_completed":
       return { auth_method: productEvent.properties.authMethod };
     case "profile_completed":
-      return {};
+      return { switching_source: productEvent.properties.switchingSource };
     case "first_meal_logged":
       return productEvent.properties.entryMethod === "import"
         ? {


### PR DESCRIPTION
## What changed

- add the fixed-choice switching-source question and persist it with the profile
- classify customer, internal, and synthetic traffic for PostHog
- add a weekly customer-only growth report and two managed UI canaries
- add a repository verification skill with production landing-page evidence
- serve pre-rendered routes directly so Traefik and Cloudflare do not emit HTTP redirects

## Verification

- backend: 405 tests passed
- frontend: 770 tests passed
- backend and frontend type checks passed
- backend and frontend production builds passed
- backend and frontend lint passed with existing warnings only
- both managed canary scenarios are discovered by Playwright
- 30-day PostHog customer baseline completed with zero funnel events before deployment
- local nginx check returned 200 for no-slash comparison and calculator routes

## Deployment notes

The weekly report is enabled. The production canary remains disabled until this change deploys, then it can be run once by workflow dispatch before enabling the schedule. Secrets are stored in GitHub Actions, not in the repository.