### PR TITLE
fix(reporting): stop macro percentages clipping out of the card

### DIFF
--- a/frontend/src/features/reporting/components/MacroSummaryStat.tsx
+++ b/frontend/src/features/reporting/components/MacroSummaryStat.tsx
@@ -128,9 +128,9 @@ const MacroSummaryItem = React.memo(function MacroSummaryItem({
       {/* Average Intake vs Target */}
       <div className="mb-2 space-y-1">
         {/* Average Intake Display */}
-        <div className="flex items-baseline justify-between gap-2">
+        <div className="flex flex-wrap items-baseline justify-between gap-x-2">
           <span className="mr-1 text-xs text-muted shrink-0">Average Intake:</span>
-          <div className="text-right min-w-0">
+          <div className="ml-auto text-right min-w-0">
             <span className="text-lg leading-none font-bold text-foreground">
               <AnimatedNumber
                 value={avgGrams}
@@ -152,9 +152,9 @@ const MacroSummaryItem = React.memo(function MacroSummaryItem({
           </div>
         </div>
         {/* Your Target Display */}
-        <div className="flex items-baseline justify-between gap-2">
+        <div className="flex flex-wrap items-baseline justify-between gap-x-2">
           <span className="mr-1 text-xs text-muted shrink-0">Your Target:</span>
-          <div className="text-right min-w-0">
+          <div className="ml-auto text-right min-w-0">
             <span className="text-sm font-medium text-foreground">
               <AnimatedNumber
                 value={targetGrams}
@@ -289,9 +289,9 @@ export default function MacroSummaryStats({
             )}
           </div>
           <div className="mb-2 space-y-1">
-            <div className="flex items-baseline justify-between">
-              <span className="mr-1 text-xs text-muted">Average Intake:</span>
-              <span className="text-lg leading-none font-bold text-foreground">
+            <div className="flex flex-wrap items-baseline justify-between gap-x-2">
+              <span className="mr-1 text-xs text-muted shrink-0">Average Intake:</span>
+              <span className="ml-auto text-lg leading-none font-bold whitespace-nowrap text-foreground">
                 <AnimatedNumber
                   value={avgCalories}
                   toFixedValue={0}
@@ -300,9 +300,9 @@ export default function MacroSummaryStats({
                 />
               </span>
             </div>
-            <div className="flex items-baseline justify-between">
-              <span className="mr-1 text-xs text-muted">Your Target:</span>
-              <span className="text-sm font-medium text-foreground">
+            <div className="flex flex-wrap items-baseline justify-between gap-x-2">
+              <span className="mr-1 text-xs text-muted shrink-0">Your Target:</span>
+              <span className="ml-auto text-sm font-medium whitespace-nowrap text-foreground">
                 <AnimatedNumber
                   value={effectiveCalorieTarget}
                   toFixedValue={0}
@@ -312,10 +312,10 @@ export default function MacroSummaryStats({
               </span>
             </div>
           </div>
-          <div className="mt-auto flex items-baseline justify-between border-t border-border pt-1">
-            <span className="mr-1.5 text-xs text-muted">Difference:</span>
+          <div className="mt-auto flex flex-wrap items-baseline justify-between gap-x-2 border-t border-border pt-1">
+            <span className="mr-1.5 text-xs text-muted shrink-0">Difference:</span>
             <span
-              className={`text-sm font-semibold ${
+              className={`ml-auto text-sm font-semibold whitespace-nowrap ${
                 avgCalories - effectiveCalorieTarget >= 0
                   ? "text-success"
                   : "text-error"


### PR DESCRIPTION
## Problem

On the Analytics summary cards at a 412px viewport, the parenthetical percentage renders **outside the card and gets cut off**:

```
Protein   Average Intake:  121.0g (3…
Carbs     Average Intake:  163.0g (4…
Fats      Average Intake:   42.0g (25…
```

Found while capturing screenshots on a real Pixel 8 Pro, so it reproduces on device, not just in an emulated viewport.

## Cause

In `MacroSummaryItem`, the row label carries `shrink-0` so it never yields, while the value block is `min-w-0` containing a `text-lg` number plus a `whitespace-nowrap` parenthetical. Nothing in the row may wrap, so at roughly 170px of usable card width (2-up grid at 412px) the inline content simply overflows the panel.

## Fix

Let the row wrap and push the value onto its own right-aligned line when it no longer fits — `flex-wrap` on the row, `ml-auto` on the value. Every number keeps its full size and nothing is truncated.

The Calories card gets the same treatment plus `whitespace-nowrap` on its values, which also stops `1509 kcal` breaking between the number and its unit.

## Notes

- **Desktop is unchanged.** The rows only wrap when they would otherwise overflow; at ≥`sm` the layout is identical.
- No new tokens, no hex literals, no new components — this is purely allowing existing rows to reflow.

## Verification

- Real Pixel 8 Pro and emulated 412px: `(32%)` / `(43%)` / `(25%)` / `(30%)` all fully visible
- `tsc --noEmit` clean
- `scripts/check-ui-budgets.mjs` green, nothing ratcheted worse (smOverrides 266/270, boldOutsideScale 63/63, hexLiterals 21/21)