### PR TITLE
fix: use production-valid growth canary accounts

### DIFF
--- a/backend/tests/lib/product-analytics.test.ts
+++ b/backend/tests/lib/product-analytics.test.ts
@@ -17,9 +17,15 @@ describe("product analytics contract", () => {
     ).toEqual({ switching_source: "myfitnesspal" });
   });
 
-  it("classifies Clerk test aliases as synthetic traffic", () => {
+  it("classifies Clerk test addresses as synthetic traffic", () => {
     expect(
       resolveAnalyticsTrafficType("growth+clerk_test@example.com", []),
+    ).toBe("synthetic");
+    expect(
+      resolveAnalyticsTrafficType(
+        "macrotrackr-manual-clerk-test-123@macrotrackr.com",
+        [],
+      ),
     ).toBe("synthetic");
   });
 

--- a/frontend/e2e/growth-canary.test.ts
+++ b/frontend/e2e/growth-canary.test.ts
@@ -32,6 +32,10 @@ interface PostHogQueryResponse {
   results?: Array<[string, number]>;
 }
 
+interface ClerkErrorResponse {
+  errors?: Array<{ code?: string; long_message?: string; message?: string }>;
+}
+
 function requireEnvironment(name: string): string {
   const value = process.env[name]?.trim();
   if (!value) throw new Error(`${name} is required`);
@@ -47,7 +51,7 @@ async function createManagedUser(label: string): Promise<ManagedUser> {
   const password = requireEnvironment("GROWTH_CANARY_USER_PASSWORD");
   const secretKey = requireEnvironment("CLERK_SECRET_KEY");
   const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  const email = `macrotrackr-${label}+clerk_test_${runId}@${domain}`;
+  const email = `macrotrackr-${label}-clerk-test-${runId}@${domain}`;
   const clerk = createClerkClient({ secretKey });
   const user = await clerk.users.createUser({
     emailAddress: [email],
@@ -87,7 +91,30 @@ async function registerThroughUi(page: Page, user: ManagedUser): Promise<void> {
   await page
     .getByLabel("Password")
     .fill(requireEnvironment("GROWTH_CANARY_USER_PASSWORD"));
+  const signupResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes("/v1/client/sign_ups") &&
+      response.request().method() === "POST",
+  );
   await page.getByRole("button", { name: "Create Account" }).click();
+  const signupResponse = await signupResponsePromise;
+  if (!signupResponse.ok()) {
+    const payload = (await signupResponse.json()) as ClerkErrorResponse;
+    const expectedDuplicateCodes = new Set([
+      "form_identifier_exists",
+      "identifier_already_signed_up",
+    ]);
+    const unexpectedError = payload.errors?.find(
+      ({ code }) => !code || !expectedDuplicateCodes.has(code),
+    );
+    if (unexpectedError) {
+      throw new Error(
+        unexpectedError.long_message ??
+          unexpectedError.message ??
+          `Clerk sign-up failed with ${signupResponse.status()}`,
+      );
+    }
+  }
   await expect(page).toHaveURL(/\/profile-setup/u, { timeout: 30_000 });
 }
 

--- a/shared/product-analytics.ts
+++ b/shared/product-analytics.ts
@@ -131,7 +131,12 @@ export function resolveAnalyticsTrafficType(
   const normalizedEmail = email.trim().toLowerCase();
   const localPart = normalizedEmail.split("@", 1)[0] ?? "";
 
-  if (localPart.includes("+clerk_test")) return "synthetic";
+  if (
+    localPart.includes("+clerk_test") ||
+    localPart.includes("-clerk-test-")
+  ) {
+    return "synthetic";
+  }
   if (
     internalEmails.some(
       (internalEmail) => internalEmail.trim().toLowerCase() === normalizedEmail,


### PR DESCRIPTION
## Summary
- use production-valid synthetic email addresses for managed growth canaries
- classify the new address marker as synthetic traffic
- surface unexpected Clerk signup errors immediately in canary output

## Verification
- backend focused tests: 7 passed
- backend and frontend typechecks: passed
- growth canary discovery: 2 tests
- lint: passed with existing warnings

No collaborators, reviewers, or assignees were added.