### PR TITLE
fix(pwa): unblock the camera so the barcode scanner can scan

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -12,7 +12,11 @@ server {
   add_header X-Content-Type-Options "nosniff" always;
   add_header X-Frame-Options "DENY" always;
   add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-  add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), interest-cohort=()" always;
+  # camera is `(self)`, not `()`: the barcode scanner calls getUserMedia, and an
+  # empty allowlist denies the camera to our own origin too — Chrome rejects the
+  # call outright without prompting, and the user cannot grant it back from site
+  # settings. Everything else stays denied.
+  add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(), payment=(), interest-cohort=()" always;
   add_header Cross-Origin-Opener-Policy "same-origin" always;
 
   # HSTS is only meaningful over TLS; harmless on plain HTTP requests.
@@ -48,7 +52,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), interest-cohort=()" always;
+    add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(), payment=(), interest-cohort=()" always;
     add_header Cross-Origin-Opener-Policy "same-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://*.macrotrackr.com https://*.clerk.accounts.dev https://*.clerk.com https://challenges.cloudflare.com https://*.posthog.com https://js.stripe.com; style-src 'self' 'unsafe-inline' https://*.macrotrackr.com https://fonts.googleapis.com; font-src 'self' https://*.macrotrackr.com https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; connect-src 'self' https:; worker-src 'self' blob: data:; frame-src https://*.macrotrackr.com https://challenges.cloudflare.com https://js.stripe.com https://*.clerk.accounts.dev https://*.clerk.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;

--- a/frontend/src/features/macroTracking/components/BarcodeScannerModal.test.tsx
+++ b/frontend/src/features/macroTracking/components/BarcodeScannerModal.test.tsx
@@ -68,6 +68,28 @@ describe("BarcodeScannerModal", () => {
     });
   });
 
+  it("falls back to manual entry when the browser has no BarcodeDetector", async () => {
+    // Safari/iOS: getUserMedia exists but there is nothing to decode frames with.
+    const getUserMedia = vi.fn();
+    vi.stubGlobal("navigator", {
+      ...navigator,
+      mediaDevices: { getUserMedia },
+    });
+
+    render(
+      <BarcodeScannerModal isOpen onClose={vi.fn()} onProductFound={vi.fn()} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/cannot scan barcodes/i)).toBeInTheDocument();
+    });
+    // The camera is never opened, so no preview streams that could not scan.
+    expect(getUserMedia).not.toHaveBeenCalled();
+    expect(screen.getByLabelText(/barcode number/i)).toBeInTheDocument();
+
+    vi.unstubAllGlobals();
+  });
+
   it("shows error status when barcode is not found", async () => {
     (macrosApi.getByBarcode as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 

--- a/frontend/src/features/macroTracking/components/BarcodeScannerModal.tsx
+++ b/frontend/src/features/macroTracking/components/BarcodeScannerModal.tsx
@@ -12,6 +12,27 @@ import {
 } from "@/components/ui";
 import { cn } from "@/lib/classnameUtilities";
 
+interface BarcodeDetectorLike {
+  detect(
+    source: HTMLVideoElement | ImageBitmap | HTMLCanvasElement
+  ): Promise<Array<{ rawValue: string }>>;
+}
+
+type BarcodeDetectorConstructor = new (options?: { formats: string[] }) => BarcodeDetectorLike;
+
+/**
+ * Safari (iOS, and therefore every browser on iOS) ships no BarcodeDetector, so
+ * there is nothing to decode frames with. Opening the camera anyway would show a
+ * live preview that silently never scans, so we check first and say so instead.
+ */
+const getBarcodeDetectorConstructor = (): BarcodeDetectorConstructor | null => {
+  if (typeof window === "undefined") return null;
+
+  return (
+    (window as unknown as { BarcodeDetector?: BarcodeDetectorConstructor }).BarcodeDetector ?? null
+  );
+};
+
 interface BarcodeScannerModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -94,6 +115,17 @@ const BarcodeScannerModal = memo(function BarcodeScannerModal({
       return;
     }
 
+    const BarcodeDetectorConstructor = getBarcodeDetectorConstructor();
+    if (!BarcodeDetectorConstructor) {
+      setHasCamera(false);
+      setMode("manual");
+      setErrorMessage(
+        "This browser cannot scan barcodes (Safari and every iOS browser lack the detector). Enter the barcode numbers below instead."
+      );
+
+      return;
+    }
+
     try {
       const stream = await navigator.mediaDevices.getUserMedia({
         video: {
@@ -112,35 +144,24 @@ const BarcodeScannerModal = memo(function BarcodeScannerModal({
         await videoRef.current.play().catch(() => {});
       }
 
-      // Check if native BarcodeDetector is available
-      const WindowWithBarcode = window as unknown as {
-        BarcodeDetector?: {
-          new (options?: { formats: string[] }): {
-            detect(source: HTMLVideoElement | ImageBitmap | HTMLCanvasElement): Promise<Array<{ rawValue: string }>>;
-          };
-        };
-      };
+      const barcodeDetector = new BarcodeDetectorConstructor({
+        formats: ["ean_13", "ean_8", "upc_a", "upc_e", "code_128", "code_39", "qr_code"],
+      });
 
-      if (WindowWithBarcode.BarcodeDetector) {
-        const barcodeDetector = new WindowWithBarcode.BarcodeDetector({
-          formats: ["ean_13", "ean_8", "upc_a", "upc_e", "code_128", "code_39", "qr_code"],
-        });
-
-        scanIntervalRef.current = window.setInterval(async () => {
-          if (!videoRef.current || videoRef.current.readyState < 2 || isLookupInProgressRef.current) {
-            return;
+      scanIntervalRef.current = window.setInterval(async () => {
+        if (!videoRef.current || videoRef.current.readyState < 2 || isLookupInProgressRef.current) {
+          return;
+        }
+        try {
+          const barcodes = await barcodeDetector.detect(videoRef.current);
+          if (barcodes && barcodes.length > 0 && barcodes[0]?.rawValue) {
+            const detected = barcodes[0].rawValue;
+            handleLookup(detected);
           }
-          try {
-            const barcodes = await barcodeDetector.detect(videoRef.current);
-            if (barcodes && barcodes.length > 0 && barcodes[0]?.rawValue) {
-              const detected = barcodes[0].rawValue;
-              handleLookup(detected);
-            }
-          } catch {
-            // Ignore detection errors in animation loop
-          }
-        }, 300);
-      }
+        } catch {
+          // Ignore detection errors in animation loop
+        }
+      }, 300);
     } catch {
       setHasCamera(false);
       setMode("manual");


### PR DESCRIPTION
## The bug

The barcode scanner's camera mode never worked in the deployed PWA. Tapping **Scan** opened the modal, then immediately flipped to manual entry with *"Camera access was not granted."* — and no amount of fiddling with Chrome's site permissions helped.

## Root cause

`frontend/nginx.conf` sent:

```
Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), interest-cohort=()
```

`camera=()` is an **empty allowlist**: it denies the camera to every origin, our own included, not just to third-party frames. Chrome rejects `getUserMedia()` outright without ever prompting, and a Permissions-Policy denial outranks a user grant, so site settings offered no way back. `BarcodeScannerModal` caught the rejection in its generic handler and blamed the user.

`camera=(self)` restores the normal permission prompt for our origin. Every other feature in the policy stays denied.

The header landed in `c4e19a20` (Aug 12); the scanner shipped in `4591adc5` (Aug 18). The camera path only ever worked against the Vite dev server, which sets no Permissions-Policy — which is why it passed review.

The header is repeated in the `= /index.html` location block, because an `add_header` in a location discards everything inherited from the server block (already noted in the file). Both copies are updated.

## Also fixed: iOS scanned nothing, silently

`startCamera` only started its decode interval when `window.BarcodeDetector` existed. Safari doesn't implement it, so on iPhone the fix above would have produced a live preview with an animating viewfinder that never reads a barcode and never says why.

Now the constructor is checked *before* requesting the stream. If it's missing, the modal goes straight to manual entry with a reason instead of opening a camera that cannot work.

## Verification

- `vitest run` — 143 files, 834 tests, all pass
- New test covers the no-`BarcodeDetector` path: asserts the fallback message renders and `getUserMedia` is never called
- `tsc --noEmit` clean; `npm run lint` 0 errors; UI budgets pass
- **`nginx -t` was not run** — no Docker daemon available in this environment. The change is a one-token edit inside an existing quoted header value plus comments, but worth a glance.

## Reviewer note

The header fix cannot be verified by tests — it needs a real device against a deployed build. After this ships, worth confirming on an Android phone that tapping **Scan** now shows Chrome's camera prompt.