### PR TITLE
fix(pwa): open the app on launch, survive an offline start, and cut a round trip from login

### DIFF
--- a/backend/src/modules/auth/routes.ts
+++ b/backend/src/modules/auth/routes.ts
@@ -796,6 +796,9 @@ export const authRoutes = (app: Elysia) =>
               email: emailToUpdate,
               firstName,
               lastName,
+              // Already linked, so the caller's profile is whatever is on
+              // record and it has to go and read it.
+              isNewUser: false,
               message: "User synced successfully",
             };
           }
@@ -848,6 +851,10 @@ export const authRoutes = (app: Elysia) =>
             email,
             firstName,
             lastName,
+            // The rows above were just inserted with NULL details, so the
+            // caller already knows the profile is empty and can skip a round
+            // trip to /api/user/me to find that out.
+            isNewUser: true,
             message: "User created and synced successfully",
           };
         },

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -14,8 +14,14 @@ export interface AuthSuccessResponse {
 }
 
 export interface AuthSyncResponse {
-  user: unknown;
+  id: number;
+  clerkId: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  /** True when this call inserted the row, so the profile is known to be empty. */
   isNewUser: boolean;
+  message?: string;
 }
 
 export interface ResetPasswordPayload {

--- a/frontend/src/api/contracts.test.ts
+++ b/frontend/src/api/contracts.test.ts
@@ -107,29 +107,23 @@ describe("apiServices contracts", () => {
   });
 
   it("keeps auth sync typed to its actual backend contract", async () => {
-    fetchMock.mockResolvedValueOnce(
-      createJsonResponse({
-        user: {
-          id: 12,
-          clerkId: "user_456",
-          email: "casey@example.com",
-          firstName: "Casey",
-          lastName: "Ng",
-        },
-        isNewUser: true,
-      }),
-    );
-
-    await expect(authApiClient.syncUser({ token: "token-123" })).resolves.toEqual({
-      user: {
-        id: 12,
-        clerkId: "user_456",
-        email: "casey@example.com",
-        firstName: "Casey",
-        lastName: "Ng",
-      },
+    // Flat, matching what /api/auth/clerk-sync actually returns. The nested
+    // `user` this once claimed never existed on the wire.
+    const syncResponse = {
+      id: 12,
+      clerkId: "user_456",
+      email: "casey@example.com",
+      firstName: "Casey",
+      lastName: "Ng",
       isNewUser: true,
-    });
+      message: "User created and synced successfully",
+    };
+
+    fetchMock.mockResolvedValueOnce(createJsonResponse(syncResponse));
+
+    await expect(authApiClient.syncUser({ token: "token-123" })).resolves.toEqual(
+      syncResponse,
+    );
 
     expect(fetchMock).toHaveBeenCalledWith(
       "http://localhost:3000/api/auth/clerk-sync",

--- a/frontend/src/components/auth/AuthLoadingScreen.test.tsx
+++ b/frontend/src/components/auth/AuthLoadingScreen.test.tsx
@@ -1,0 +1,78 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AuthLoadingScreen } from "@/components/auth/AuthLoadingScreen";
+
+function setOnLine(value: boolean) {
+  Object.defineProperty(navigator, "onLine", {
+    configurable: true,
+    value,
+  });
+}
+
+describe("AuthLoadingScreen", () => {
+  const reload = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    reload.mockReset();
+    setOnLine(true);
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: { ...globalThis.location, reload },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("spins while auth is still resolving", () => {
+    render(<AuthLoadingScreen />);
+
+    expect(screen.queryByText(/You're offline/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Try again" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("says so immediately when the device is offline", () => {
+    setOnLine(false);
+
+    render(<AuthLoadingScreen />);
+
+    expect(screen.getByText(/You're offline/)).toBeInTheDocument();
+  });
+
+  it("stops spinning once auth has had long enough", () => {
+    render(<AuthLoadingScreen />);
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(screen.getByText(/Couldn't confirm your session/)).toBeInTheDocument();
+  });
+
+  it("reloads when the connection comes back, since Clerk will not retry", () => {
+    setOnLine(false);
+
+    render(<AuthLoadingScreen />);
+
+    act(() => {
+      globalThis.dispatchEvent(new Event("online"));
+    });
+
+    expect(reload).toHaveBeenCalled();
+  });
+
+  it("does not reload on a connection blip while it is still spinning", () => {
+    render(<AuthLoadingScreen />);
+
+    act(() => {
+      globalThis.dispatchEvent(new Event("online"));
+    });
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/auth/AuthLoadingScreen.tsx
+++ b/frontend/src/components/auth/AuthLoadingScreen.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react";
+
+import LoadingSpinner from "@/components/ui/LoadingSpinner";
+import StateCard from "@/components/ui/StateCard";
+import { useIsOffline } from "@/hooks/useIsOffline";
+
+/**
+ * What a route guard shows while it still does not know who you are.
+ *
+ * A spinner is right for the first moment and wrong forever. Resolving a
+ * session needs the network — Clerk downloads clerk-js and then asks the
+ * Frontend API whose session this is — so a cold launch with no connection
+ * leaves `isLoaded` false permanently: Clerk's loader gives up after its own
+ * timeout and does not retry, and every guard sits on the spinner. The PWA
+ * makes that easy to hit, because the precached shell means the app opens
+ * offline and only then discovers it cannot get past the door.
+ *
+ * The threshold is a plain timeout rather than Clerk's `status`, so it also
+ * covers self-hosted mode and says the one thing the person needs to know
+ * regardless of which step hung.
+ */
+const AUTH_RESOLVE_TIMEOUT_MS = 10_000;
+
+export function AuthLoadingScreen() {
+  const isOffline = useIsOffline();
+  const [hasTimedOut, setHasTimedOut] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setHasTimedOut(true), AUTH_RESOLVE_TIMEOUT_MS);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  // Offline is knowable immediately; no reason to spin for ten seconds first.
+  const hasGivenUp = isOffline || hasTimedOut;
+
+  // Clerk's loader does not retry once it has failed, so the provider stays
+  // stuck for the life of the document and only a fresh one recovers. Waiting
+  // for the network beats asking someone to remember to pull to refresh.
+  useEffect(() => {
+    if (!hasGivenUp) return;
+
+    const reload = () => globalThis.location.reload();
+
+    globalThis.addEventListener("online", reload);
+
+    return () => globalThis.removeEventListener("online", reload);
+  }, [hasGivenUp]);
+
+  if (!hasGivenUp) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-surface">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-surface">
+      {isOffline ? (
+        <StateCard
+          tone="offline"
+          title="You're offline"
+          message="Signing you in needs a connection. This will pick up on its own once you're back online."
+          action={{ label: "Try again", onClick: () => globalThis.location.reload() }}
+        />
+      ) : (
+        <StateCard
+          tone="error"
+          title="Couldn't confirm your session"
+          message="We can't reach the sign-in service right now. Nothing has been lost — your data is still there."
+          action={{ label: "Try again", onClick: () => globalThis.location.reload() }}
+        />
+      )}
+    </div>
+  );
+}
+
+export default AuthLoadingScreen;

--- a/frontend/src/components/auth/RequireCompleteProfile.tsx
+++ b/frontend/src/components/auth/RequireCompleteProfile.tsx
@@ -1,5 +1,6 @@
 import { Navigate, useLocation } from "@tanstack/react-router";
 
+import { AuthLoadingScreen } from "@/components/auth/AuthLoadingScreen";
 import LoadingSpinner from "@/components/ui/LoadingSpinner";
 import { isClerkAuthMode } from "@/config/runtime";
 import {
@@ -37,8 +38,12 @@ export function RequireCompleteProfile({
     enabled: shouldCheckProfileCompletion && isAuthLoaded && isSignedIn,
   });
 
-  // Show loading while auth state is being determined
-  if (!isAuthLoaded || isUserLoading) {
+  // Auth state is the one that can hang forever without a network.
+  if (!isAuthLoaded) {
+    return <AuthLoadingScreen />;
+  }
+
+  if (isUserLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-surface">
         <LoadingSpinner size="lg" />

--- a/frontend/src/components/layout/OfflineBar.tsx
+++ b/frontend/src/components/layout/OfflineBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useIsOffline } from "@/hooks/useIsOffline";
 
 /**
  * The shell is precached, so offline the app opens and then every route fails
@@ -6,22 +6,7 @@ import { useEffect, useState } from "react";
  * render an unexplained empty state.
  */
 const OfflineBar: React.FC = () => {
-  const [isOffline, setIsOffline] = useState(
-    typeof navigator === "undefined" ? false : !navigator.onLine,
-  );
-
-  useEffect(() => {
-    const goOffline = () => setIsOffline(true);
-    const goOnline = () => setIsOffline(false);
-
-    globalThis.addEventListener("offline", goOffline);
-    globalThis.addEventListener("online", goOnline);
-
-    return () => {
-      globalThis.removeEventListener("offline", goOffline);
-      globalThis.removeEventListener("online", goOnline);
-    };
-  }, []);
+  const isOffline = useIsOffline();
 
   if (!isOffline) return null;
 

--- a/frontend/src/features/auth/hooks/useAuthReady.test.ts
+++ b/frontend/src/features/auth/hooks/useAuthReady.test.ts
@@ -1,0 +1,161 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/api/core";
+import { useAuthReady } from "@/features/auth/hooks/useAuthReady";
+
+const navigate = vi.fn();
+const setQueryData = vi.fn();
+const invalidateQueries = vi.fn();
+const signOut = vi.fn();
+const syncUser = vi.fn();
+const getUserDetails = vi.fn();
+
+vi.mock("@clerk/react", () => ({
+  useAuth: () => ({ isLoaded: true, isSignedIn: true }),
+  useClerk: () => ({ signOut }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ setQueryData, invalidateQueries }),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigate,
+}));
+
+vi.mock("@/api/auth", () => ({
+  authApi: { syncUser: (...arguments_: unknown[]) => syncUser(...arguments_) },
+}));
+
+vi.mock("@/api/user", () => ({
+  userApi: {
+    getUserDetails: (...arguments_: unknown[]) => getUserDetails(...arguments_),
+  },
+}));
+
+const COMPLETE_PROFILE = { id: 7, dateOfBirth: "1990-01-01" };
+
+function notSyncedError() {
+  return new ApiError("Account not synced", 409, "ACCOUNT_NOT_SYNCED");
+}
+
+describe("useAuthReady", () => {
+  beforeEach(() => {
+    for (const mock of [
+      navigate,
+      setQueryData,
+      invalidateQueries,
+      signOut,
+      syncUser,
+      getUserDetails,
+    ]) {
+      mock.mockReset();
+    }
+  });
+
+  it("costs a returning sign-in one request and no sync", async () => {
+    getUserDetails.mockResolvedValue(COMPLETE_PROFILE);
+
+    const { result } = renderHook(() => useAuthReady("/home"));
+    await result.current.setupAuth();
+
+    expect(getUserDetails).toHaveBeenCalledTimes(1);
+    expect(syncUser).not.toHaveBeenCalled();
+    expect(setQueryData).toHaveBeenCalledWith(expect.anything(), COMPLETE_PROFILE);
+    expect(navigate).toHaveBeenCalledWith({
+      to: "/home",
+      search: { limit: 20, offset: 0 },
+    });
+  });
+
+  it("syncs only when there is no local account yet", async () => {
+    getUserDetails.mockRejectedValue(notSyncedError());
+    syncUser.mockResolvedValue({ isNewUser: true });
+
+    const { result } = renderHook(() => useAuthReady("/home"));
+    await result.current.setupAuth();
+
+    expect(syncUser).toHaveBeenCalledTimes(1);
+    // A row the sync just inserted is empty by construction; reading it back
+    // would only confirm what the response already said.
+    expect(getUserDetails).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith({
+      to: "/profile-setup",
+      search: { redirectTo: "/home" },
+    });
+  });
+
+  it("reads the profile back when the sync linked an existing row", async () => {
+    getUserDetails.mockRejectedValueOnce(notSyncedError());
+    getUserDetails.mockResolvedValueOnce(COMPLETE_PROFILE);
+    syncUser.mockResolvedValue({ isNewUser: false });
+
+    const { result } = renderHook(() => useAuthReady("/home"));
+    await result.current.setupAuth();
+
+    expect(getUserDetails).toHaveBeenCalledTimes(2);
+    expect(navigate).toHaveBeenCalledWith({
+      to: "/home",
+      search: { limit: 20, offset: 0 },
+    });
+  });
+
+  it("retries once when the token has not landed yet", async () => {
+    getUserDetails.mockRejectedValueOnce(
+      new ApiError("Unauthorized", 401, "HTTP_401"),
+    );
+    getUserDetails.mockResolvedValueOnce(COMPLETE_PROFILE);
+
+    const { result } = renderHook(() => useAuthReady("/home"));
+    await result.current.setupAuth();
+
+    expect(getUserDetails).toHaveBeenCalledTimes(2);
+    expect(navigate).toHaveBeenCalledWith({
+      to: "/home",
+      search: { limit: 20, offset: 0 },
+    });
+  });
+
+  it("hands a colliding account to the linking flow", async () => {
+    getUserDetails.mockRejectedValue(notSyncedError());
+    syncUser.mockRejectedValue(
+      new ApiError("Already exists", 409, "ACCOUNT_LINK_REQUIRED"),
+    );
+
+    const { result } = renderHook(() => useAuthReady("/home"));
+    await result.current.setupAuth();
+
+    expect(signOut).toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith({
+      to: "/login",
+      search: { returnTo: "/settings?tab=accounts" },
+      replace: true,
+    });
+  });
+
+  it("sends an incomplete profile to setup", async () => {
+    getUserDetails.mockResolvedValue({ id: 7, dateOfBirth: null });
+
+    const { result } = renderHook(() => useAuthReady("/home"));
+    await result.current.setupAuth();
+
+    expect(navigate).toHaveBeenCalledWith({
+      to: "/profile-setup",
+      search: { redirectTo: "/home" },
+    });
+  });
+
+  it("skips the network entirely when heading to profile setup", async () => {
+    const { result } = renderHook(() => useAuthReady("/profile-setup"));
+    await result.current.setupAuth();
+
+    expect(getUserDetails).not.toHaveBeenCalled();
+    expect(syncUser).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith({
+      to: "/profile-setup",
+      search: { redirectTo: "/profile-setup" },
+      replace: true,
+    });
+  });
+});

--- a/frontend/src/features/auth/hooks/useAuthReady.ts
+++ b/frontend/src/features/auth/hooks/useAuthReady.ts
@@ -25,11 +25,31 @@ function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promi
   ]);
 }
 
+function isApiErrorWithStatus(error: unknown, status: number): boolean {
+  return error instanceof ApiError && error.status === status;
+}
+
+const SYNC_TIMEOUT_MS = 12_000;
+const PROFILE_TIMEOUT_MS = 8000;
+
 interface UseAuthReadyResult {
   error: string | null;
   setupAuth: () => Promise<void>;
 }
 
+/**
+ * The step between "Clerk says you're signed in" and the app proper.
+ *
+ * Ordered around the fact that almost every visit here is a returning sign-in,
+ * whose account was linked to a local row long ago. So it asks for the profile
+ * first and only syncs when the answer is that there isn't one — one request
+ * for the common case, where this used to always spend a sync and a profile
+ * fetch back to back, plus 150ms of fixed sleeps between them.
+ *
+ * The sleeps are gone rather than shortened: they were waiting for the Clerk
+ * token to become available, and `apiClient.getAuthToken()` awaits the token
+ * getter on every request, so there was never anything to wait for.
+ */
 export function useAuthReady(redirectTo: string): UseAuthReadyResult {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -51,13 +71,57 @@ export function useAuthReady(redirectTo: string): UseAuthReadyResult {
         return;
       }
 
-      await new Promise((r) => setTimeout(r, 50));
+      if (shouldBypassSyncForRedirect(redirectTo)) {
+        navigate({ to: "/profile-setup", search: { redirectTo }, replace: true });
 
-      const shouldBypassSync = shouldBypassSyncForRedirect(redirectTo);
+        return;
+      }
 
-      if (!shouldBypassSync) {
+      // A 401 here means the backend rejected a token the client believes is
+      // live. Asking again picks up a freshly minted one; beyond that it is a
+      // real failure and not worth sitting on.
+      let userDetails: Record<string, unknown> | null = null;
+      let isAccountSynced = true;
+      for (let attempt = 0; attempt < 2; attempt += 1) {
         try {
-          await withTimeout(authApi.syncUser(), 12000, "Account synchronization timed out");
+          const response = await withTimeout(
+            userApi.getUserDetails(),
+            PROFILE_TIMEOUT_MS,
+            "Fetching user details timed out",
+          );
+          if (isLikelyUserDetailsPayload(response)) {
+            userDetails = response;
+          }
+          break;
+        } catch (profileError) {
+          // No local row for this Clerk account yet: a first-ever sign-in, or a
+          // sign-up whose sync never landed. That is what the sync is for.
+          if (
+            profileError instanceof ApiError &&
+            profileError.status === 409 &&
+            profileError.code === "ACCOUNT_NOT_SYNCED"
+          ) {
+            isAccountSynced = false;
+            break;
+          }
+
+          if (isApiErrorWithStatus(profileError, 401) && attempt === 0) {
+            continue;
+          }
+
+          throw profileError;
+        }
+      }
+
+      if (!isAccountSynced) {
+        let isNewUser = false;
+        try {
+          const syncResult = await withTimeout(
+            authApi.syncUser(),
+            SYNC_TIMEOUT_MS,
+            "Account synchronization timed out",
+          );
+          isNewUser = syncResult.isNewUser;
         } catch (syncError: unknown) {
           if (
             syncError instanceof ApiError &&
@@ -69,48 +133,43 @@ export function useAuthReady(redirectTo: string): UseAuthReadyResult {
             return;
           }
 
-          if (syncError instanceof Error && "status" in syncError) {
-            const errorWithStatus = syncError as { status: number };
-            if (errorWithStatus.status === 401) {
-              setError("Authentication failed. Please sign in again.");
+          if (isApiErrorWithStatus(syncError, 401)) {
+            setError("Authentication failed. Please sign in again.");
 
-              return;
-            }
+            return;
           }
+
           logger.error("[AuthReadyPage] Failed to sync user", syncError);
           setError("We couldn't link your account yet. Please try signing in again.");
 
           return;
         }
-        await new Promise((r) => setTimeout(r, 100));
-        queryClient.invalidateQueries({ queryKey: queryKeys.auth.user() });
-      }
 
-      if (shouldBypassSync) {
-        navigate({ to: "/profile-setup", search: { redirectTo }, replace: true });
+        // A row the sync just inserted has NULL details by construction, so
+        // there is nothing to read back — it goes to setup either way.
+        if (isNewUser) {
+          queryClient.invalidateQueries({ queryKey: queryKeys.auth.user() });
+          navigate({ to: "/profile-setup", search: { redirectTo } });
 
-        return;
-      }
+          return;
+        }
 
-      let userDetails: Record<string, unknown> | null = null;
-      for (let attempt = 0; attempt < 3; attempt += 1) {
         try {
-          const response = await withTimeout(userApi.getUserDetails(), 8000, "Fetching user details timed out");
-          if (!isLikelyUserDetailsPayload(response)) {
-            await new Promise((r) => setTimeout(r, 120));
-            continue;
+          const response = await withTimeout(
+            userApi.getUserDetails(),
+            PROFILE_TIMEOUT_MS,
+            "Fetching user details timed out",
+          );
+          if (isLikelyUserDetailsPayload(response)) {
+            userDetails = response;
           }
-          userDetails = response;
-          break;
-        } catch (userError) {
-          if (userError instanceof ApiError && userError.status === 401) {
-            await new Promise((r) => setTimeout(r, 120));
-            continue;
-          }
-          throw userError;
+        } catch (profileError) {
+          logger.error("[AuthReadyPage] Failed to load profile after sync", profileError);
         }
       }
 
+      // Seeds the cache the destination route is about to read, so it renders
+      // from this response instead of asking for it again.
       if (userDetails) {
         queryClient.setQueryData(queryKeys.auth.user(), userDetails);
       }

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -2,6 +2,7 @@ export { useBeforeUnload } from "./useBeforeUnload";
 export { useDeferredVisibility } from "./useDeferredVisibility";
 export { useFeatureLoading } from "./useFeatureLoading";
 export { useCriticalLoading, useGlobalLoading } from "./useGlobalLoading";
+export { useIsOffline } from "./useIsOffline";
 export {
   useMutationErrorHandler,
   useOptimisticMutationHandler,

--- a/frontend/src/hooks/useIsOffline.ts
+++ b/frontend/src/hooks/useIsOffline.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Tracks `navigator.onLine`.
+ *
+ * Reports whether the device has a network interface at all, not whether the
+ * API is reachable — a captive portal reads as online. That is enough for the
+ * two callers, which both only need to tell "no connection" apart from
+ * "connection, but something else is wrong".
+ */
+export function useIsOffline(): boolean {
+  const [isOffline, setIsOffline] = useState(
+    typeof navigator === "undefined" ? false : !navigator.onLine,
+  );
+
+  useEffect(() => {
+    const goOffline = () => setIsOffline(true);
+    const goOnline = () => setIsOffline(false);
+
+    globalThis.addEventListener("offline", goOffline);
+    globalThis.addEventListener("online", goOnline);
+
+    return () => {
+      globalThis.removeEventListener("offline", goOffline);
+      globalThis.removeEventListener("online", goOnline);
+    };
+  }, []);
+
+  return isOffline;
+}

--- a/frontend/src/routes/-PublicSelfHostedGate.tsx
+++ b/frontend/src/routes/-PublicSelfHostedGate.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { Navigate } from "@tanstack/react-router";
 
+import { AuthLoadingScreen } from "@/components/auth/AuthLoadingScreen";
 import { isLocalAuthMode } from "@/config/runtime";
 import { useAppAuthState } from "@/hooks/auth/useAuthState";
-import { LoadingFallback } from "@/routes/-authGuards";
 
 interface PublicSelfHostedGateProps {
   children: React.ReactNode;
@@ -19,7 +19,7 @@ export function PublicSelfHostedGate({
   }
 
   if (!isLoaded) {
-    return <LoadingFallback />;
+    return <AuthLoadingScreen />;
   }
 
   if (isSignedIn) {

--- a/frontend/src/routes/-RedirectSignedInToApp.test.tsx
+++ b/frontend/src/routes/-RedirectSignedInToApp.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RedirectSignedInToApp } from "@/routes/-RedirectSignedInToApp";
+
+const useAppAuthStateMock = vi.fn();
+
+vi.mock("@/hooks/auth/useAuthState", () => ({
+  useAppAuthState: (...arguments_: unknown[]) => useAppAuthStateMock(...arguments_),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Navigate: ({ to }: { to: string }) => <div data-testid="navigate">{to}</div>,
+}));
+
+describe("RedirectSignedInToApp", () => {
+  beforeEach(() => {
+    useAppAuthStateMock.mockReset();
+  });
+
+  it("sends a signed-in visitor to the app", () => {
+    useAppAuthStateMock.mockReturnValue({ isLoaded: true, isSignedIn: true });
+
+    render(
+      <RedirectSignedInToApp>
+        <div data-testid="children">Landing content</div>
+      </RedirectSignedInToApp>,
+    );
+
+    expect(screen.getByTestId("navigate")).toHaveTextContent("/home");
+    expect(screen.queryByTestId("children")).not.toBeInTheDocument();
+  });
+
+  it("renders the landing page for a signed-out visitor", () => {
+    useAppAuthStateMock.mockReturnValue({ isLoaded: true, isSignedIn: false });
+
+    render(
+      <RedirectSignedInToApp>
+        <div data-testid="children">Landing content</div>
+      </RedirectSignedInToApp>,
+    );
+
+    expect(screen.getByTestId("children")).toBeInTheDocument();
+    expect(screen.queryByTestId("navigate")).not.toBeInTheDocument();
+  });
+
+  it("renders the landing page while auth is still resolving, rather than a spinner", () => {
+    useAppAuthStateMock.mockReturnValue({ isLoaded: false, isSignedIn: false });
+
+    render(
+      <RedirectSignedInToApp>
+        <div data-testid="children">Landing content</div>
+      </RedirectSignedInToApp>,
+    );
+
+    expect(screen.getByTestId("children")).toBeInTheDocument();
+    expect(screen.queryByTestId("navigate")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/routes/-RedirectSignedInToApp.tsx
+++ b/frontend/src/routes/-RedirectSignedInToApp.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { Navigate } from "@tanstack/react-router";
+
+import { useAppAuthState } from "@/hooks/auth/useAuthState";
+
+interface RedirectSignedInToAppProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Sends an already signed-in visitor from `/` straight into the app.
+ *
+ * The installed PWA launches at `start_url`, and the marketing header is
+ * auth-unaware — it offers "Log in" and "Get started" whether or not there is
+ * a session. So a signed-in launch landed on the marketing page, which read as
+ * having been signed out; tapping "Log in" then went through `/auth-ready`,
+ * which re-syncs the account and re-fetches the profile before forwarding to
+ * `/home`. Several seconds of spinner for a session that was never lost.
+ *
+ * `start_url` now points at `/home`, but a manifest change only reaches an
+ * installed app when the browser re-reads it (never, on iOS, without a
+ * reinstall), so the redirect has to exist client side too.
+ *
+ * Deliberately renders the landing page while Clerk is still loading rather
+ * than holding a spinner: `/` is the marketing entry point and its first paint
+ * should not wait on auth. A signed-in visitor sees it for a frame; a crawler,
+ * which never resolves a session, sees the page it came for.
+ */
+export function RedirectSignedInToApp({ children }: RedirectSignedInToAppProps) {
+  const { isLoaded, isSignedIn } = useAppAuthState();
+
+  if (isLoaded && isSignedIn) {
+    return <Navigate to="/home" search={{ limit: 20, offset: 0 }} replace />;
+  }
+
+  return children;
+}

--- a/frontend/src/routes/-authGuards.tsx
+++ b/frontend/src/routes/-authGuards.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Navigate } from "@tanstack/react-router";
 
+import { AuthLoadingScreen } from "@/components/auth/AuthLoadingScreen";
 import LoadingSpinner from "@/components/ui/LoadingSpinner";
 import { isClerkAuthMode } from "@/config/runtime";
 import { useAppAuthState } from "@/hooks/auth/useAuthState";
@@ -10,11 +11,7 @@ export function RequireAuth({ children }: { children: React.ReactNode }) {
   const { isSignedIn, isLoaded } = useAppAuthState();
 
   if (!isLoaded) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-surface">
-        <LoadingSpinner size="lg" />
-      </div>
-    );
+    return <AuthLoadingScreen />;
   }
 
   if (!isSignedIn) {
@@ -28,11 +25,7 @@ export function RequireUnauth({ children }: { children: React.ReactNode }) {
   const { isSignedIn, isLoaded } = useAppAuthState();
 
   if (!isLoaded) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-surface">
-        <LoadingSpinner size="lg" />
-      </div>
-    );
+    return <AuthLoadingScreen />;
   }
 
   if (isSignedIn) {

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -2,13 +2,16 @@ import React from "react";
 import { createFileRoute } from "@tanstack/react-router";
 
 import { PublicSelfHostedGate } from "@/routes/-PublicSelfHostedGate";
+import { RedirectSignedInToApp } from "@/routes/-RedirectSignedInToApp";
 
 const LandingPage = React.lazy(() => import("@/features/landing/pages/LandingPage"));
 
 export const Route = createFileRoute("/")({
   component: () => (
     <PublicSelfHostedGate>
-      <LandingPage />
+      <RedirectSignedInToApp>
+        <LandingPage />
+      </RedirectSignedInToApp>
     </PublicSelfHostedGate>
   ),
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -69,7 +69,15 @@ export default defineConfig(({ command }) => {
                 short_name: "MacroTrackr",
                 description:
                   "Log meals in seconds, set a macro split, and see where the week actually went.",
-                start_url: "/",
+                // The app, not the marketing page. `/` is a sales pitch with a
+                // "Log in" button in its header regardless of session state, so
+                // launching there made an installed app look signed out every
+                // time. `/home` is behind RequireAuth, which sends a genuinely
+                // signed-out launch to /login on its own.
+                //
+                // `id` stays "/" so this is a manifest update to the same
+                // installed app rather than a second install.
+                start_url: "/home",
                 display: "standalone",
                 // Shortcuts put the two things people open the app for on the
                 // launcher's long-press menu.


### PR DESCRIPTION
Opening the installed PWA landed on the marketing page and read as a lost session. It was never a lost session.

## The report

> Everytime I open the PWA app, i keep getting sent to the landing page and having to re log in

Three things stacked up:

1. `start_url` was `/`, and `/` renders `LandingPage` unconditionally in managed mode — `PublicSelfHostedGate` only redirects a signed-in visitor when auth mode is `local`.
2. `AppHeader` is entirely auth-unaware. It offers "Log in" and "Get started" whether or not there is a session, so a live session looked like a lost one.
3. Tapping "Log in" took the slow road back in: `/login` → `RequireUnauth` sees you *are* signed in → `/auth-ready`, which re-syncs the account and re-fetches the profile before forwarding to `/home`. Several seconds of spinner for a session that was never gone.

## What changed

**`start_url` is now `/home`** (`id` stays `/`, so it is a manifest update to the same install, not a second one). `/home` sits behind `RequireAuth`, so a genuinely signed-out launch still goes to `/login` on its own. A manifest change only reaches an installed app when the browser re-reads it — on iOS, not without a reinstall — so the same redirect exists client side in `RedirectSignedInToApp`. It renders the landing page while Clerk is still loading rather than holding a spinner: `/` is the marketing entry point and its first paint should not wait on auth.

**An offline launch no longer spins forever.** Opening on a guarded route surfaced a pre-existing trap: when the clerk-js download fails, `IsomorphicClerk.getEntryChunks()` emits status `"error"` and returns *without* calling `emitLoaded()`, so `isLoaded` stays false for the life of the document, and Clerk's loader does not retry. Every guard keyed on `!isLoaded` spun until the app was killed. `AuthLoadingScreen` keeps the spinner for the first moment and then says what happened — offline is knowable immediately from `navigator.onLine`, so it does not spin for ten seconds first — and reloads on its own when the connection returns, since a stuck provider only recovers with a fresh document.

**Login costs one round trip instead of two.** `/auth-ready` was doing `sleep 50ms` → `POST /api/auth/clerk-sync` → `sleep 100ms` → `GET /api/user/me`, on every login. The sleeps were waiting for the Clerk token, but `ApiClient.getAuthToken()` awaits the token getter on every request, so there was nothing to wait for. And `/api/user/me` already answers 409 `ACCOUNT_NOT_SYNCED` when an account has no local row — exactly the signal for "this one needs syncing" — so the profile is fetched first and the sync only happens when there is no profile. A returning login sends no sync at all.

## Review notes

- Three commits, one concern each; they read in order.
- `AuthSyncResponse` claimed `{ user, isNewUser }` while the route has always returned a flat object. The contract test named for that contract asserted the nested shape against its own mock, so it proved nothing. Both now match the wire, and `isNewUser` — declared but never implemented — is now populated and used.
- Deliberately not done: sign-in could skip `/auth-ready` entirely, since all four guarded routes wrap `RequireCompleteProfile`, which already fetches the profile and already bounces an unsynced account to `/auth-ready`. It saves a route transition and a chunk load, and in the PWA that chunk is precached — little gain for a change to the sign-in completion path.
- Also left alone: `AppHeader` still shows "Log in" to a signed-in visitor on `/pricing`, `/blog` and `/tools`. Outside the reported symptom now that `/` redirects.
- Not covered: letting a signed-in user read cached data offline. The react-query cache *is* persisted to localStorage, but `RequireAuth` gates on Clerk's `isSignedIn`, which cannot resolve without the network, and every API call would 401 without a token. That needs a "was signed in" marker and a read-only degraded mode.

## Verified

frontend 866 tests / 148 files, backend 453 / 45, both workspaces typecheck clean, lint 0 errors, UI budgets 16/16 unchanged.

New tests cover the redirect gate in all three auth states; the offline screen's spin / offline / timeout / auto-reload / no-reload-on-a-blip paths; and for login, that a returning user sends no sync, an unsynced one syncs once and skips the read-back, a sync that linked an existing row does read it back, the 401 retry, `ACCOUNT_LINK_REQUIRED` still reaching the linking flow, an incomplete profile, and the profile-setup bypass.

Not exercised in a browser: the manifest `start_url` change reaching an already-installed app, and the offline screen on a real cold offline launch. Both are read from the code.