### PR TITLE
fix(nav): reset scroll on navigation, drop the phone-only app header

### DIFF
--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -14,6 +14,15 @@ export const router = createRouter({
   },
   defaultPreload: "intent",
   defaultPreloadStaleTime: 0,
+  // Without this the browser keeps the previous page's scroll offset across a
+  // client navigation, so leaving a long page (/pricing, /blog) for a shorter
+  // one dropped you into its footer — or past its content entirely while the
+  // lazy sections were still resolving — which reads as a blank page.
+  scrollRestoration: true,
+  // `html { scroll-behavior: smooth }` makes the router's default `auto` scroll
+  // animate, and the animation is aborted the moment the outgoing page unmounts
+  // and the document shrinks — leaving the offset untouched. Jump instead.
+  scrollRestorationBehavior: "instant",
 });
 
 declare module "@tanstack/react-router" {

--- a/frontend/src/components/layout/MainLayout.test.tsx
+++ b/frontend/src/components/layout/MainLayout.test.tsx
@@ -73,6 +73,25 @@ describe("MainLayout", () => {
     );
   });
 
+  it("keeps the app header off phone viewports, where it held only the wordmark", () => {
+    render(<MainLayout>
+      <div />
+    </MainLayout>);
+
+    expect(screen.getByTestId("app-navbar").parentElement).toHaveClass(
+      "hidden",
+      "md:block",
+    );
+  });
+
+  it("drops the header offset on phones, so nothing reserves a band for it", () => {
+    const { container } = render(<MainLayout>
+      <div />
+    </MainLayout>);
+
+    expect(container.firstElementChild).toHaveClass("app-shell-headerless");
+  });
+
   it("gives the signed-in app a bottom tab bar for the four destinations", () => {
     render(<MainLayout>
       <div />

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -64,7 +64,11 @@ const MainLayout: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
     isLoaded && isSignedIn && !isPublicRoute && !isNoNavRoute;
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <div
+      className={`min-h-screen bg-background text-foreground ${
+        isAuthenticated ? "app-shell-headerless" : ""
+      }`}
+    >
       {/* One instance for the app, rather than a full-viewport mix-blend-overlay
           that re-mounts on every navigation. */}
       <PageBackground />
@@ -74,7 +78,14 @@ const MainLayout: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
       >
         Skip to content
       </a>
-      {isAuthenticated && <AppHeader mode="app" />}
+      {/* Phone-sized, the app header held nothing but the wordmark: its nav is
+          `hidden md:flex` and MobileTabBar already carries all four
+          destinations. Hidden rather than removed so the desktop bar stays. */}
+      {isAuthenticated && (
+        <div className="hidden md:block">
+          <AppHeader mode="app" />
+        </div>
+      )}
       <main
         id="main-content"
         className={`relative min-h-screen ${

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -147,6 +147,17 @@
   );
 }
 
+/* Signed in on a phone there is no top bar — MobileTabBar carries navigation —
+   so pages must not reserve a band for a header that is not rendered. Set on
+   the MainLayout root by the authenticated branch. */
+@media (width < 48rem) {
+  .app-shell-headerless {
+    --header-offset: calc(1rem + var(--sat));
+    /* Toasts cleared a bar that is no longer there. */
+    --floating-notification-top: calc(1rem + var(--sat));
+  }
+}
+
 .safe-area-pt {
   padding-top: var(--sat);
 }


### PR DESCRIPTION
Two reported issues.

## 1. `/pricing` or `/blog` → logo → blank page

It was never blank. The page had rendered; the scroll position hadn't moved. The router had no scroll management, so leaving a ~3300px page for `/` kept the window at its old offset — which on the landing page lands in the footer, or past the content entirely while the lazy Features/Pricing sections are still resolving.

`frontend/src/AppRouter.tsx`:
- `scrollRestoration: true` — top on a new navigation, restore on back/forward.
- `scrollRestorationBehavior: "instant"` — **this is the part that made it work.** `global.css` sets `html { scroll-behavior: smooth }`, so the router's default `auto` scroll animated, and the animation was aborted the instant the outgoing page unmounted and the document shrank. With `scrollRestoration` alone I watched `window.scrollTo({top: 0})` fire and `scrollY` stay at 2000.

## 2. Mobile top bar when logged in

Removed below `md`. On a phone that bar held nothing but the wordmark — the app nav is `hidden md:flex` and `MobileTabBar` already carries all four destinations plus the log action. The desktop bar is untouched.

The authenticated root gets `app-shell-headerless`, which collapses `--header-offset` (and `--floating-notification-top`) under `48rem` so pages don't reserve a ~6rem band for a header that isn't rendered.

## Verification

Driven in a real browser against the dev server: logo click from `/pricing` at y=2400 and from `/blog` at y=1500, at both iPhone 12 Pro and 1280px widths — lands at y=0 in both. Back navigation is no worse than before.

819 tests pass (2 added to `MainLayout.test.tsx`), typecheck clean, lint 0 errors, UI budgets unchanged.

**Not verified in a browser:** the logged-in mobile layout — no working credentials for this instance, so issue 2 rests on the CSS and tests rather than a screenshot. Worth a look on a phone before merging.