### PR TITLE
fix(pwa): stop the cached shell freezing the camera policy

### DIFF
--- a/frontend/src/service-worker.ts
+++ b/frontend/src/service-worker.ts
@@ -25,13 +25,6 @@ interface ServiceWorkerRuntime {
       type: "message",
       listener: (event: { data?: { type?: string } }) => void,
     ): void;
-    (
-      type: "fetch",
-      listener: (event: {
-        request: Request;
-        respondWith: (response: Promise<Response> | Response) => void;
-      }) => void,
-    ): void;
   };
   clients: {
     matchAll: () => Promise<Array<{ postMessage: (message: { type: string }) => void }>>;
@@ -59,7 +52,7 @@ const sw = globalThis as unknown as ServiceWorkerRuntime;
 const injectedManifest = globalThis.__WB_MANIFEST;
 precacheAndRoute(injectedManifest);
 
-// Serve the cached shell for any navigation the precache does not match.
+// The precached shell answers a navigation only when the network does not.
 //
 // `_redirects` gives the SPA fallback (`/* /index.html 200`), but that is the
 // host's job and the host needs the network. Offline, `precacheAndRoute` only
@@ -67,10 +60,43 @@ precacheAndRoute(injectedManifest);
 // cold launch at `start_url` worked and a refresh on /home or /goals did not.
 // The API routes are excluded: those should fail as requests rather than be
 // answered with an HTML document.
+//
+// Network first, though, because Permissions-Policy and CSP travel on the
+// document response: answering a navigation from the precache pins both to
+// whatever the server sent when the shell was captured. That is how
+// `camera=()` outlived the deploy that changed it to `camera=(self)` — an
+// installed app went on serving its captured shell, so getUserMedia stayed
+// blocked by policy and the scanner reported the camera as denied, with no
+// site setting able to grant it back. A header-only deploy has to be able to
+// reach an installed app; nginx already marks /index.html `no-store` on the
+// same reasoning.
+const precachedShell = createHandlerBoundToURL("index.html");
+
+// Without a bound, a cold launch on a bad connection waits on the document for
+// as long as the network takes to give up. The shell is already on disk.
+const SHELL_NETWORK_TIMEOUT_MS = 3000;
+
 registerRoute(
-  new NavigationRoute(createHandlerBoundToURL("index.html"), {
-    denylist: [/^\/api\//],
-  }),
+  new NavigationRoute(
+    async (options) => {
+      try {
+        const response = await Promise.race([
+          fetch(options.request),
+          new Promise<never>((_, reject) => {
+            setTimeout(() => reject(new Error("shell network timeout")), SHELL_NETWORK_TIMEOUT_MS);
+          }),
+        ]);
+
+        // A 5xx or a captive-portal redirect is not a shell. Prefer the real one.
+        if (response.ok) return response;
+      } catch {
+        // Offline, or slower than it is worth waiting for.
+      }
+
+      return precachedShell(options);
+    },
+    { denylist: [/^\/api\//] },
+  ),
 );
 
 sw.addEventListener("activate", (event) => {
@@ -96,14 +122,6 @@ sw.addEventListener("activate", (event) => {
   );
 });
 
-// SPA navigations: precacheAndRoute only matches precached URLs, so offline a
-// refresh worked at / and nowhere else - /home, /goals and every article
-// 404'd. The _redirects SPA fallback lives on the server and needs the
-// network, which is exactly what is missing. Serve the precached shell for any
-// navigation instead, and let the router take it from there.
-sw.addEventListener("fetch", (event) => {
-  if (event.request.mode !== "navigate") return;
-});
 
 // Handle messages from the main thread
 sw.addEventListener("message", (event) => {


### PR DESCRIPTION
`Permissions-Policy` and CSP travel on the **document response**, so binding navigations to the precached `index.html` pinned both to whatever the server sent when that shell was captured. A header-only deploy then has no way to reach an installed app.

That is what happened to the barcode scanner. #150 changed `camera=()` to `camera=(self)`, but an installed PWA went on serving its captured shell, so `getUserMedia` stayed blocked by policy and the scanner still reported the camera as denied — with no site setting able to grant it back, because a policy denial outranks a user grant. The worker deliberately does not call `skipWaiting()` (for good reasons — see the comment it preserves), which as `UpdatePrompt.tsx` notes is "days" for an installed app.

## Change

Navigations now go to the network first and fall back to the precached shell, which keeps the offline SPA fallback that route exists for. nginx already marks `/index.html` `no-store`; serving it out of Cache Storage was quietly contradicting that.

The fallback is bounded at 3s so a cold launch on a bad connection does not wait on the document for as long as the network takes to give up — the shell is already on disk. A non-`ok` response falls back too: a 5xx or a captive-portal interstitial is not a shell.

Also drops a `fetch` listener that returned unconditionally and whose comment restated the navigation rationale it no longer implemented, plus its now-unused type overload.

## Note on chunk consistency

This does not reintroduce the problem the waiting worker exists to prevent. A network-first navigation returns the new HTML and the new chunk URLs, which miss the old worker's precache and pass through to the network where the deploy has them — consistent. Offline, the fallback serves the old shell whose chunks *are* precached — also consistent. The failure mode being avoided was an old page with a new worker purging its chunks, which is untouched.

## Verification

- `bun run typecheck` and `eslint src/service-worker.ts` clean.
- `bun run build` succeeds; `index.html` is still emitted as a precache entry, so `createHandlerBoundToURL` resolves and the offline fallback works.
- The 3 `BarcodeScannerModal` tests pass.
- The header-from-cache behaviour is read from the code and known service-worker semantics, not exercised in a browser.

## Deploy note

Production was *also* serving `camera=()` independently of this: the nginx config that serves macrotrackr.com lives in the infra repo, not `frontend/nginx.conf` here, so #150 edited a file production never reads. Fixed in arogan178/macrotrackr-infra#5 and already live. This PR is what stops the class of bug recurring on the next header change.
