### PR TITLE
fix(contact): put the real support address back, and stop the placeholder shipping

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -25,7 +25,7 @@ Code of Conduct.
 
 ## Reporting
 
-Report issues to `support@local.invalid`. Include links, screenshots, and
+Report issues to `support@macrotrackr.com`. Include links, screenshots, and
 context when possible.
 
 All reports will be reviewed and handled in a timely manner.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@
 
 Do not open public issues for sensitive vulnerabilities.
 
-Email: `support@local.invalid`
+Email: `support@macrotrackr.com`
 
 Include:
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -7,7 +7,7 @@
 
 ## Direct contact
 
-Email: `support@local.invalid`
+Email: `support@macrotrackr.com`
 
 ## Self-hosted help checklist
 

--- a/TRADEMARK_POLICY.md
+++ b/TRADEMARK_POLICY.md
@@ -15,4 +15,4 @@ You may not:
 - Use project trademarks or logos in a way that implies endorsement.
 - Rebrand a modified service as the official hosted service.
 
-For permission requests, contact `support@local.invalid`.
+For permission requests, contact `support@macrotrackr.com`.

--- a/backend/src/services/openfoodfacts-api-client.ts
+++ b/backend/src/services/openfoodfacts-api-client.ts
@@ -1,10 +1,18 @@
 // src/services/openfoodfacts-api-client.ts
 
+import { getConfig } from "../config";
 import { logger, loggerHelpers } from "../lib/observability/logger";
 
 // Use the search-a-licious API for full-text search
 const API_URL = "https://search.openfoodfacts.org/search";
-const USER_AGENT = "MacroTrackr/1.0 (contact: support@local.invalid)";
+
+// Open Food Facts asks for a reachable contact and throttles or blocks clients
+// that do not give one. This was pinned to the placeholder address, so every
+// barcode lookup identified itself with a mailbox that cannot be written to.
+// Reading it from config means it follows the deployment.
+function userAgent(): string {
+  return `MacroTrackr/1.0 (contact: ${getConfig().SUPPORT_EMAIL})`;
+}
 
 // Configuration constants
 const MAX_RESULTS = 10;
@@ -578,7 +586,7 @@ export class OpenFoodFactsApiClient {
 
       const response = await fetch(url, {
         headers: {
-          "User-Agent": USER_AGENT,
+          "User-Agent": userAgent(),
           "Accept": "application/json",
         },
         signal: controller.signal,
@@ -634,7 +642,7 @@ export class OpenFoodFactsApiClient {
 
       const response = await fetch(url, {
         headers: {
-          "User-Agent": USER_AGENT,
+          "User-Agent": userAgent(),
           "Accept": "application/json",
         },
         signal: controller.signal,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "bunx vite",
-    "build": "bunx vite build",
+    "build": "node ./scripts/check-support-email.mjs && bunx vite build",
     "postbuild": "(bun ./scripts/generate-sitemap.js || node ./scripts/generate-sitemap.js) && (bun ./scripts/prerender.mjs || node ./scripts/prerender.mjs)",
     "preview": "bunx vite preview",
     "typecheck": "tsc -p tsconfig.app.json --noEmit && tsc -p tsconfig.node.json --noEmit",
@@ -27,6 +27,7 @@
     "bundle:size": "node scripts/analyze-bundle.js",
     "ui:budgets": "node ./scripts/check-ui-budgets.mjs",
     "verify:assetlinks": "node ./scripts/check-assetlinks.mjs",
+    "verify:support-email": "node ./scripts/check-support-email.mjs",
     "release:blog": "node ./scripts/release-note-to-blog.mjs"
   },
   "dependencies": {

--- a/frontend/scripts/check-support-email.mjs
+++ b/frontend/scripts/check-support-email.mjs
@@ -1,0 +1,64 @@
+// The support address is the only way a user can reach us from the privacy
+// policy, the terms and the site footer, and it fails silently: a build with
+// VITE_SUPPORT_EMAIL unset bakes in the `support@local.invalid` placeholder,
+// the pages render a well-formed mailto, and nothing reports that the address
+// cannot receive mail. `.invalid` is reserved by RFC 2606 precisely so it can
+// never resolve, so anything sent there is gone.
+//
+// Only the managed build is checked. A self-hosted deployment has no
+// macrotrackr.com support desk and is right to keep the placeholder, so the
+// gate keys on VITE_AUTH_MODE=clerk, which is what makes a build ours.
+import { existsSync, readFileSync } from "node:fs";
+
+const ENV_FILE = new URL("../.env.production", import.meta.url);
+
+/**
+ * Vite reads .env.production itself and injects the result, so a local
+ * `bun run build` never puts these in process.env. The container build sets
+ * them as real env vars instead. Both paths ship, so both are read, with the
+ * real environment winning.
+ */
+function readEnvFile() {
+  if (!existsSync(ENV_FILE)) return {};
+
+  const entries = {};
+  for (const line of readFileSync(ENV_FILE, "utf8").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const separator = trimmed.indexOf("=");
+    if (separator === -1) continue;
+
+    entries[trimmed.slice(0, separator).trim()] = trimmed
+      .slice(separator + 1)
+      .trim()
+      .replace(/^["']|["']$/g, "");
+  }
+
+  return entries;
+}
+
+const fileEnv = readEnvFile();
+const read = (key) => process.env[key] ?? fileEnv[key] ?? "";
+
+if (read("VITE_AUTH_MODE") !== "clerk") {
+  process.exit(0);
+}
+
+const email = read("VITE_SUPPORT_EMAIL");
+
+if (!email) {
+  console.error(
+    "VITE_SUPPORT_EMAIL is not set, so this build would ship a placeholder\n" +
+      "support address on the privacy policy, the terms and the footer.",
+  );
+  process.exit(1);
+}
+
+if (email.toLowerCase().endsWith(".invalid")) {
+  console.error(
+    `VITE_SUPPORT_EMAIL is ${email}, which is an RFC 2606 reserved domain and\n` +
+      "can never receive mail. Set the real support address for a managed build.",
+  );
+  process.exit(1);
+}

--- a/frontend/src/data/blog-content/carbs-fats-balance.md
+++ b/frontend/src/data/blog-content/carbs-fats-balance.md
@@ -311,4 +311,4 @@ Your body will tell you what it needs. You just have to listen.
 
 The MacroTrackr Team
 
-*Need help setting your targets? Email us at support@local.invalid.*
+*Need help setting your targets? Email us at support@macrotrackr.com.*

--- a/frontend/src/data/blog-content/macro-tracking-tips-for-beginners.md
+++ b/frontend/src/data/blog-content/macro-tracking-tips-for-beginners.md
@@ -205,4 +205,4 @@ That's it. Start simple. Stay consistent. The results will come.
 
 The MacroTrackr Team
 
-*Questions about getting started? Email us at support@local.invalid. We read every message.*
+*Questions about getting started? Email us at support@macrotrackr.com. We read every message.*

--- a/frontend/src/data/blog-content/meal-prep-for-macro-tracking.md
+++ b/frontend/src/data/blog-content/meal-prep-for-macro-tracking.md
@@ -310,4 +310,4 @@ Start small. Prep just lunches for one week. See how much easier your tracking b
 
 The MacroTrackr Team
 
-*Questions about meal prep strategies? Email us at support@local.invalid.*
+*Questions about meal prep strategies? Email us at support@macrotrackr.com.*

--- a/frontend/src/utils/appConstants.ts
+++ b/frontend/src/utils/appConstants.ts
@@ -31,7 +31,12 @@ export const APP_URL = trimTrailingSlash(rawAppUrl);
 // One spelling in this deployment: the title, the manifest and the README
 // disagreed ("MacroTrackr", "Macro Tracker", "MacroTracker").
 export const APP_NAME = import.meta.env.VITE_PUBLIC_APP_NAME ?? "MacroTrackr";
-export const SUPPORT_EMAIL = import.meta.env.VITE_SUPPORT_EMAIL ?? "support@local.invalid";
+// `??` let an explicitly empty build arg through as "", which renders a bare
+// `mailto:` link. The placeholder is a self-hosting default and is rejected for
+// a managed build by scripts/check-support-email.mjs.
+export const SUPPORT_EMAIL =
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- "" has to fall through to the default, which ?? would not do
+  import.meta.env.VITE_SUPPORT_EMAIL?.trim() || "support@local.invalid";
 export const SUPPORT_EMAIL_MAILTO = `mailto:${SUPPORT_EMAIL}`;
 export const GITHUB_REPO_URL = rawGitHubRepoUrl;
 export const DOCS_URL = rawDocumentationUrl;


### PR DESCRIPTION
The privacy policy, the terms and the site footer were all offering `support@local.invalid`. `.invalid` is reserved by RFC 2606 so that it can never resolve — every message sent from those pages went nowhere, and nothing reported it.

## Why it was possible

The address reaches those pages through `VITE_SUPPORT_EMAIL`, and **every layer of the build chain defaults to the placeholder** when it is unset:

| Layer | Default |
|---|---|
| `frontend/Dockerfile:22` | `ARG VITE_SUPPORT_EMAIL=support@local.invalid` |
| `docker-compose.build.yml:16` | `${VITE_SUPPORT_EMAIL:-support@local.invalid}` |
| `frontend/src/utils/appConstants.ts:34` | `?? "support@local.invalid"` |

That is correct for a self-hosted deployment, which has no macrotrackr.com support desk. It is wrong for ours: a missing variable produced a well-formed `mailto:` to a dead mailbox instead of a failed build.

`frontend/scripts/check-support-email.mjs` now runs ahead of `vite build` and rejects a missing or `.invalid` address — but only when `VITE_AUTH_MODE=clerk`, which is what makes a build ours. A self-hosted build keeps the placeholder and is left alone. It reads `.env.production` as well as the environment, because Vite loads that file itself and a local production build never puts those values in `process.env`.

## Also hardcoded, so env had nothing to do with it

- `SECURITY.md`, `SUPPORT.md`, `CODE_OF_CONDUCT.md`, `TRADEMARK_POLICY.md` — the address a vulnerability report or a conduct complaint is meant to go to.
- Three blog posts that sign off asking people to email us.
- **The Open Food Facts `User-Agent`** (`backend/src/services/openfoodfacts-api-client.ts:7`). That service asks for a reachable contact and throttles or blocks clients for faking one, and every barcode lookup — including the scanner that shipped in #132 — identified itself with an unreachable mailbox. Now reads `SUPPORT_EMAIL` from config so it follows the deployment.

`appConstants` used `??`, which let an explicitly empty build arg through as `""` and rendered a bare `mailto:`. Now falls through to the default.

## Action needed outside this PR

`frontend/.env.production` is gitignored, so it is not in this diff. It had the placeholder for **both** `SUPPORT_EMAIL` and `VITE_SUPPORT_EMAIL`, which is where the live pages got it. I have corrected it locally. The backend one also feeds the outbound From domain (`email-service.ts:11-12` derives `noreply@${domain}`), so **password-reset mail was being sent as `noreply@local.invalid`** — worth checking whether any reset mail actually left the building.

Whatever builds production needs `VITE_SUPPORT_EMAIL=support@macrotrackr.com` set. Once this merges, a build without it fails loudly rather than shipping a dead address — so set it before the next deploy.

## Verified

backend 453 tests / 45 files, frontend 866 / 148, both typecheck clean, lint 0 errors, UI budgets 16/16.

The guard was exercised in all four states: managed + placeholder and managed + empty both fail; self-hosted + placeholder and managed + real address both pass.

Not verified in a browser: the rendered pages. The address is read from a constant that the guard now protects.