### PR TITLE
fix: make the onboarding goal step answer the goal you picked, and repair a UI budget that measured nothing

### DIFF
--- a/.github/design-system.md
+++ b/.github/design-system.md
@@ -46,6 +46,14 @@ There is one of each. Adding a second is drift.
 | A comparison table | `ComparisonTable` | `frontend/src/features/landing/comparisons/ComparisonTable.tsx` |
 | Page chrome and header offset | `PageShell`, `AppHeader` | `frontend/src/components/layout/` |
 
+One exception you will meet immediately: `CardContainer`
+(`frontend/src/components/form/CardContainer.tsx`) has 19 call sites to
+`Panel`'s 18, and the auth screens are among them. It is not a second card —
+its `default` variant *is* `PANEL_CLASS` — but it is a second front door, with
+no header, footer or divider grading behind it. Reach for `Panel` in new work.
+Its `transparent` variant is the part that genuinely drifted: own radius, own
+two durations, and it belongs in `Panel` as a prop or nowhere.
+
 Colour, radius, surface and motion values come from `frontend/src/style.css` and
 `frontend/src/styles/global.css`. Write the Tailwind token class (`bg-surface-2`,
 `text-muted`, `rounded-card`); a hex literal in a component is drift by
@@ -76,10 +84,26 @@ actions, and live values. Macros have their own three tokens; check
 `style.css` for which — do not assume, and do not reuse the brand green for a
 macro.
 
-**Animate what changes.** Opacity-only, three durations, two curves, all in
-`Reveal`. A static number counting up from zero on every mount is decoration:
-`AnimatedNumber` is for the value that actually moves, at most one per screen.
-Every animation honours `prefers-reduced-motion`.
+**Animate what changes.** Entrances are opacity-only and go through `Reveal`,
+which is the whole vocabulary: three durations and two curves, in `DURATIONS`
+and `EASINGS` (`frontend/src/components/utils/UiConstants.ts`). A static number
+counting up from zero on every mount is decoration: `AnimatedNumber` is for the
+value that actually moves, at most one per screen.
+
+That describes `Reveal`, not yet the whole app: the tree still holds 17 distinct
+durations across transitions, timers and one-off variants. The budgets below
+carry the real figure, and it is the one to trust.
+
+**Reduced motion has two halves, and CSS is only one of them.** The block at
+`frontend/src/styles/global.css:119` zeroes every CSS animation and transition,
+which covers each `transition-*` utility for free. It cannot touch motion driven
+from JS — `animate()` writing `textContent`, or a `motion` element's inline
+transform — because neither is a CSS animation. Anything in that second half
+asks for itself, via `usePrefersReducedMotion`. `Reveal`, `PageTransition` and
+`AnimatedNumber` do. `AnimatedNumber` did not until its figures were found still
+counting under the preference, and the test that now holds it there asserts the
+timer never starts, not the value it lands on — the animation lands on the same
+figure either way, which is how it went unnoticed.
 
 **Icons carry meaning or they go.** An icon beside a heading that repeats the
 heading is decoration. Icon-only controls need `aria-label`.
@@ -111,10 +135,44 @@ budget is blind to it.
 
 Three of them are the residue of drift already found, and are expected to keep
 falling: `hexLiterals` (chart series, the native status bar, Google's brand
-colours), `boldOutsideScale`, and `smOverrides`. `emoji` is pinned at 0.
+colours), `boldOutsideScale`, and `smOverrides`. `emoji` is pinned at 0. Two of
+those three currently sit *on* their ceiling rather than under it, so the next
+call site that adds one fails the build — which is the ratchet working, but read
+it as a queue of work rather than as headroom.
 
 The numbers may fall freely. Raising one is a design decision and belongs in the
 same commit as the change that needs it, so the trade-off appears in the diff.
+
+**A counter that cannot rise is worse than no counter.** `surfaces` read 2
+against a budget of 4 for its whole life, and printed `ratchet this down` the
+entire time. Its alternation listed `surface` ahead of `surface-2`, and `-` is a
+word boundary, so `bg-surface-2` and `bg-surface-3` both matched as
+`bg-surface`: three of the four steps collapsed into one and a fifth surface
+would have entered silently. Any alternation whose branches share a prefix runs
+longest-first, and a budget sitting well under its ceiling with no memory of
+falling is the thing to go and verify.
+
+## What has not moved yet
+
+The rules above are the target, not a description of every file. Knowing where
+the system does *not* reach yet matters, because the largest risk to it is a
+reader opening a screen that predates it, seeing 24px bold headings and a
+hand-rolled card, and copying that as house style. It is not. Counted today:
+
+- **59 hand-rolled `<h1>`–`<h3>` with a `text-Nxl` class, across 30 files**,
+  against 14 files on `Heading`. `/compare` and the calculators are migrated;
+  most of auth, goals and billing are not.
+- **`CardContainer` over `Panel`** in 19 places, including `AuthPageShell` and
+  so the whole onboarding flow.
+- **83 motion variants that animate `x` or `y`.** Entrances are meant to be
+  opacity-only — travel reflows the text underneath it — and `Reveal` is the
+  way in. `LandingPage`'s section reveal is one of these.
+
+Two rules for touching any of it. If you are editing a file for another reason,
+migrate what you touch and leave the rest; a half-migrated file is fine, an
+unattributed restyle in the middle of a bugfix is not. And check the diff for
+what it *ratchets*: these three all feed budgets, so real migration shows up as
+a number falling in `ui-budgets.json`.
 
 ## Before you call UI work done
 
@@ -145,6 +203,6 @@ deciding for itself again.
 
 ## History
 
-`docs/ui-changelog.md` records the nine passes that built this system and why
-each decision was made. Read it when a rule here looks arbitrary — the reason is
-almost certainly there.
+`docs/ui-changelog.md` records the passes that built this system, Phase 0
+through Phase 9, and why each decision was made. Read it when a rule here looks
+arbitrary — the reason is almost certainly there.

--- a/frontend/scripts/check-ui-budgets.mjs
+++ b/frontend/scripts/check-ui-budgets.mjs
@@ -66,7 +66,15 @@ const measurements = {
   // Only class strings: `rounded="card"` is the Skeleton prop, not a utility.
   legacyRadii: countMatches(/\brounded-(?:sm|md|lg|xl|2xl|3xl)\b/g),
   // Four opaque surface steps, no alpha.
-  surfaces: countDistinct(/\bbg-(?:background|surface|surface-2|surface-3)\b/g),
+  //
+  // Longest alternative first, and the reason is not style. `-` is a word
+  // boundary, so with `surface` listed ahead of `surface-2` the engine matches
+  // `bg-surface-2` as `bg-surface` and stops. Three of the four steps collapsed
+  // into one, the distinct count could not exceed 2 against a budget of 4, and
+  // the line printed `ratchet this down` for a counter measuring nothing — a
+  // `bg-surface-4` would have entered the codebase silently. Any alternation
+  // here whose branches share a prefix has to run longest-first.
+  surfaces: countDistinct(/\bbg-(?:background|surface-2|surface-3|surface)\b/g),
   surfaceAlpha: countMatches(/\bbg-(?:surface|surface-2|surface-3)\/\d+\b/g),
   // Two hairlines.
   hairlineAlpha: countMatches(/\bborder-(?:border|border-2|white)\/\d+\b/g),

--- a/frontend/src/components/animation/AnimatedNumber.test.tsx
+++ b/frontend/src/components/animation/AnimatedNumber.test.tsx
@@ -1,7 +1,23 @@
 import { render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { animate } from "motion/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import AnimatedNumber from "./AnimatedNumber";
+
+const { reducedMotion } = vi.hoisted(() => ({ reducedMotion: vi.fn() }));
+
+vi.mock("motion/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("motion/react")>()),
+  animate: vi.fn(() => ({ stop: vi.fn() })),
+  useReducedMotion: () => reducedMotion(),
+}));
+
+const animateMock = vi.mocked(animate);
+
+beforeEach(() => {
+  animateMock.mockClear();
+  reducedMotion.mockReturnValue(false);
+});
 
 describe("AnimatedNumber", () => {
   it("renders with value", () => {
@@ -30,5 +46,27 @@ describe("AnimatedNumber", () => {
     render(<AnimatedNumber value={100} prefix="$" suffix=" USD" />);
     expect(document.body.textContent).toContain("$");
     expect(document.body.textContent).toContain("USD");
+  });
+
+  // The global reduced-motion reset in styles/global.css only zeroes CSS
+  // animations and transitions. This counts from a JS timer, so assert the
+  // timer never starts rather than asserting the value it lands on: the
+  // animation lands on the same figure either way, which is what let a
+  // counting number ship past the preference unnoticed.
+  it("counts when motion is allowed", () => {
+    const { rerender } = render(<AnimatedNumber value={0} />);
+    rerender(<AnimatedNumber value={2200} />);
+
+    expect(animateMock).toHaveBeenCalledWith(0, 2200, expect.anything());
+  });
+
+  it("jumps straight to the value when reduced motion is preferred", () => {
+    reducedMotion.mockReturnValue(true);
+
+    const { rerender } = render(<AnimatedNumber value={0} />);
+    rerender(<AnimatedNumber value={2200} />);
+
+    expect(animateMock).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("2200");
   });
 });

--- a/frontend/src/components/animation/AnimatedNumber.tsx
+++ b/frontend/src/components/animation/AnimatedNumber.tsx
@@ -1,6 +1,18 @@
 import { useCallback, useEffect, useRef } from "react";
 import { animate } from "motion/react";
 
+// The leaf module, not the `@/hooks` barrel: that barrel re-exports
+// `useSubscriptionStatus`, which reaches `useAuthQueries` and `@/config/runtime`,
+// and pulling it in here dragged auth into every screen that prints a number.
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+
+/**
+ * A counting number, and the one animation the global reduced-motion reset in
+ * `styles/global.css` cannot reach. That block zeroes CSS animation and
+ * transition durations; this drives `textContent` from a JS timer, which is
+ * neither. So it has to ask for itself — a figure ticking from zero is exactly
+ * the motion someone setting that preference is trying to switch off.
+ */
 interface AnimatedNumberProps {
   value: number;
   toFixedValue?: number;
@@ -31,6 +43,7 @@ export default function AnimatedNumber({
     [prefix, suffix, toFixedValue],
   );
 
+  const prefersReducedMotion = usePrefersReducedMotion();
   const nodeReference = useRef<HTMLSpanElement>(null);
   // Always store a valid number in the ref
   const previousValueReference = useRef<number>(
@@ -45,7 +58,7 @@ export default function AnimatedNumber({
     const toValue =
       typeof value === "number" && !Number.isNaN(value) ? value : 0;
 
-    if (fromValue === toValue || duration === 0) {
+    if (fromValue === toValue || duration === 0 || prefersReducedMotion) {
       node.textContent = safeFormat(toValue);
       previousValueReference.current = toValue;
 
@@ -66,7 +79,15 @@ export default function AnimatedNumber({
     previousValueReference.current = toValue;
 
     return () => controls.stop();
-  }, [value, toFixedValue, duration, prefix, suffix, safeFormat]);
+  }, [
+    value,
+    toFixedValue,
+    duration,
+    prefix,
+    suffix,
+    safeFormat,
+    prefersReducedMotion,
+  ]);
 
   return (
     <span ref={nodeReference} className={className}>

--- a/frontend/src/components/utils/UiConstants.ts
+++ b/frontend/src/components/utils/UiConstants.ts
@@ -195,8 +195,16 @@ export const DURATIONS = {
   value: 0.45,
 } as const;
 
-// Mirrors --ease-out / --ease-modal in style.css. `modal` is the sheet curve
-// and belongs to the sheet; everything else entering uses `out`.
+// `modal` is the sheet curve and belongs to the sheet; everything else entering
+// uses `out`.
+//
+// These are the JS curves, and they live here rather than in style.css because
+// motion takes a control-point array and a CSS variable cannot supply one. The
+// comment here used to claim they mirrored `--ease-out` / `--ease-modal`;
+// `--ease-out` has never existed, and adding it to the `@theme` block would
+// redefine Tailwind's own `ease-out` utility under all ~16 call sites that use
+// it. `--ease-modal` does exist and holds the same control points as `modal`,
+// so keep the two in step by hand if either moves.
 export const EASINGS = {
   out: [0.16, 1, 0.3, 1],
   modal: [0.32, 0.72, 0, 1],

--- a/frontend/src/features/auth/components/ProfileCreationForm.goalStep.test.tsx
+++ b/frontend/src/features/auth/components/ProfileCreationForm.goalStep.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ProfileCreationForm } from "@/features/auth/components/ProfileCreationForm";
+
+// Reveal is opacity-only; under jsdom the animation never settles, so render
+// the element directly and keep the flow synchronous.
+vi.mock("motion/react", () => {
+  const components = new Map<string, React.FC<Record<string, unknown>>>();
+
+  return {
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+    useReducedMotion: () => true,
+    m: new Proxy({} as Record<string, React.FC>, {
+      get: (_target, tag: string) => {
+        const cached = components.get(tag);
+        if (cached) return cached;
+
+        const Component = ({
+          children,
+          ...properties
+        }: React.PropsWithChildren<Record<string, unknown>>) => {
+          const {
+            initial: _initial,
+            animate: _animate,
+            exit: _exit,
+            transition: _transition,
+            ...domProps
+          } = properties;
+
+          return <div {...domProps}>{children}</div>;
+        };
+        Component.displayName = `m.${tag}`;
+        components.set(tag, Component);
+
+        return Component;
+      },
+    }),
+  };
+});
+
+vi.mock("@clerk/react", () => ({
+  useAuth: () => ({ isSignedIn: true, isLoaded: true }),
+  useUser: () => ({ user: { firstName: "Sam" }, isLoaded: true }),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@/store/store", () => ({
+  useStore: () => ({ showNotification: vi.fn() }),
+}));
+
+vi.mock("@/api/auth", () => ({ authApi: { syncUser: vi.fn() } }));
+vi.mock("@/api/goals", () => ({ goalsApi: { createWeightGoal: vi.fn() } }));
+vi.mock("@/api/user", () => ({ userApi: { completeProfile: vi.fn() } }));
+
+/** Walks steps 1 and 2 with a 90 kg profile so step 3 has a real TDEE. */
+async function reachGoalStep(user: ReturnType<typeof userEvent.setup>) {
+  render(<ProfileCreationForm />);
+
+  await user.type(screen.getByLabelText(/date of birth/i), "1990-01-01");
+  await user.selectOptions(screen.getByLabelText(/^gender$/i), "male");
+  await user.type(screen.getByLabelText(/height/i), "180");
+  await user.type(screen.getByLabelText(/^weight/i), "90");
+  await user.click(screen.getByRole("button", { name: /continue/i }));
+
+  await user.selectOptions(screen.getByLabelText(/how active are you/i), "3");
+  await user.click(screen.getByRole("button", { name: /continue/i }));
+}
+
+/** The figure printed opposite a summary row's label. */
+const summaryValue = (label: RegExp) =>
+  screen.getByText(label).nextElementSibling!.textContent!;
+
+describe("ProfileCreationForm goal step", () => {
+  it("moves the calorie target when the goal changes", async () => {
+    const user = userEvent.setup();
+    await reachGoalStep(user);
+
+    await user.click(screen.getByRole("radio", { name: /lose weight/i }));
+    await user.type(screen.getByLabelText(/target weight/i), "80");
+    const losing = summaryValue(/daily calorie target/i);
+
+    await user.click(screen.getByRole("radio", { name: /gain weight/i }));
+    await user.type(screen.getByLabelText(/target weight/i), "95");
+    const gaining = summaryValue(/daily calorie target/i);
+
+    expect(losing).not.toEqual(gaining);
+  });
+
+  it("drops a target weight that contradicts the newly picked goal", async () => {
+    const user = userEvent.setup();
+    await reachGoalStep(user);
+
+    await user.click(screen.getByRole("radio", { name: /lose weight/i }));
+    await user.type(screen.getByLabelText(/target weight/i), "80");
+
+    await user.click(screen.getByRole("radio", { name: /gain weight/i }));
+
+    expect(screen.getByLabelText(/target weight/i)).toHaveValue(null);
+    expect(screen.queryByText(/daily calorie target/i)).not.toBeInTheDocument();
+  });
+
+  it("flags a target pointing the wrong way while the user types", async () => {
+    const user = userEvent.setup();
+    await reachGoalStep(user);
+
+    await user.click(screen.getByRole("radio", { name: /gain weight/i }));
+    await user.type(screen.getByLabelText(/target weight/i), "85");
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /target must be over 90 kg/i,
+    );
+    expect(screen.queryByText(/daily calorie target/i)).not.toBeInTheDocument();
+  });
+
+  it("shortens the time to target as the target weight moves closer", async () => {
+    const user = userEvent.setup();
+    await reachGoalStep(user);
+
+    await user.click(screen.getByRole("radio", { name: /lose weight/i }));
+    const field = screen.getByLabelText(/target weight/i);
+
+    await user.type(field, "75");
+    const far = summaryValue(/time to target/i);
+
+    await user.clear(field);
+    await user.type(field, "88");
+    const near = summaryValue(/time to target/i);
+
+    expect(Number.parseInt(far, 10)).toBeGreaterThan(Number.parseInt(near, 10));
+  });
+
+  it("shows maintenance calories with no weekly change", async () => {
+    const user = userEvent.setup();
+    await reachGoalStep(user);
+
+    await user.click(screen.getByRole("radio", { name: /maintain/i }));
+
+    expect(screen.getByText(/daily calorie target/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/target weight/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/expected change/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/auth/components/ProfileCreationForm.tsx
+++ b/frontend/src/features/auth/components/ProfileCreationForm.tsx
@@ -10,12 +10,16 @@ import { useNavigate } from "@tanstack/react-router";
 import { authApi } from "@/api/auth";
 import { goalsApi } from "@/api/goals";
 import { userApi } from "@/api/user";
+import Reveal from "@/components/animation/Reveal";
 import DateField from "@/components/form/DateField";
 import Dropdown from "@/components/form/Dropdown";
 import InfoCard from "@/components/form/InfoCard";
 import NumberField from "@/components/form/NumberField";
 import Button from "@/components/ui/Button";
+import { TYPE_SCALE } from "@/components/ui/Heading";
 import { CheckIcon, InfoIcon } from "@/components/ui/Icons";
+import Panel, { RULE_HAIRLINE } from "@/components/ui/Panel";
+import Value from "@/components/ui/Value";
 import { useSocialProfileData } from "@/features/auth/hooks/useSocialProfileData";
 import {
   getFirstErrorMessage,
@@ -24,6 +28,7 @@ import {
   validateStep2 as checkStep2,
 } from "@/features/auth/utils/profileValidation";
 import { normalizeAuthRedirect } from "@/features/auth/utils/redirect";
+import { cn } from "@/lib/classnameUtilities";
 import { logger } from "@/lib/logger";
 import { hasStatus, queryClient } from "@/lib/queryClient";
 import { queryKeys } from "@/lib/queryKeys";
@@ -53,6 +58,16 @@ const GOAL_CHOICES: { value: WeightGoalChoice; label: string }[] = [
   { value: "maintain", label: "Maintain" },
   { value: "gain", label: "Gain weight" },
 ];
+
+// The summary reads as a label/value ledger. Rows are divided, not boxed: a
+// hairline says "same group", which is what these three figures are.
+const SUMMARY_ROW = cn(
+  "flex items-baseline justify-between gap-3 border-b py-3",
+  "first:pt-0 last:border-b-0 last:pb-0",
+  RULE_HAIRLINE,
+);
+
+const SUMMARY_LABEL = cn(TYPE_SCALE.small, "text-muted");
 
 function StepIndicator({ step }: { step: number }) {
   return (
@@ -142,14 +157,44 @@ export function ProfileCreationForm() {
         }).tdee
       : 0;
 
+  // The preview has to agree with the button the user pressed. Deriving the
+  // direction from the two weights alone meant a target left over from "Lose
+  // weight" kept printing deficit numbers after the user switched to "Gain",
+  // and the whole card sat frozen until submit finally rejected it.
+  const liveGoalErrors = checkGoalStep(weightGoal, targetWeight, weight);
+
+  // "Required" is not feedback while the field is still untouched, so the live
+  // check only speaks once there is a number to disagree with.
+  const targetWeightError =
+    targetWeight == null ? errors.targetWeight : liveGoalErrors.targetWeight;
+
   const goalCalculations =
-    tdee && weight && weightGoal
+    tdee && weight && weightGoal && !getFirstErrorMessage(liveGoalErrors)
       ? generateWeightGoalCalculations(
           tdee,
           weight,
           weightGoal === "maintain" ? weight : (targetWeight ?? weight),
         )
       : undefined;
+
+  const handleGoalChange = (choice: WeightGoalChoice) => {
+    setWeightGoal(choice);
+    setErrors((previous) => ({
+      ...previous,
+      weightGoal: "",
+      targetWeight: "",
+    }));
+    setTargetWeight((previous) => {
+      if (choice === "maintain") return null;
+      if (previous == null || weight == null) return previous;
+
+      // A target that pointed the other way is not a target for this goal.
+      const pointsTheRightWay =
+        choice === "lose" ? previous < weight : previous > weight;
+
+      return pointsTheRightWay ? previous : null;
+    });
+  };
 
   const handleNext = () => {
     if (step === 1 && getFirstErrorMessage(validateStep1())) return;
@@ -495,16 +540,14 @@ export function ProfileCreationForm() {
                 type="button"
                 role="radio"
                 aria-checked={isSelected}
-                onClick={() => {
-                  setWeightGoal(choice.value);
-                  setErrors({});
-                  if (choice.value === "maintain") setTargetWeight(null);
-                }}
-                className={`cursor-pointer rounded-control border p-3 text-center font-medium transition-colors ${
+                onClick={() => handleGoalChange(choice.value)}
+                className={cn(
+                  "cursor-pointer rounded-control border p-3 text-center transition-colors",
+                  "focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface focus-visible:outline-none",
                   isSelected
-                    ? "border-primary bg-primary/10 text-foreground"
-                    : "border-border bg-surface-2 text-muted hover:border-primary/40"
-                }`}
+                    ? "border-primary bg-primary/10 font-semibold text-foreground"
+                    : "border-border bg-surface-2 text-muted hover:border-primary/40",
+                )}
               >
                 {choice.label}
               </button>
@@ -513,49 +556,82 @@ export function ProfileCreationForm() {
         </div>
         <FieldError message={errors.weightGoal} />
 
-        {weightGoal !== "" && weightGoal !== "maintain" && (
-          <div>
-            <NumberField
-              label={`Target Weight (${USER_MINIMUM_WEIGHT}-${USER_MAXIMUM_WEIGHT} kg)`}
-              value={targetWeight ?? undefined}
-              onChange={(value: number | undefined) => {
-                setTargetWeight(value ?? null);
-                if (errors.targetWeight) {
-                  setErrors((previous) => ({ ...previous, targetWeight: "" }));
-                }
-              }}
-              min={USER_MINIMUM_WEIGHT}
-              max={USER_MAXIMUM_WEIGHT}
-              step={0.1}
-              unit="kg"
-              required
-            />
-            <FieldError message={errors.targetWeight} />
-          </div>
-        )}
-
-        {goalCalculations && !errors.targetWeight && (
-          <div className="rounded-control border border-border bg-surface-2 p-4">
-            <div className="flex justify-between">
-              <span className="text-muted">Daily calorie target</span>
-              <span className="font-medium">
-                {goalCalculations.calorieTarget} kcal
-              </span>
+        {/* Keyed on the goal so switching pills fades the panel below them in.
+            The key never changes while typing, so the field keeps focus. */}
+        <Reveal key={weightGoal || "unset"} className="space-y-4">
+          {weightGoal !== "" && weightGoal !== "maintain" && (
+            <div>
+              <NumberField
+                label={`Target Weight (${USER_MINIMUM_WEIGHT}-${USER_MAXIMUM_WEIGHT} kg)`}
+                value={targetWeight ?? undefined}
+                onChange={(value: number | undefined) => {
+                  setTargetWeight(value ?? null);
+                  if (errors.targetWeight) {
+                    setErrors((previous) => ({
+                      ...previous,
+                      targetWeight: "",
+                    }));
+                  }
+                }}
+                min={USER_MINIMUM_WEIGHT}
+                max={USER_MAXIMUM_WEIGHT}
+                step={0.1}
+                unit="kg"
+                required
+              />
+              <FieldError message={targetWeightError} />
             </div>
-            {weightGoal !== "maintain" && (
-              <div className="mt-2 flex justify-between">
-                <span className="text-muted">Expected change</span>
-                <span className="font-medium">
-                  {Math.abs(goalCalculations.weeklyChange).toFixed(2)} kg per
-                  week
-                </span>
-              </div>
-            )}
-            <p className="mt-3 text-xs text-muted">
-              You can change any of this later under Goals.
-            </p>
-          </div>
-        )}
+          )}
+
+          {goalCalculations && (
+            <Reveal step={1}>
+              <Panel raised padding="compact">
+                <dl>
+                  <div className={SUMMARY_ROW}>
+                    <dt className={SUMMARY_LABEL}>Daily calorie target</dt>
+                    <dd>
+                      <Value
+                        value={goalCalculations.calorieTarget}
+                        unit="kcal"
+                        size="stat"
+                      />
+                    </dd>
+                  </div>
+                  {weightGoal !== "maintain" && (
+                    <>
+                      <div className={SUMMARY_ROW}>
+                        <dt className={SUMMARY_LABEL}>Expected change</dt>
+                        <dd>
+                          <Value
+                            value={Math.abs(goalCalculations.weeklyChange)}
+                            unit="kg"
+                            suffix="per week"
+                          />
+                        </dd>
+                      </div>
+                      <div className={SUMMARY_ROW}>
+                        <dt className={SUMMARY_LABEL}>Time to target</dt>
+                        <dd>
+                          <Value
+                            value={goalCalculations.calculatedWeeks}
+                            suffix={
+                              goalCalculations.calculatedWeeks === 1
+                                ? "week"
+                                : "weeks"
+                            }
+                          />
+                        </dd>
+                      </div>
+                    </>
+                  )}
+                </dl>
+                <p className={cn(SUMMARY_LABEL, "mt-4")}>
+                  You can change any of this later under Goals.
+                </p>
+              </Panel>
+            </Reveal>
+          )}
+        </Reveal>
       </div>
 
       <div className="flex gap-3">

--- a/frontend/src/features/landing/pages/LandingPage.tsx
+++ b/frontend/src/features/landing/pages/LandingPage.tsx
@@ -3,6 +3,7 @@ import { m, useReducedMotion } from "motion/react";
 
 import AppHeader from "@/components/layout/AppHeader";
 import { ErrorBoundary, LoadingSpinner } from "@/components/ui";
+import { DURATIONS, EASINGS } from "@/components/utils/UiConstants";
 import { usePageMetadata } from "@/hooks";
 import {
   APP_ICON_URL,
@@ -27,7 +28,7 @@ const sectionRevealVariants = {
   visible: {
     opacity: 1,
     y: 0,
-    transition: { duration: 0.4, ease: [0.22, 1, 0.36, 1] },
+    transition: { duration: DURATIONS.base, ease: EASINGS.out },
   },
 } as const;
 

--- a/frontend/src/features/reporting/utils/unifiedInsightsUtilities.test.ts
+++ b/frontend/src/features/reporting/utils/unifiedInsightsUtilities.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { DURATIONS, EASINGS } from "@/components/utils/UiConstants";
+
 import {
   CARD_BASE_CLASSES,
   getColorByScore,
@@ -11,9 +13,12 @@ import {
 
 describe("unifiedInsightsUtilities", () => {
   describe("TRANSITIONS", () => {
-    it("has expected values", () => {
-      expect(TRANSITIONS.duration).toBe(0.3);
-      expect(TRANSITIONS.ease).toHaveLength(4);
+    // Assert the source, not the figure. This file held 0.3 and its own
+    // cubic-bezier while its header claimed it used existing tokens only; a
+    // test that copies the number cannot tell the two apart.
+    it("reads the motion tokens rather than holding its own", () => {
+      expect(TRANSITIONS.duration).toBe(DURATIONS.base);
+      expect(TRANSITIONS.ease).toBe(EASINGS.out);
     });
   });
 

--- a/frontend/src/features/reporting/utils/unifiedInsightsUtilities.ts
+++ b/frontend/src/features/reporting/utils/unifiedInsightsUtilities.ts
@@ -1,11 +1,15 @@
+import { DURATIONS, EASINGS } from "@/components/utils/UiConstants";
+
 /**
  * Local utilities for UnifiedInsights and its subcomponents.
- * Uses existing design tokens only.
  */
- 
+
+// This file's header claimed it used existing tokens only while holding a
+// duration and a cubic-bezier that appeared nowhere else in the system. It
+// reads them now.
 export const TRANSITIONS = {
-  duration: 0.3,
-  ease: [0.22, 1, 0.36, 1] as const,
+  duration: DURATIONS.base,
+  ease: EASINGS.out,
 };
 
 export const STAGGER = {
@@ -22,7 +26,8 @@ export const BAR_BASE_CLASSES =
 export const CARD_BASE_CLASSES =
   "rounded-card border border-border bg-surface p-6";
 
-export const SECTION_HEADING_CLASSES = "text-lg font-semibold tracking-tight text-foreground/90";
+export const SECTION_HEADING_CLASSES =
+  "text-lg font-semibold tracking-tight text-foreground/90";
 
 export const SUBTEXT_MUTED_CLASSES = "text-xs text-foreground";
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -100,10 +100,12 @@
   /* Shadows – only the modal casts one; nothing is darker than the page */
   --shadow-modal: 0 20px 40px -12px rgba(0, 0, 0, 0.5);
 
-  /* Design system easing curves */
+  /* The sheet curve. `--ease-drawer` sat here holding the same four control
+     points under a second name, and `--ease-spring` held an overshoot no call
+     site ever asked for; both are gone. The paired JS array lives in
+     `components/utils/UiConstants.ts`, because motion takes control points and
+     a variable cannot supply them. */
   --ease-modal: cubic-bezier(0.32, 0.72, 0, 1);
-  --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
-  --ease-spring: cubic-bezier(0.175, 0.885, 0.32, 1.275);
 
   /* Letter spacing tokens for labels */
   --tracking-label: 0.025em;

--- a/frontend/ui-budgets.json
+++ b/frontend/ui-budgets.json
@@ -7,7 +7,7 @@
     "surfaceAlpha": 0,
     "hairlineAlpha": 0,
     "motionDurations": 20,
-    "motionEasings": 5,
+    "motionEasings": 4,
     "motionCallSites": 27,
     "layoutProjection": 12,
     "motionFiles": 43,
@@ -30,6 +30,8 @@
       "motionEasings": 9,
       "motionCallSites": 27,
       "layoutProjection": 15
-    }
+    },
+    "$surfacesNote": "surfaces read 2 for as long as it existed and no UI changed to make it 4. The counter was broken: its alternation listed `surface` ahead of `surface-2`, and `-` is a word boundary, so bg-surface-2 and bg-surface-3 both matched as bg-surface. Three steps collapsed into one, the measurement could not exceed 2 against a budget of 4, and it printed `ratchet this down` while catching nothing — a bg-surface-4 would have entered silently. Fixed by ordering the alternation longest-first; 4 is the closed set, measured for real.",
+    "$easingNote": "motionEasings fell 5 -> 4 when UnifiedInsights and LandingPage stopped holding their own cubic-bezier. The remaining four are EASINGS.out, EASINGS.modal, and the easeIn/easeInOut/easeOut keywords."
   }
 }


### PR DESCRIPTION
Two related passes: a user-visible bug on the sign-up goal step, and the design-system accuracy work that came out of reviewing it.

## The onboarding bug

Step 3 computed its preview from the two weights alone, never from the button the user pressed. Pick "Lose weight", type a target, switch to "Gain weight" — the stale target stays, so the card still reads as a deficit. Same kcal, same weekly change, no error until **Finish setup** rejects it.

- Switching goals drops a target weight that points the wrong way.
- The goal step validates live, so a contradictory target is flagged while typing instead of at submit. "Required" still waits for a value.
- The summary only renders when the figures agree with the selected goal.
- New **Time to target** row. The calorie target is a fixed-rate model (−500 to lose, +300 to gain, shared with the Goals page and `api/goals.ts`), so the entered weight moves the *duration*, not the daily number. The card previously showed nothing that responded to it, which is why it looked frozen. Happy to make the deficit scale with distance instead, but that changes shared math.

Also brought onto the system while in there: the summary card is a `Panel` with `Value` figures and graded hairlines rather than a hand-rolled box, the pills get the auth focus ring they were missing as a `radiogroup`, and switching pills fades the panel through `Reveal`.

Three of the five new tests fail against the previous component (verified by stashing it).

## The budget that measured nothing

`surfaces` read **2** against a ceiling of 4 for its whole life, printing `ratchet this down` the entire time. Its alternation listed `surface` ahead of `surface-2`, and `-` is a word boundary, so `bg-surface-2` and `bg-surface-3` both matched as `bg-surface`. Three of the four steps collapsed into one, the count could not exceed 2, and a `bg-surface-4` would have entered silently. Ordered longest-first, it now reads a real **4/4**.

## Reduced motion

`AnimatedNumber` did not honour `prefers-reduced-motion`, though the doc named it two sentences from that claim. The global reset in `global.css` only zeroes CSS animations and transitions; this drives `textContent` from a JS timer, which is neither. Its tests assert the timer never *starts* rather than the value it lands on — the animation ends on the same figure either way, which is how it went unnoticed.

It imports the leaf hook, not the `@/hooks` barrel: that barrel reaches `useSubscriptionStatus` → `useAuthQueries` → `config/runtime`, and importing it dragged auth into every screen that prints a number. Caught by `DateRangeSelector.test.tsx`.

## Motion tokens

`--ease-out` never existed, so `UiConstants` stops claiming to mirror it — adding it to `@theme` would have redefined Tailwind's own `ease-out` utility under ~16 call sites. Dropped `--ease-drawer` (identical control points to `--ease-modal` under a second name) and `--ease-spring` (no call sites).

`UnifiedInsights` and `LandingPage` held their own cubic-bezier while the former's header claimed to use tokens only. Both read `DURATIONS`/`EASINGS` now, so `motionEasings` falls 5 → 4 and the budget ratchets with it.

⚠️ **Visible change:** the landing section reveal runs 0.4s → 0.2s and the insights transition 0.3s → 0.2s, matching every other entrance in the app.

## The doc

`design-system.md` gains the CSS/JS split on reduced motion, an honest motion paragraph (it described `Reveal`, not the 17 durations actually in the tree), `CardContainer`'s 19 call sites against `Panel`'s 18, and a **"What has not moved yet"** section — 59 hand-rolled `text-Nxl` headings across 30 files, 83 variants animating `x`/`y`. That gap is what made me misread the system on the onboarding screen: legacy reads as precedent when nothing says otherwise.

## Verification

- `bun run lint` — 0 errors, all 16 budgets `ok`
- `bun run typecheck` — clean
- `bun run test` — 874 passed / 149 files
- `bun run build` — succeeds (matters here, two `@theme` tokens were deleted)

## Left undone

`Reveal.tsx` still imports from the `@/hooks` barrel — same latent hazard as `AnimatedNumber` had, one line, but nothing currently trips on it. The three items in "What has not moved yet" are queued, not fixed.