### PR TITLE
fix(seo): pre-render blog article bodies and drop duplicate h1

### DIFF
--- a/frontend/scripts/prerender.mjs
+++ b/frontend/scripts/prerender.mjs
@@ -185,6 +185,38 @@ try {
   console.warn("Could not read blog-posts.json:", e.message);
 }
 
+// Render post bodies with the same markdown pipeline as BlogArticlePage, so
+// crawlers get the article instead of just the excerpt. Loaded lazily because
+// the script also runs in fixtures that have no node_modules.
+let renderMarkdownBody = () => "";
+
+if (blogPosts.length > 0) {
+  const [React, { renderToStaticMarkup }, { default: ReactMarkdown }, { default: remarkGfm }, { default: rehypeSlug }, { default: rehypeAutolinkHeadings }] =
+    await Promise.all([
+      import("react").then((m) => m.default ?? m),
+      import("react-dom/server"),
+      import("react-markdown"),
+      import("remark-gfm"),
+      import("rehype-slug"),
+      import("rehype-autolink-headings"),
+    ]);
+
+  renderMarkdownBody = (slug) => {
+    const mdPath = path.join(srcDir, "data/blog-content", `${slug}.md`);
+    if (!fs.existsSync(mdPath)) return "";
+    return renderToStaticMarkup(
+      React.createElement(
+        ReactMarkdown,
+        {
+          remarkPlugins: [remarkGfm],
+          rehypePlugins: [rehypeSlug, [rehypeAutolinkHeadings, { behavior: "wrap" }]],
+        },
+        fs.readFileSync(mdPath, "utf8")
+      )
+    );
+  };
+}
+
 // Build all pages to pre-render
 const pages = [
   {
@@ -425,6 +457,7 @@ for (const post of blogPosts) {
         <h1>${post.title}</h1>
         <p>Published on ${post.date} by ${post.author || APP_NAME}</p>
         <p>${post.excerpt}</p>
+        <article>${renderMarkdownBody(post.slug)}</article>
       </main>
     `,
   });

--- a/frontend/src/data/blog-content/carbs-fats-balance.md
+++ b/frontend/src/data/blog-content/carbs-fats-balance.md
@@ -1,5 +1,3 @@
-# Carbs vs. Fats: Finding Your Optimal Balance for Performance and Body Composition
-
 The internet loves a good macro war.
 
 Team Keto says carbs are the enemy. Team High-Carb says fat is outdated. Meanwhile, the average person just wants to know: *How much of each should I actually eat?*

--- a/frontend/src/data/blog-content/how-to-estimate-restaurant-meals-without-guessing-blind.md
+++ b/frontend/src/data/blog-content/how-to-estimate-restaurant-meals-without-guessing-blind.md
@@ -1,5 +1,3 @@
-# How to Estimate Restaurant Meals Without Guessing Blind
-
 Restaurant meals are one of the first places people give up on tracking.
 
 That is understandable. You did not cook the meal, you cannot see every ingredient, and the menu description usually hides the things that matter most: oils, sauces, butter, dressings, and portion sizes that are much larger than they look in a quick glance.

--- a/frontend/src/data/blog-content/macro-tracking-tips-for-beginners.md
+++ b/frontend/src/data/blog-content/macro-tracking-tips-for-beginners.md
@@ -1,5 +1,3 @@
-# The Beginner's Guide to Macro Tracking: Start Simple, Stay Consistent
-
 Macro tracking can feel overwhelming at first. The numbers, the ratios, the fear of getting it "wrong". It is enough to make many people quit before they start seeing results.
 
 But here's the truth: you don't need to be perfect. You need to be consistent.

--- a/frontend/src/data/blog-content/meal-prep-for-macro-tracking.md
+++ b/frontend/src/data/blog-content/meal-prep-for-macro-tracking.md
@@ -1,5 +1,3 @@
-# Meal Prep for Macro Tracking: How to Build Accuracy Into Your Week
-
 Here's a truth most macro trackers eventually face: the days you hit your targets perfectly are usually the days you prepared your food in advance. The days you miss? Those are the days you were "winging it."
 
 Meal prep is not just about convenience. It is about accuracy. When you weigh and portion food in advance, you remove the guesswork from your tracking.

--- a/frontend/src/data/blog-content/understanding-protein-intake.md
+++ b/frontend/src/data/blog-content/understanding-protein-intake.md
@@ -1,5 +1,3 @@
-# The Complete Guide to Protein Intake: How Much, What Kind, and When
-
 Protein is the most discussed macronutrient in fitness, and for good reason. It's the building block of muscle, essential for recovery, and the most satiating nutrient you can eat.
 
 But walk into any gym or scroll through fitness forums and you'll hear conflicting advice:

--- a/frontend/src/data/blog-content/v0-8-0.md
+++ b/frontend/src/data/blog-content/v0-8-0.md
@@ -1,5 +1,3 @@
-# MacroTrackr 0.8.0: Core Features Complete
-
 Version 0.8.0 is out. Here is what changed and why.
 
 ## What changed

--- a/frontend/src/data/blog-content/v0-9-0.md
+++ b/frontend/src/data/blog-content/v0-9-0.md
@@ -1,5 +1,3 @@
-# MacroTrackr 0.9.0: Beta Release
-
 Version 0.9.0 is out. Here is what changed and why.
 
 ## What changed

--- a/frontend/src/data/blog-content/v1-0-0.md
+++ b/frontend/src/data/blog-content/v1-0-0.md
@@ -1,5 +1,3 @@
-# MacroTrackr 1.0.0: MacroTrackr Launch
-
 Version 1.0.0 is out. Here is what changed and why.
 
 ## What changed

--- a/frontend/src/data/blog-content/v2-5-mobile-ux-polish-and-responsive-density.md
+++ b/frontend/src/data/blog-content/v2-5-mobile-ux-polish-and-responsive-density.md
@@ -1,5 +1,3 @@
-# MacroTrackr v2.5: Compact Mobile Layouts, Sleeker Navigation, and Search Improvements
-
 MacroTrackr v2.5 delivers a major mobile UX upgrade, reducing vertical scrolling by up to 50% across key screens, refining form inputs, polishing navigation, and ensuring seamless infrastructure routing.
 
 ## What's New in v2.5

--- a/frontend/src/data/blog-content/v2-6-0.md
+++ b/frontend/src/data/blog-content/v2-6-0.md
@@ -1,5 +1,3 @@
-# MacroTrackr 2.6.0: Free Nutrition Calculators & Organic Discovery
-
 Version 2.6.0 is out. Here is what changed and why.
 
 ## What changed

--- a/frontend/src/data/blog-content/v2-launch-complete-ui-overhaul.md
+++ b/frontend/src/data/blog-content/v2-launch-complete-ui-overhaul.md
@@ -1,5 +1,3 @@
-# MacroTrackr v2.0: Faster Search, Better Editing, Cleaner Reporting
-
 MacroTrackr v2.0 is the release where the app starts feeling coherent from search to logging to review.
 
 This version is less about one flashy feature and more about removing the small trust-breaking moments that make tracking feel clumsy: search results that feel noisy, quick-add flows that linger after you have already made a choice, grouped meals that are hard to edit confidently, and reporting screens that feel more assembled than designed.

--- a/frontend/src/data/blog-content/v3-0-0.md
+++ b/frontend/src/data/blog-content/v3-0-0.md
@@ -1,5 +1,3 @@
-# MacroTrackr 3.0.0: One Design System, End to End
-
 Version 3 closes a design system that had drifted into twenty surface fills, seven corner radii and three separate page headers, and fixes a long list of things that were quietly not working underneath it.
 
 ## What changed

--- a/frontend/src/data/blog-content/why-weekly-averages-beat-perfect-days.md
+++ b/frontend/src/data/blog-content/why-weekly-averages-beat-perfect-days.md
@@ -1,5 +1,3 @@
-# Why Weekly Averages Beat Perfect Days
-
 A lot of macro tracking frustration comes from treating each day like a verdict.
 
 If breakfast goes off plan, the day feels ruined. If dinner runs heavy, the week feels lost. If Saturday is social, Sunday suddenly becomes a punishment day. That pattern is emotionally intense and analytically weak.

--- a/frontend/src/lib/blogContentHeadings.test.ts
+++ b/frontend/src/lib/blogContentHeadings.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+const contentModules = import.meta.glob("../data/blog-content/*.md", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+describe("blog content headings", () => {
+  it("finds markdown files to check", () => {
+    expect(Object.keys(contentModules).length).toBeGreaterThan(0);
+  });
+
+  // BlogArticlePage renders post.title as the page's h1, so a top-level
+  // heading in the markdown would produce two h1 elements per article.
+  it.each(Object.keys(contentModules))("%s has no top-level h1", (file) => {
+    const h1Lines = contentModules[file]
+      .split("\n")
+      .filter((line) => /^# \S/.test(line));
+    expect(h1Lines).toEqual([]);
+  });
+});


### PR DESCRIPTION
Blog posts pre-rendered as nav + title + excerpt only. The article bodies live in `src/data/blog-content/*.md` and reach the client through `import.meta.glob` in `lib/blog.ts`, but `prerender.mjs` runs as plain Node and never executed the app, so it only ever read `blog-posts.json` metadata.

Readers saw full articles after hydration; crawlers fetching the raw HTML saw ~130 words. Six editorial posts of 750-1624 words were invisible to search, which matches the thin-content signal in Search Console (4 of 34 pages indexed, 22 discovered but uncrawled).

## Changes

**Pre-render article bodies.** Render each body with the same pipeline `BlogArticlePage` uses — `react-markdown` + `remark-gfm` + `rehype-slug` + `rehype-autolink-headings` — so the static HTML matches the client. No new dependency; all four were already in `package.json`.

The imports load lazily behind a `blogPosts.length > 0` guard because `prerenderOutput.test.ts` copies the script into a fixture with no `node_modules`. A fallback-to-empty-string would have failed silently in CI, which is the same failure mode that hid the original bug.

**Drop the duplicate h1.** `BlogArticlePage.tsx:387` renders `post.title`, and every markdown file also opened with its own `#`, so injecting the body produced two `h1` elements with disagreeing text (e.g. "Finding Your Optimal Carb-to-Fat Ratio" vs "Carbs vs. Fats: Finding Your Optimal Balance for Performance and Body Composition"). The duplication predated this work and was live in the client.

Stripped the leading `#` from all 13 files. `post.title` is the single heading, consistent with `<title>`, the canonical and the BlogPosting `headline`. `blogContentHeadings.test.ts` fails the build if a future post reintroduces one.

## Verification

| Post | Before | After |
|---|---|---|
| meal-prep-for-macro-tracking | ~130 | 1611 |
| carbs-fats-balance | 133 | 1554 |
| understanding-protein-intake | ~130 | 1539 |
| macro-tracking-tips-for-beginners | ~130 | 1290 |
| how-to-estimate-restaurant-meals | ~130 | 1053 |
| why-weekly-averages-beat-perfect-days | ~130 | 852 |

- 833/833 frontend tests pass, typecheck clean, all UI budgets within limits
- All 34 pages still pre-render, 1 `h1` per blog page

## Note for follow-up

Pre-rendered crawler copy sits inside `<noscript>` with `#root` left empty. That is the existing pattern and the indexed pages are pre-rendered ones, but Google weights `<noscript>` lower than visible markup. If blog posts still do not index a few weeks after deploy, that is the next thing to look at.