### PR TITLE
chore(release): v3.1.0 — Barcode Scanning, One-Click Imports, and a Faster Way In

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -57,6 +57,12 @@ jobs:
       working-directory: ./frontend
       run: bun run lint
 
+    # Five releases' worth of drift went unnoticed because this only ever ran
+    # by hand. A release note with no post is a release nobody was told about.
+    - name: Check release notes have posts
+      working-directory: ./frontend
+      run: bun run release:blog --check
+
     - name: Build
       working-directory: ./frontend
       run: bun run build

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.macrotrackr.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "3.0.0"
+        versionCode 2
+        versionName "3.1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "macrotrackr-frontend",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.1.0",
   "type": "module",
   "scripts": {
     "dev": "bunx vite",

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -2,79 +2,79 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://macrotrackr.com/</loc>
-    <lastmod>2026-08-15</lastmod>
+    <lastmod>2026-08-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/blog</loc>
-    <lastmod>2026-08-15</lastmod>
+    <lastmod>2026-08-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/tools</loc>
-    <lastmod>2026-08-15</lastmod>
+    <lastmod>2026-08-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/tools/tdee-calculator</loc>
-    <lastmod>2026-08-15</lastmod>
+    <lastmod>2026-08-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/tools/bmr-calculator</loc>
-    <lastmod>2026-08-15</lastmod>
+    <lastmod>2026-08-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/tools/macro-calculator</loc>
-    <lastmod>2026-08-15</lastmod>
+    <lastmod>2026-08-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/tools/weight-loss-calculator</loc>
-    <lastmod>2026-08-15</lastmod>
+    <lastmod>2026-08-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/tools/protein-calculator</loc>
-    <lastmod>2026-08-15</lastmod>
+    <lastmod>2026-08-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/compare</loc>
-    <lastmod>2026-08-15</lastmod>
+    <lastmod>2026-08-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/compare/myfitnesspal</loc>
-    <lastmod>2026-08-15</lastmod>
+    <lastmod>2026-08-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/compare/macrofactor</loc>
-    <lastmod>2026-08-15</lastmod>
+    <lastmod>2026-08-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/compare/cronometer</loc>
-    <lastmod>2026-08-15</lastmod>
+    <lastmod>2026-08-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/compare/lose-it</loc>
-    <lastmod>2026-08-15</lastmod>
+    <lastmod>2026-08-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -110,21 +110,27 @@
   </url>
   <url>
     <loc>https://macrotrackr.com/pricing</loc>
-    <lastmod>2026-08-15</lastmod>
+    <lastmod>2026-08-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/privacy</loc>
-    <lastmod>2026-08-15</lastmod>
+    <lastmod>2026-08-24</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/terms</loc>
-    <lastmod>2026-08-15</lastmod>
+    <lastmod>2026-08-24</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>
+  </url>
+  <url>
+    <loc>https://macrotrackr.com/blog/v3-1-0</loc>
+    <lastmod>2026-08-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
   </url>
   <url>
     <loc>https://macrotrackr.com/blog/v0-8-0</loc>

--- a/frontend/scripts/release-note-to-blog.mjs
+++ b/frontend/scripts/release-note-to-blog.mjs
@@ -50,14 +50,16 @@ export const hasPostFor = (version, posts) => {
 export const readingTimeFor = (markdown) =>
   `${Math.max(1, Math.round(markdown.split(/\s+/).length / 200))} min`;
 
+// No h1. BlogArticlePage renders post.title as the page heading, so one here
+// gives every release article two — which is what the markdown in this
+// directory was stripped of, while this script went on emitting it.
 export function markdownFor(note) {
-  const heading = `# MacroTrackr ${note.version}: ${note.title}`;
   const intro =
     note.summary ??
     `Version ${note.version} is out. Here is what changed and why.`;
   const bullets = note.highlights.map((line) => `- ${line}`).join("\n");
 
-  return `${heading}\n\n${intro}\n\n## What changed\n\n${bullets}\n\nAs always, everything here is in the open-source repository, and your data stays exportable.\n\nThe MacroTrackr Team\n`;
+  return `${intro}\n\n## What changed\n\n${bullets}\n\nAs always, everything here is in the open-source repository, and your data stays exportable.\n\nThe MacroTrackr Team\n`;
 }
 
 export function postFor(note, markdown) {

--- a/frontend/src/data/blog-content/v3-1-0.md
+++ b/frontend/src/data/blog-content/v3-1-0.md
@@ -1,0 +1,19 @@
+Version 3.1 is mostly about the phone: barcode scanning that works inside an installed app, importers so switching trackers does not mean starting from an empty log, and an Android build with in-app Pro. Plus the launch and sign-in path, which had been dropping people on the marketing page and making them think they had been signed out.
+
+## What changed
+
+- Barcode scanning on your phone: point the camera at a label and the food goes in, with the two policy bugs fixed that were stopping an installed app from using the camera at all
+- One-click imports from MyFitnessPal, Cronometer, MacroFactor and Lose It!, so moving over does not start from an empty log
+- Shareable macro snapshots: a rendered scorecard of your day, drawn on your own device
+- The installed app now opens on your log instead of the marketing page, and no longer sits on a spinner when it starts with no connection
+- Signing in costs one round trip instead of two, with 150ms of fixed delay taken out of the path
+- An Android build with in-app Pro through Google Play Billing. Not on the Play Store yet — the listing is still being set up
+- Health data stays out of browser storage, and biometric unlock is opt-in and cleared when you sign out
+- Migration guides for anyone moving from another tracker, and a comparison hub covering the alternatives
+- Blog posts and comparison pages are pre-rendered, so a cold load and a search crawler both get real content instead of a flash of fallback
+- Macro percentages no longer clip out of the reporting card, navigation resets the scroll position, and logout moved into Settings
+- The support address on the privacy policy, the terms and the footer works again. It had been shipping as a placeholder that could not receive mail
+
+As always, everything here is in the open-source repository, and your data stays exportable.
+
+The MacroTrackr Team

--- a/frontend/src/data/blog-posts.json
+++ b/frontend/src/data/blog-posts.json
@@ -1,5 +1,19 @@
 [
   {
+    "slug": "v3-1-0",
+    "title": "MacroTrackr 3.1.0: Barcode Scanning, One-Click Imports, and a Faster Way In",
+    "excerpt": "Version 3.1 is mostly about the phone: barcode scanning that works inside an installed app, importers so switching trackers does not mean starting from an empty log, and an Android build with in-app Pro. Plus the launch and sign-in path, which had been dropping people on the marketing page and making them think they had been signed out.",
+    "date": "2026-08-24",
+    "category": "Releases",
+    "author": "MacroTrackr Team",
+    "readingTime": "2 min",
+    "tags": [
+      "Product",
+      "Release Notes"
+    ],
+    "featured": false
+  },
+  {
     "slug": "v0-8-0",
     "title": "MacroTrackr 0.8.0: Core Features Complete",
     "excerpt": "Calorie and macro tracking",

--- a/frontend/src/data/release-notes.json
+++ b/frontend/src/data/release-notes.json
@@ -1,5 +1,25 @@
 [
   {
+    "version": "3.1.0",
+    "date": "2026-08-24",
+    "title": "Barcode Scanning, One-Click Imports, and a Faster Way In",
+    "type": "release",
+    "summary": "Version 3.1 is mostly about the phone: barcode scanning that works inside an installed app, importers so switching trackers does not mean starting from an empty log, and an Android build with in-app Pro. Plus the launch and sign-in path, which had been dropping people on the marketing page and making them think they had been signed out.",
+    "highlights": [
+      "Barcode scanning on your phone: point the camera at a label and the food goes in, with the two policy bugs fixed that were stopping an installed app from using the camera at all",
+      "One-click imports from MyFitnessPal, Cronometer, MacroFactor and Lose It!, so moving over does not start from an empty log",
+      "Shareable macro snapshots: a rendered scorecard of your day, drawn on your own device",
+      "The installed app now opens on your log instead of the marketing page, and no longer sits on a spinner when it starts with no connection",
+      "Signing in costs one round trip instead of two, with 150ms of fixed delay taken out of the path",
+      "An Android build with in-app Pro through Google Play Billing. Not on the Play Store yet \u2014 the listing is still being set up",
+      "Health data stays out of browser storage, and biometric unlock is opt-in and cleared when you sign out",
+      "Migration guides for anyone moving from another tracker, and a comparison hub covering the alternatives",
+      "Blog posts and comparison pages are pre-rendered, so a cold load and a search crawler both get real content instead of a flash of fallback",
+      "Macro percentages no longer clip out of the reporting card, navigation resets the scroll position, and logout moved into Settings",
+      "The support address on the privacy policy, the terms and the footer works again. It had been shipping as a placeholder that could not receive mail"
+    ]
+  },
+  {
     "version": "3.0.0",
     "date": "2026-08-15",
     "title": "One Design System, End to End",


### PR DESCRIPTION
32 PRs have landed since the `v3.0.0` tag with no release note between them. This cuts 3.1.0.

## The release

`frontend/src/data/release-notes.json` is the only hand-written part. `blog-posts.json` and `blog-content/v3-1-0.md` are generated from it by `bun run release:blog`, and `sitemap.xml` by the `postbuild` step — so review the note and the rest follows.

Headline is the phone: barcode scanning that works inside an installed app, importers so a switch does not start from an empty log, and an Android build with in-app Pro. The note says plainly that it is **not on the Play Store yet**, since #155 left the assetlinks fingerprint as a placeholder pending Play Console.

## Versions

| Where | From | To |
|---|---|---|
| `frontend/package.json` | 3.0.0 | 3.1.0 |
| `frontend/android/app/build.gradle` `versionName` | 3.0.0 | 3.1.0 |
| `frontend/android/app/build.gradle` `versionCode` | 1 | 2 |

The Android version is **not** derived from `package.json` — Capacitor does not sync it, so `build.gradle` carries its own copy and has to be bumped by hand. `versionCode` goes to 2 because Play rejects an upload that does not exceed the last one, which matters now that there is something to upload.

`backend/package.json` stays at 2.6.0. The two version independently and nothing reads across, but the gap is wide enough to deserve a deliberate decision rather than drift — say if you want them aligned.

## Two tooling bugs this release exposed

Both are in the first commit, separate from the release itself.

**The generator was writing a duplicate h1.** `markdownFor()` opened every post with `# MacroTrackr <version>: <title>`, but `BlogArticlePage` renders `post.title` as the page's h1. #149 stripped the h1 out of the files in `blog-content/` and added `blogContentHeadings.test.ts` to keep it that way — without updating the script that writes them. So the fix held only until the next release regenerated one. The test caught it here; the generator is now what's fixed, rather than the output.

**`release:blog --check` was never wired up.** Its own docstring calls it "the CI hook for when you want the gate to enforce it", and no workflow ran it. It now runs in the frontend quality gate. This is why five releases' worth of drift went unnoticed — the check only ever ran by hand, and it also can't see the real gap, since it verifies that every *note* has a post, not that every shipped change has a note.

## Verified

frontend 867 tests / 148 files, typecheck clean, lint 0 errors, UI budgets 16/16, `release:blog --check` passes for all 7 notes. Sitemap regenerated by a real build; the diff is the new blog URL plus refreshed `lastmod` dates.

## After merge

Tagging `v3.1.0` triggers `publish-images.yml`, which builds and pushes the images and then dispatches a deploy to `macrotrackr-infra`. I have not tagged or created the GitHub release — that is the outward-facing step and yours to time.