### PR TITLE
fix: remember the goal target per direction, and settle on one spelling for a figure

### DIFF
--- a/.github/design-system.md
+++ b/.github/design-system.md
@@ -108,6 +108,26 @@ figure either way, which is how it went unnoticed.
 **Icons carry meaning or they go.** An icon beside a heading that repeats the
 heading is decoration. Icon-only controls need `aria-label`.
 
+**A figure has one spelling, and it is grouped.** "2,000 kcal", not "2000
+kcal". Every separator in the product comes from `formatGrouped`
+(`frontend/src/lib/formatNumber.ts`). Two budgets hold it, both pinned at 0,
+because there are two ways to get it wrong: `adHocNumberFormat` catches a call
+site reaching for `toLocaleString` itself, and `rawCalorieFigures` catches one
+that formats by not formatting — `{tdee} kcal`, which prints "2841 kcal" beside
+a "2,841 kcal" two components away. The second is the one that actually shipped,
+in eleven places.
+The standard is grouped because `Value` always was, and because the type scale
+was picked partly to carry it — Archivo's width axis is here so a condensed
+"2,140 kcal" fits a 390px column, which is an argument about the grouped form.
+
+It shipped both ways for a while, and the split ran straight through the
+primitive that exists to prevent it: `Value` grouped via `toLocaleString`, the
+`AnimatedNumber` it delegates to formatted with `toFixed` and did not, so the
+same call site changed spelling the moment someone added `animate`. A shared
+primitive delegating to a second one that formats differently is the same
+failure as two renderers disagreeing — it is just harder to see, because one
+prop is the whole reproduction. Changing the standard is one line in that file.
+
 **A number is never clamped to look better.** Clamp the bar — a bar cannot be
 longer than its track. Print the real figure beside it. A day over target is
 information the user came for.

--- a/frontend/scripts/check-ui-budgets.mjs
+++ b/frontend/scripts/check-ui-budgets.mjs
@@ -47,16 +47,13 @@ const all = sources.join("\n");
  */
 const code = sources
   .map((source) =>
-    source
-      .replaceAll(/\/\*[\s\S]*?\*\//g, "")
-      .replaceAll(/^\s*\/\/.*$/gm, ""),
+    source.replaceAll(/\/\*[\s\S]*?\*\//g, "").replaceAll(/^\s*\/\/.*$/gm, ""),
   )
   .join("\n");
 
 const countMatches = (pattern) => (all.match(pattern) ?? []).length;
 const countCode = (pattern) => (code.match(pattern) ?? []).length;
-const countDistinct = (pattern) =>
-  new Set(all.match(pattern) ?? []).size;
+const countDistinct = (pattern) => new Set(all.match(pattern) ?? []).size;
 const countFiles = (needle) =>
   sources.filter((source) => source.includes(needle)).length;
 
@@ -86,9 +83,7 @@ const measurements = {
   // site is the drift. Motion gets measured the same way.
   //
   // Seconds-scale only — `duration: 8000` is a toast timer, not an animation.
-  motionDurations: countDistinct(
-    /\bduration: (?:[0-4](?:\.\d+)?)\b/g,
-  ),
+  motionDurations: countDistinct(/\bduration: (?:[0-4](?:\.\d+)?)\b/g),
   motionEasings: countDistinct(/\bease: (?:"[a-zA-Z]+"|\[[\d.,\s]+\])/g),
   // A call site declaring its own initial/animate is how 23 durations happened.
   // Intent belongs in <Reveal>; numbers belong in DURATIONS/EASINGS.
@@ -119,6 +114,40 @@ const measurements = {
   hexLiterals: countCode(/#[\dA-Fa-f]{6}\b/g),
   // Emoji are not part of the UI vocabulary. Badges shipped with 🔥, 🎯 and ⚡.
   emoji: countMatches(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/gu),
+  // One spelling for a figure. A daily target shipped as both "2000 kcal" and
+  // "2,000 kcal", and the split ran through the primitive meant to prevent it:
+  // `Value` grouped via toLocaleString, the `AnimatedNumber` it delegates to
+  // did not, so adding `animate` changed the spelling. Every separator comes
+  // from `formatGrouped` now; a call site formatting for itself is the drift.
+  // The no-argument form only: `date.toLocaleString("en-US", {...})` in the
+  // reporting queries formats a month label, which is not a figure and not
+  // this counter's business. formatNumber.ts is excluded as the implementation.
+  adHocNumberFormat: files.reduce(
+    (total, file, index) =>
+      /lib[/\\]formatNumber\.ts$/.test(file)
+        ? total
+        : total + (sources[index].match(/\.toLocaleString\(\)/g) ?? []).length,
+    0,
+  ),
+  // The other half of the same rule. `adHocNumberFormat` catches a call site
+  // reaching for `toLocaleString`; this catches one that formats by not
+  // formatting — `{tdee} kcal`, which prints "2841 kcal" beside a "2,841 kcal"
+  // two components away. Both JSX and template-literal forms, because the
+  // sweep found the split in both. Anything printing a figure next to a
+  // calorie unit goes through `formatGrouped`.
+  //
+  // Counted by matching then filtering rather than by subtracting two patterns:
+  // `{" "}` is JSX's explicit space, so `{formatGrouped(tdee)}{" "}\nkcal` puts
+  // a bare `{" "}` directly before the unit and a subtracting pattern scores it
+  // as raw. The expression itself has to be inspected.
+  rawCalorieFigures: (() => {
+    const figureBeforeUnit =
+      /\{[^{}\n]{1,70}\}\s*(?:\{" "\})?\s*(?:kcal|calories|cal\/)|\$\{[^}\n]{1,70}\}\s*(?:kcal|calories)/g;
+
+    return (code.match(figureBeforeUnit) ?? []).filter(
+      (match) => !match.includes("formatGrouped") && !/^\{"\s*"\}/.test(match),
+    ).length;
+  })(),
   // TYPE_SCALE stops at font-semibold except for its two display steps, so
   // font-bold outside Heading/Value is a call site inventing a weight. Heading
   // and Value are excluded because they define the scale.

--- a/frontend/src/components/animation/AnimatedNumber.test.tsx
+++ b/frontend/src/components/animation/AnimatedNumber.test.tsx
@@ -67,6 +67,8 @@ describe("AnimatedNumber", () => {
     rerender(<AnimatedNumber value={2200} />);
 
     expect(animateMock).not.toHaveBeenCalled();
-    expect(document.body.textContent).toContain("2200");
+    // Grouped, same as the static path in `Value`. This asserted "2200"
+    // before, which is the spelling the two primitives used to disagree on.
+    expect(document.body.textContent).toContain("2,200");
   });
 });

--- a/frontend/src/components/animation/AnimatedNumber.tsx
+++ b/frontend/src/components/animation/AnimatedNumber.tsx
@@ -4,7 +4,9 @@ import { animate } from "motion/react";
 // The leaf module, not the `@/hooks` barrel: that barrel re-exports
 // `useSubscriptionStatus`, which reaches `useAuthQueries` and `@/config/runtime`,
 // and pulling it in here dragged auth into every screen that prints a number.
+import { DURATIONS } from "@/components/utils/UiConstants";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import { formatGrouped } from "@/lib/formatNumber";
 
 /**
  * A counting number, and the one animation the global reduced-motion reset in
@@ -25,12 +27,15 @@ interface AnimatedNumberProps {
 export default function AnimatedNumber({
   value,
   toFixedValue = 0,
-  duration = 0.6,
+  duration = DURATIONS.value,
   className = "",
   prefix = "",
   suffix = "",
 }: AnimatedNumberProps) {
-  // Helper to safely format numbers
+  // Grouped, via the same `toLocaleString` call `Value` uses. This used to be
+  // `toFixed`, which meant one primitive printed a daily target two ways
+  // depending on a single prop: `<Value value={2000} unit="kcal" />` gave
+  // "2,000 kcal" and the same call with `animate` gave "2000 kcal".
   const safeFormat = useCallback(
     (inputValue: unknown) => {
       const numericValue =
@@ -38,7 +43,7 @@ export default function AnimatedNumber({
           ? inputValue
           : 0;
 
-      return `${prefix}${numericValue.toFixed(toFixedValue)}${suffix}`;
+      return `${prefix}${formatGrouped(numericValue, toFixedValue)}${suffix}`;
     },
     [prefix, suffix, toFixedValue],
   );

--- a/frontend/src/components/chart/LineChartComponent.tsx
+++ b/frontend/src/components/chart/LineChartComponent.tsx
@@ -21,6 +21,7 @@ import {
 import type { ContentType } from "recharts/types/component/Tooltip";
 
 import { LoadingSpinner } from "@/components/ui";
+import { formatGrouped } from "@/lib/formatNumber";
 
 import ChartTooltip from "./ChartTooltip";
 import type { ChartDataPoint, LineConfig } from "./ChartTypes";
@@ -137,7 +138,7 @@ const LineChartComponent: React.FC<LineChartComponentProps> = ({
     axisLine: { stroke: "rgba(75, 85, 99, 0.3)" },
     tickLine: { stroke: "rgba(75, 85, 99, 0.3)" },
     tickFormatter: (value) =>
-      typeof value === "number" ? value.toLocaleString() : String(value),
+      typeof value === "number" ? formatGrouped(value) : String(value),
     width: 40, // Default width, can be overridden
     ...yAxisProps, // Merge user props
   };
@@ -246,7 +247,7 @@ const LineChartComponent: React.FC<LineChartComponentProps> = ({
                   strokeLinejoin="round"
                   strokeWidth="1.5"
                   d="M9 13h6m-3-3v6m5 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                 />
+                />
               </svg>
               <p className="max-w-xs text-sm text-foreground">
                 No data available for the selected period.
@@ -281,9 +282,7 @@ const LineChartComponent: React.FC<LineChartComponentProps> = ({
             <Tooltip
               // ContentType is what the prop declares; the previous cast to
               // ComponentType<Record<string, unknown>> was not assignable to it.
-              content={
-                TooltipContent as ContentType<ValueType, NameType>
-              }
+              content={TooltipContent as ContentType<ValueType, NameType>}
               cursor={{ fill: "rgba(110, 118, 145, 0.1)" }}
             />
             {showLegend && (
@@ -303,7 +302,7 @@ const LineChartComponent: React.FC<LineChartComponentProps> = ({
                   ? 1.5
                   : dataLength > 30
                     ? 2
-                    : line.strokeWidth ?? 2;
+                    : (line.strokeWidth ?? 2);
               const adaptiveActiveDot =
                 dataLength > 60
                   ? { r: 4 }

--- a/frontend/src/components/macros/MacroComponents.tsx
+++ b/frontend/src/components/macros/MacroComponents.tsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 
 import AnimatedNumber from "@/components/animation/AnimatedNumber";
 import ProgressBar from "@/components/ui/ProgressBar";
+import { formatGrouped } from "@/lib/formatNumber";
 import type { MacroTargetGrams } from "@/types/macro";
 import { calculateCaloriePercentages } from "@/utils/nutritionCalculations";
 
@@ -136,10 +137,10 @@ export function MacroIndicator({
 
         <div className="flex items-baseline gap-1 text-xs sm:text-sm shrink-0">
           <span className="font-bold text-foreground">
-            {Math.round(value)}g
+            {formatGrouped(value)}g
           </span>
           {target !== undefined && target > 0 && (
-            <span className="text-muted text-xs">/ {target}g</span>
+            <span className="text-muted text-xs">/ {formatGrouped(target)}g</span>
           )}
           {showPercentage && percentage !== undefined && (
             <span className="ml-1 text-[11px] font-medium text-muted">

--- a/frontend/src/components/metrics/UserMetricsPanel.tsx
+++ b/frontend/src/components/metrics/UserMetricsPanel.tsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 
 import { StarIcon, UserIcon } from "@/components/ui";
 import MetricCard from "@/components/ui/MetricCard";
+import { formatGrouped } from "@/lib/formatNumber";
 
 interface UserMetricsPanelProps {
   bmr: number;
@@ -75,11 +76,16 @@ function UserMetricsPanel({
             className="flex flex-1 items-center justify-between gap-2 rounded-full border border-border bg-surface px-3.5 py-1.5 shadow-xs"
           >
             <div className="flex items-center gap-1.5 min-w-0">
-              <Icon className={`h-3.5 w-3.5 shrink-0 ${iconClass}`} strokeWidth={1.5} />
-              <span className="text-xs font-medium text-foreground">{label}</span>
+              <Icon
+                className={`h-3.5 w-3.5 shrink-0 ${iconClass}`}
+                strokeWidth={1.5}
+              />
+              <span className="text-xs font-medium text-foreground">
+                {label}
+              </span>
             </div>
             <span className="text-xs font-semibold text-foreground whitespace-nowrap">
-              {value ? `${Math.round(value)} kcal` : "—"}
+              {value ? `${formatGrouped(value)} kcal` : "—"}
             </span>
           </div>
         ))}

--- a/frontend/src/components/ui/MetricCard.tsx
+++ b/frontend/src/components/ui/MetricCard.tsx
@@ -6,6 +6,7 @@ import Heading from "@/components/ui/Heading";
 import { InfoTooltip } from "@/components/ui/InfoTooltip";
 import Panel from "@/components/ui/Panel";
 import { cn } from "@/lib/classnameUtilities";
+import { formatGrouped } from "@/lib/formatNumber";
 
 /**
  * Five real meanings, each mapping to a declared token. This replaces
@@ -114,7 +115,10 @@ function MetricCardInner({
             {score === undefined ? null : (
               <span
                 aria-hidden="true"
-                className={cn("h-2.5 w-2.5 rounded-full", scoreToneClass(score))}
+                className={cn(
+                  "h-2.5 w-2.5 rounded-full",
+                  scoreToneClass(score),
+                )}
               />
             )}
           </div>
@@ -135,12 +139,10 @@ function MetricCardInner({
                     duration={0.8}
                   />
                 ) : (
-                  Math.round(numericValue).toLocaleString()
+                  formatGrouped(numericValue)
                 )}
               </span>
-              {unit ? (
-                <span className="text-xs text-muted">{unit}</span>
-              ) : null}
+              {unit ? <span className="text-xs text-muted">{unit}</span> : null}
             </p>
             {subtitle ? (
               <span className="text-[11px] text-muted">{subtitle}</span>
@@ -157,12 +159,10 @@ function MetricCardInner({
                     duration={0.8}
                   />
                 ) : (
-                  Math.round(numericValue).toLocaleString()
+                  formatGrouped(numericValue)
                 )}
               </span>
-              {unit ? (
-                <span className="text-sm text-muted">{unit}</span>
-              ) : null}
+              {unit ? <span className="text-sm text-muted">{unit}</span> : null}
             </p>
             {/* The subtitle used to sit on the value's own line with `ml-auto`,
                 which pushed it hard right and wrapped it to two ragged lines in a

--- a/frontend/src/components/ui/Value.tsx
+++ b/frontend/src/components/ui/Value.tsx
@@ -1,7 +1,9 @@
 import { memo } from "react";
 
 import AnimatedNumber from "@/components/animation/AnimatedNumber";
+import { DURATIONS } from "@/components/utils/UiConstants";
 import { cn } from "@/lib/classnameUtilities";
+import { formatGrouped } from "@/lib/formatNumber";
 
 export type ValueSize = "hero" | "stat" | "inline";
 export type ValueUnit = "kcal" | "g" | "kg" | "lb" | "%" | "";
@@ -64,17 +66,18 @@ function ValueInner({
 }: ValueProps) {
   const decimals = DECIMALS[unit];
   const safeValue = Number.isFinite(value) ? value : 0;
-  const formatted = safeValue.toLocaleString(undefined, {
-    minimumFractionDigits: decimals,
-    maximumFractionDigits: decimals,
-  });
+  const formatted = formatGrouped(safeValue, decimals);
   const sign = signed && safeValue > 0 ? "+" : "";
 
   return (
     <span className={cn("inline-flex items-baseline gap-1", className)}>
       <span className={cn(SIZE_CLASS[size], "tabular-nums")}>
         {animate ? (
-          <AnimatedNumber value={safeValue} toFixedValue={decimals} duration={0.8} />
+          <AnimatedNumber
+            value={safeValue}
+            toFixedValue={decimals}
+            duration={DURATIONS.value}
+          />
         ) : (
           `${sign}${formatted}`
         )}

--- a/frontend/src/features/auth/components/ProfileCreationForm.goalStep.test.tsx
+++ b/frontend/src/features/auth/components/ProfileCreationForm.goalStep.test.tsx
@@ -91,17 +91,36 @@ describe("ProfileCreationForm goal step", () => {
     expect(losing).not.toEqual(gaining);
   });
 
-  it("drops a target weight that contradicts the newly picked goal", async () => {
+  it("keeps each direction's target weight to itself", async () => {
     const user = userEvent.setup();
     await reachGoalStep(user);
 
     await user.click(screen.getByRole("radio", { name: /lose weight/i }));
     await user.type(screen.getByLabelText(/target weight/i), "80");
 
+    // Gain must not inherit Lose's number, or the summary contradicts the pill.
     await user.click(screen.getByRole("radio", { name: /gain weight/i }));
-
     expect(screen.getByLabelText(/target weight/i)).toHaveValue(null);
     expect(screen.queryByText(/daily calorie target/i)).not.toBeInTheDocument();
+
+    // ...and looking at Gain must not cost you what you typed for Lose.
+    await user.click(screen.getByRole("radio", { name: /lose weight/i }));
+    expect(screen.getByLabelText(/target weight/i)).toHaveValue(80);
+    expect(screen.getByText(/daily calorie target/i)).toBeInTheDocument();
+  });
+
+  it("remembers a target through a detour via Maintain", async () => {
+    const user = userEvent.setup();
+    await reachGoalStep(user);
+
+    await user.click(screen.getByRole("radio", { name: /gain weight/i }));
+    await user.type(screen.getByLabelText(/target weight/i), "95");
+
+    await user.click(screen.getByRole("radio", { name: /maintain/i }));
+    expect(screen.queryByLabelText(/target weight/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("radio", { name: /gain weight/i }));
+    expect(screen.getByLabelText(/target weight/i)).toHaveValue(95);
   });
 
   it("flags a target pointing the wrong way while the user types", async () => {

--- a/frontend/src/features/auth/components/ProfileCreationForm.tsx
+++ b/frontend/src/features/auth/components/ProfileCreationForm.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/features/auth/utils/profileValidation";
 import { normalizeAuthRedirect } from "@/features/auth/utils/redirect";
 import { cn } from "@/lib/classnameUtilities";
+import { formatGrouped } from "@/lib/formatNumber";
 import { logger } from "@/lib/logger";
 import { hasStatus, queryClient } from "@/lib/queryClient";
 import { queryKeys } from "@/lib/queryKeys";
@@ -110,7 +111,14 @@ export function ProfileCreationForm() {
 
   // Goal data
   const [weightGoal, setWeightGoal] = useState<WeightGoalChoice | "">("");
-  const [targetWeight, setTargetWeight] = useState<number | null>(null);
+
+  // A target belongs to a direction, so it is stored per direction rather than
+  // in one slot. Clearing the slot on a direction switch stopped the preview
+  // contradicting itself, but it also meant looking at Gain to see what it did
+  // cost you the number you had already typed for Lose.
+  const [targetWeightByGoal, setTargetWeightByGoal] = useState<
+    Partial<Record<"lose" | "gain", number>>
+  >({});
   const [switchingSource, setSwitchingSource] = useState<
     Exclude<SwitchingSource, "unknown"> | ""
   >("");
@@ -157,6 +165,20 @@ export function ProfileCreationForm() {
         }).tdee
       : 0;
 
+  const targetWeight =
+    weightGoal === "lose" || weightGoal === "gain"
+      ? (targetWeightByGoal[weightGoal] ?? null)
+      : null;
+
+  const setTargetWeight = (value: number | null) => {
+    if (weightGoal !== "lose" && weightGoal !== "gain") return;
+
+    setTargetWeightByGoal((previous) => ({
+      ...previous,
+      [weightGoal]: value ?? undefined,
+    }));
+  };
+
   // The preview has to agree with the button the user pressed. Deriving the
   // direction from the two weights alone meant a target left over from "Lose
   // weight" kept printing deficit numbers after the user switched to "Gain",
@@ -177,6 +199,8 @@ export function ProfileCreationForm() {
         )
       : undefined;
 
+  // No clearing needed: each direction reads its own stored target, so Gain
+  // cannot show Lose's number and going back to Lose finds it still there.
   const handleGoalChange = (choice: WeightGoalChoice) => {
     setWeightGoal(choice);
     setErrors((previous) => ({
@@ -184,16 +208,6 @@ export function ProfileCreationForm() {
       weightGoal: "",
       targetWeight: "",
     }));
-    setTargetWeight((previous) => {
-      if (choice === "maintain") return null;
-      if (previous == null || weight == null) return previous;
-
-      // A target that pointed the other way is not a target for this goal.
-      const pointsTheRightWay =
-        choice === "lose" ? previous < weight : previous > weight;
-
-      return pointsTheRightWay ? previous : null;
-    });
   };
 
   const handleNext = () => {
@@ -495,7 +509,7 @@ export function ProfileCreationForm() {
         </h2>
         <p className="mt-2 text-muted">
           {tdee
-            ? `You burn about ${tdee} kcal a day. Your goal sets the target around it.`
+            ? `You burn about ${formatGrouped(tdee)} kcal a day. Your goal sets the target around it.`
             : "Your goal sets the daily calorie target on your dashboard."}
         </p>
       </div>
@@ -612,8 +626,13 @@ export function ProfileCreationForm() {
                       <div className={SUMMARY_ROW}>
                         <dt className={SUMMARY_LABEL}>Time to target</dt>
                         <dd>
+                          {/* The one animated figure on this card, and the
+                              only one that moves: the calorie target and the
+                              weekly rate are fixed per direction, while this
+                              tracks every keystroke in the target weight. */}
                           <Value
                             value={goalCalculations.calculatedWeeks}
+                            animate
                             suffix={
                               goalCalculations.calculatedWeeks === 1
                                 ? "week"

--- a/frontend/src/features/goals/components/weight-goals/WeightGoalForm.tsx
+++ b/frontend/src/features/goals/components/weight-goals/WeightGoalForm.tsx
@@ -9,6 +9,7 @@ import {
 
 import NumberField from "@/components/form/NumberField";
 import { RangeSlider } from "@/components/ui";
+import { formatGrouped } from "@/lib/formatNumber";
 import type { WeightGoals } from "@/types/goal";
 import { todayISO } from "@/utils/dateUtilities";
 import { generateWeightGoalCalculations } from "@/utils/nutritionCalculations";
@@ -69,8 +70,8 @@ const getCalorieAdjustmentInfo = (
   const diff = Math.abs(tdee - calorieIntake);
   const displayDiff = Math.max(diff, 50);
   const label = isWeightLoss
-    ? `Deficit: ${displayDiff} kcal`
-    : `Surplus: ${displayDiff} kcal`;
+    ? `Deficit: ${formatGrouped(displayDiff)} kcal`
+    : `Surplus: ${formatGrouped(displayDiff)} kcal`;
   const isLargeAdjustment = diff > 800;
 
   return { label, isLargeAdjustment };
@@ -365,7 +366,9 @@ const WeightGoalForm = forwardRef<WeightGoalFormHandle, WeightGoalFormProps>(
           <div className="rounded-control border border-amber-500/30 bg-amber-500/10 p-4 text-amber-600 dark:text-amber-400">
             <p className="text-sm font-semibold">Profile Details Incomplete</p>
             <p className="mt-1 text-xs">
-              Please complete your profile details (Date of Birth, Gender, Height, Weight, and Activity Level) in Settings to calculate your BMR and TDEE before setting a weight goal.
+              Please complete your profile details (Date of Birth, Gender,
+              Height, Weight, and Activity Level) in Settings to calculate your
+              BMR and TDEE before setting a weight goal.
             </p>
           </div>
         )}
@@ -380,7 +383,7 @@ const WeightGoalForm = forwardRef<WeightGoalFormHandle, WeightGoalFormProps>(
                 Daily Calorie Intake
               </label>
               <span className="text-sm text-muted">
-                {calorieIntake} calories/day
+                {formatGrouped(calorieIntake)} calories/day
               </span>
             </div>
 

--- a/frontend/src/features/landing/components/ProductPreview.tsx
+++ b/frontend/src/features/landing/components/ProductPreview.tsx
@@ -2,6 +2,7 @@ import React, { lazy, Suspense, useEffect, useState } from "react";
 
 import Panel from "@/components/ui/Panel";
 import { cn } from "@/lib/classnameUtilities";
+import { formatGrouped } from "@/lib/formatNumber";
 
 /**
  * The loop, not a screenshot of it.
@@ -121,10 +122,10 @@ function LogScene({ step }: { step: number }) {
           </p>
           <p className="mt-1 flex items-baseline gap-1.5">
             <span className="text-4xl font-light tracking-tight tabular-nums">
-              {calories.toLocaleString()}
+              {formatGrouped(calories)}
             </span>
             <span className="text-sm text-muted">
-              of {TARGET.calories.toLocaleString()}
+              of {formatGrouped(TARGET.calories)}
             </span>
           </p>
           <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-surface-3">

--- a/frontend/src/features/landing/components/ProductPreviewCharts.tsx
+++ b/frontend/src/features/landing/components/ProductPreviewCharts.tsx
@@ -3,6 +3,7 @@ import { ReferenceLine } from "recharts";
 import type { ChartDataPoint, LineConfig } from "@/components/chart/ChartTypes";
 import LineChartComponent from "@/components/chart/LineChartComponent";
 import Panel from "@/components/ui/Panel";
+import { formatGrouped } from "@/lib/formatNumber";
 
 /**
  * The two scenes that are genuinely charts, drawn with the same Recharts
@@ -81,7 +82,7 @@ export function WeekChart({ step }: { step: number }) {
       <div className="flex items-baseline justify-between px-4 py-3">
         <span className="text-sm font-semibold">This week</span>
         <span className="text-xs text-muted tabular-nums">
-          {average ? `${average.toLocaleString()} kcal average` : " "}
+          {average ? `${formatGrouped(average)} kcal average` : " "}
         </span>
       </div>
       <div className="border-t border-border px-2 pt-4 pb-2">

--- a/frontend/src/features/landing/pages/BmrCalculatorPage.tsx
+++ b/frontend/src/features/landing/pages/BmrCalculatorPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 
 import { ArrowRightIcon } from "@/components/ui";
+import { formatGrouped } from "@/lib/formatNumber";
 import { calculateBMR } from "@/utils/nutritionCalculations";
 import { ACTIVITY_LEVELS } from "@/utils/userConstants";
 
@@ -57,7 +58,7 @@ export default function BmrCalculatorPage() {
         statsReady
           ? {
               label: "Your BMR",
-              value: `${Math.round(bmr).toLocaleString()} kcal / day`,
+              value: `${formatGrouped(bmr)} kcal / day`,
             }
           : undefined
       }
@@ -106,7 +107,7 @@ export default function BmrCalculatorPage() {
                     {level.label}
                   </span>
                   <span className="whitespace-nowrap rounded-control border border-border bg-surface px-2 py-1 font-semibold text-foreground tabular-nums">
-                    {Math.round(bmr * level.multiplier)} kcal
+                    {formatGrouped(bmr * level.multiplier)} kcal
                   </span>
                 </li>
               ))}

--- a/frontend/src/features/landing/pages/MacroCalculatorPage.tsx
+++ b/frontend/src/features/landing/pages/MacroCalculatorPage.tsx
@@ -4,6 +4,7 @@ import Dropdown from "@/components/form/Dropdown";
 import NumberField from "@/components/form/NumberField";
 import MacroSlider from "@/components/macros/MacroSlider";
 import { COLOR_MAP } from "@/components/utils/UiConstants";
+import { formatGrouped } from "@/lib/formatNumber";
 import type { MacroType } from "@/types/macro";
 import {
   calculateBMR,
@@ -172,7 +173,7 @@ export default function MacroCalculatorPage() {
                 <p className="rounded-control border border-border bg-surface-2 px-3 py-2.5 text-xs leading-relaxed text-muted">
                   Based on your maintenance estimate of{" "}
                   <strong className="font-semibold text-foreground tabular-nums">
-                    {tdee} kcal
+                    {formatGrouped(tdee)} kcal
                   </strong>
                   . Switch to a custom target to set calories yourself.
                 </p>
@@ -249,7 +250,7 @@ export default function MacroCalculatorPage() {
                     {row.label}
                   </span>
                   <span className="text-muted tabular-nums">
-                    {row.percentage}% · {row.calories} kcal
+                    {row.percentage}% · {formatGrouped(row.calories)} kcal
                   </span>
                 </div>
                 <div className="text-xl font-extrabold text-foreground tabular-nums">

--- a/frontend/src/features/landing/pages/ProteinCalculatorPage.tsx
+++ b/frontend/src/features/landing/pages/ProteinCalculatorPage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import Dropdown from "@/components/form/Dropdown";
 import NumberField from "@/components/form/NumberField";
+import { formatGrouped } from "@/lib/formatNumber";
 import { kgToLb } from "@/utils/unitConversion";
 
 import BodyStatsForm from "../tools/BodyStatsForm";
@@ -62,25 +63,25 @@ const HIGH_PROTEIN_FOODS = [
     name: "Chicken Breast (Cooked)",
     serving: "100g",
     protein: "31g",
-    cals: "165",
+    cals: 165,
   },
   {
     name: "Greek Yogurt (Non-fat)",
     serving: "200g",
     protein: "20g",
-    cals: "120",
+    cals: 120,
   },
-  { name: "Salmon (Cooked)", serving: "100g", protein: "25g", cals: "206" },
-  { name: "Whey Protein Scoop", serving: "30g", protein: "24g", cals: "120" },
+  { name: "Salmon (Cooked)", serving: "100g", protein: "25g", cals: 206 },
+  { name: "Whey Protein Scoop", serving: "30g", protein: "24g", cals: 120 },
   {
     name: "Cottage Cheese (Low-fat)",
     serving: "150g",
     protein: "18g",
-    cals: "125",
+    cals: 125,
   },
-  { name: "Whole Eggs", serving: "3 large", protein: "18g", cals: "210" },
-  { name: "Extra Firm Tofu", serving: "150g", protein: "15g", cals: "120" },
-  { name: "Cooked Lentils", serving: "200g", protein: "18g", cals: "230" },
+  { name: "Whole Eggs", serving: "3 large", protein: "18g", cals: 210 },
+  { name: "Extra Firm Tofu", serving: "150g", protein: "15g", cals: 120 },
+  { name: "Cooked Lentils", serving: "200g", protein: "18g", cals: 230 },
 ];
 
 export default function ProteinCalculatorPage() {
@@ -169,7 +170,7 @@ export default function ProteinCalculatorPage() {
                 Total calories from protein
               </dt>
               <dd className={calculatorStatValueClass}>
-                {totalProteinGrams * 4} kcal
+                {formatGrouped(totalProteinGrams * 4)} kcal
               </dd>
             </div>
           </dl>
@@ -233,7 +234,7 @@ export default function ProteinCalculatorPage() {
                     {item.protein}
                   </td>
                   <td className="px-3 py-2.5 text-right whitespace-nowrap tabular-nums">
-                    {item.cals} kcal
+                    {formatGrouped(item.cals)} kcal
                   </td>
                 </tr>
               ))}

--- a/frontend/src/features/landing/pages/TdeeCalculatorPage.tsx
+++ b/frontend/src/features/landing/pages/TdeeCalculatorPage.tsx
@@ -1,4 +1,5 @@
 import AnimatedNumber from "@/components/animation/AnimatedNumber";
+import { formatGrouped } from "@/lib/formatNumber";
 import {
   calculateBMR,
   calculateMacroTarget,
@@ -100,7 +101,7 @@ export default function TdeeCalculatorPage() {
         statsReady
           ? {
               label: "Your TDEE",
-              value: `${Math.round(tdee).toLocaleString()} kcal / day`,
+              value: `${formatGrouped(tdee)} kcal / day`,
             }
           : undefined
       }
@@ -130,9 +131,14 @@ export default function TdeeCalculatorPage() {
           {statsReady ? (
             <p className="mt-3 text-xs leading-relaxed text-muted">
               Your Basal Metabolic Rate (BMR) is{" "}
-              <strong className="text-foreground">{bmr} kcal</strong>. Activity
-              adds{" "}
-              <strong className="text-foreground">{tdee - bmr} kcal</strong>.
+              <strong className="text-foreground">
+                {formatGrouped(bmr)} kcal
+              </strong>
+              . Activity adds{" "}
+              <strong className="text-foreground">
+                {formatGrouped(tdee - bmr)} kcal
+              </strong>
+              .
             </p>
           ) : null}
 
@@ -161,7 +167,7 @@ export default function TdeeCalculatorPage() {
                     >
                       <span className="leading-snug">{level.label}</span>
                       <span className="whitespace-nowrap font-medium tabular-nums">
-                        {Math.round(bmr * level.multiplier)} kcal
+                        {formatGrouped(bmr * level.multiplier)} kcal
                       </span>
                     </button>
                   </li>

--- a/frontend/src/features/landing/pages/WeightLossCalculatorPage.tsx
+++ b/frontend/src/features/landing/pages/WeightLossCalculatorPage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import Dropdown from "@/components/form/Dropdown";
 import NumberField from "@/components/form/NumberField";
+import { formatGrouped } from "@/lib/formatNumber";
 import { calculateBMR, calculateTDEE } from "@/utils/nutritionCalculations";
 import { kgToLb, lbToKg } from "@/utils/unitConversion";
 import {
@@ -177,7 +178,7 @@ export default function WeightLossCalculatorPage() {
               role="status"
               className="mt-4 rounded-control border border-error/30 bg-error/10 p-3 text-sm leading-relaxed text-error"
             >
-              This target is below the usual minimum of {minSafeCalories}{" "}
+              This target is below the usual minimum of {formatGrouped(minSafeCalories)}{" "}
               kcal/day. Consider choosing a slower weekly pace.
             </p>
           )}
@@ -187,7 +188,9 @@ export default function WeightLossCalculatorPage() {
               <dt className={calculatorStatLabelClass}>
                 Maintenance burn (TDEE)
               </dt>
-              <dd className={calculatorStatValueClass}>{tdee} kcal</dd>
+              <dd className={calculatorStatValueClass}>
+                {formatGrouped(tdee)} kcal
+              </dd>
             </div>
             <div className={calculatorStatRowClass}>
               <dt className={calculatorStatLabelClass}>
@@ -196,7 +199,7 @@ export default function WeightLossCalculatorPage() {
               <dd className={calculatorStatValueClass}>
                 {isAtGoal
                   ? "0"
-                  : `${isGain ? "+" : "-"}${dailyCalorieAdjustment}`}{" "}
+                  : `${isGain ? "+" : "-"}${formatGrouped(dailyCalorieAdjustment)}`}{" "}
                 kcal
               </dd>
             </div>

--- a/frontend/src/features/macroTracking/components/CalorieSearchForm.tsx
+++ b/frontend/src/features/macroTracking/components/CalorieSearchForm.tsx
@@ -15,6 +15,7 @@ import StatusIndicator from "@/components/ui/StatusIndicator";
 import { useFoodSearch } from "@/hooks/queries/useFoodSearch";
 import { useMacroHistory } from "@/hooks/queries/useMacroQueries";
 import { cn } from "@/lib/classnameUtilities";
+import { formatGrouped } from "@/lib/formatNumber";
 import type { Ingredient, MacroEntry } from "@/types/macro";
 
 import { calculateCaloriesFromMacros } from "../calculations";
@@ -407,7 +408,7 @@ const CalorieSearch = memo(function CalorieSearch({
                     <div className="font-medium">{item.name}</div>
                     <div className="text-xs text-foreground">
                       {displayQuantity ? `${displayQuantity} | ` : ""}
-                      Calories: {calories.toFixed(1)} kcal | Protein:{" "}
+                      Calories: {formatGrouped(calories, 1)} kcal | Protein:{" "}
                       {protein.toFixed(1)}g, Carbs: {carbs.toFixed(1)}
                       g, Fats: {fats.toFixed(1)}g
                     </div>
@@ -514,7 +515,7 @@ const CalorieSearch = memo(function CalorieSearch({
                               </span>
                             </div>
                             <div className="mt-0.5 text-xs text-muted">
-                              Calories: {cals} kcal | Protein: {entry.protein}g,
+                              Calories: {formatGrouped(cals)} kcal | Protein: {entry.protein}g,
                               Carbs: {entry.carbs}g, Fats: {entry.fats}g
                             </div>
                           </button>

--- a/frontend/src/features/macroTracking/components/DailySummaryPanel.tsx
+++ b/frontend/src/features/macroTracking/components/DailySummaryPanel.tsx
@@ -11,6 +11,7 @@ import ProgressBar from "@/components/ui/ProgressBar";
 import Value from "@/components/ui/Value";
 import MacroSnapshotModal from "@/features/macroTracking/components/MacroSnapshotModal";
 import type { MacroSnapshotData } from "@/features/macroTracking/utils/macroSnapshotCanvas";
+import { formatGrouped } from "@/lib/formatNumber";
 import { MacroDailyTotals, MacroTargetSettings } from "@/types/macro";
 import { getDisplayDate } from "@/utils/dateUtilities";
 
@@ -232,7 +233,7 @@ function DailySummaryInner({
           unit="kcal"
           animate
           value={macroCalories.total}
-          suffix={`of ${Math.round(dailyCalorieTarget).toLocaleString()}`}
+          suffix={`of ${formatGrouped(dailyCalorieTarget)}`}
         />
 
         <ProgressBar
@@ -269,7 +270,9 @@ function DailySummaryInner({
           >
             <div className="flex items-baseline justify-between gap-3">
               <span className="flex items-center gap-2">
-                <span className={`h-2 w-2 shrink-0 rounded-full ${macro.color}`} />
+                <span
+                  className={`h-2 w-2 shrink-0 rounded-full ${macro.color}`}
+                />
                 <span className="text-sm font-medium">{macro.name}</span>
               </span>
               <Value

--- a/frontend/src/features/macroTracking/components/MacroSnapshotModal.tsx
+++ b/frontend/src/features/macroTracking/components/MacroSnapshotModal.tsx
@@ -19,6 +19,7 @@ import {
   shareSnapshot,
 } from "@/features/macroTracking/utils/macroSnapshotCanvas";
 import { cn } from "@/lib/classnameUtilities";
+import { formatGrouped } from "@/lib/formatNumber";
 import { useStore } from "@/store/store";
 
 export interface MacroSnapshotModalProps {
@@ -142,7 +143,7 @@ function MacroSnapshotModalInner({
               <div className="flex items-baseline justify-between gap-3">
                 <p className={cn(TYPE_SCALE.micro, "text-muted")}>Calories</p>
                 <p className="text-xs text-muted">
-                  Target {model.calorieTarget.toLocaleString()} kcal
+                  Target {formatGrouped(model.calorieTarget)} kcal
                 </p>
               </div>
 
@@ -151,7 +152,7 @@ function MacroSnapshotModalInner({
                   size="hero"
                   unit="kcal"
                   value={model.calories}
-                  suffix={`of ${model.calorieTarget.toLocaleString()}`}
+                  suffix={`of ${formatGrouped(model.calorieTarget)}`}
                 />
               </div>
 
@@ -207,7 +208,7 @@ function MacroSnapshotModalInner({
 
                   <div className="mt-2 flex items-baseline justify-between gap-2 text-xs">
                     <span className="font-semibold text-foreground tabular-nums">
-                      {row.calories.toLocaleString()} kcal
+                      {formatGrouped(row.calories)} kcal
                     </span>
                     <span className="text-muted tabular-nums">
                       {row.energyShare}%
@@ -224,7 +225,7 @@ function MacroSnapshotModalInner({
                   Energy split
                 </p>
                 <p className="text-xs text-muted">
-                  {model.totalMacroCalories.toLocaleString()} kcal from macros
+                  {formatGrouped(model.totalMacroCalories)} kcal from macros
                 </p>
               </div>
 

--- a/frontend/src/features/macroTracking/components/MobileEntryCards.tsx
+++ b/frontend/src/features/macroTracking/components/MobileEntryCards.tsx
@@ -3,6 +3,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { AnimatePresence, motion } from "motion/react";
 
 import { ChevronDownIcon, IconButton } from "@/components/ui";
+import { formatGrouped } from "@/lib/formatNumber";
 import type { MacroEntry } from "@/types/macro";
 
 import { EntryCard } from "./EntryCard";
@@ -112,7 +113,7 @@ const MobileEntryCards = memo(
             {group.totals.fats}g F
           </span>
           <span className="font-medium tracking-tight text-foreground whitespace-nowrap">
-            {group.totals.calories} kcal
+            {formatGrouped(group.totals.calories)} kcal
           </span>
           <IconButton
             variant="delete"

--- a/frontend/src/features/macroTracking/components/SavedMealsList.tsx
+++ b/frontend/src/features/macroTracking/components/SavedMealsList.tsx
@@ -9,6 +9,7 @@ import {
   useSavedMeals,
 } from "@/hooks/queries/useSavedMeals";
 import { cn } from "@/lib/classnameUtilities";
+import { formatGrouped } from "@/lib/formatNumber";
 import type { Ingredient, MealType } from "@/types/macro";
 
 import { calculateCaloriesFromMacros } from "../calculations";
@@ -89,7 +90,9 @@ const SavedMealsList = memo(
                   <span className="text-sm font-medium text-foreground">
                     {meal.name}
                   </span>
-                  <span className="text-xs text-muted">{calories} kcal</span>
+                  <span className="text-xs text-muted">
+                    {formatGrouped(calories)} kcal
+                  </span>
                 </button>
                 <button
                   type="button"

--- a/frontend/src/features/macroTracking/utils/macroSnapshot.ts
+++ b/frontend/src/features/macroTracking/utils/macroSnapshot.ts
@@ -3,6 +3,7 @@ import {
   resolveTokens,
   TOKEN_FALLBACK,
 } from "@/lib/designTokens";
+import { formatGrouped } from "@/lib/formatNumber";
 
 /**
  * One model for the share snapshot, read by both renderers.
@@ -168,11 +169,11 @@ export function buildSnapshotModel(data: MacroSnapshotData): SnapshotModel {
     calorieBarPercent: clampBar(caloriePercent),
     calorieRemainder:
       remaining >= 0
-        ? `${remaining.toLocaleString()} kcal left`
-        : `${Math.abs(remaining).toLocaleString()} kcal over`,
+        ? `${formatGrouped(remaining)} kcal left`
+        : `${formatGrouped(Math.abs(remaining))} kcal over`,
     macros,
     totalMacroCalories,
-    shareText: `${calories.toLocaleString()} of ${calorieTarget.toLocaleString()} kcal — ${macros
+    shareText: `${formatGrouped(calories)} of ${formatGrouped(calorieTarget)} kcal — ${macros
       .map((macro) => `${macro.label.toLowerCase()} ${macro.grams}g`)
       .join(", ")}.`,
     fileStem: toFileStem(dateLabel),

--- a/frontend/src/features/macroTracking/utils/macroSnapshotCanvas.ts
+++ b/frontend/src/features/macroTracking/utils/macroSnapshotCanvas.ts
@@ -2,6 +2,7 @@ import {
   BRAND_MARK_PATH,
   BRAND_MARK_VIEW_BOX,
 } from "@/components/layout/BrandMarkPath";
+import { formatGrouped } from "@/lib/formatNumber";
 
 import {
   buildSnapshotModel,
@@ -347,7 +348,7 @@ function drawHero(
   ctx.fillStyle = palette.muted;
   ctx.textAlign = "right";
   ctx.fillText(
-    `Target ${model.calorieTarget.toLocaleString()} kcal`,
+    `Target ${formatGrouped(model.calorieTarget)} kcal`,
     innerX + innerW,
     top + 44,
   );
@@ -356,14 +357,14 @@ function drawHero(
   // Hero figure: condensed and bold, per the Value scale.
   setFont(ctx, 700, 86, true);
   ctx.fillStyle = palette.foreground;
-  const figure = model.calories.toLocaleString();
+  const figure = formatGrouped(model.calories);
   ctx.fillText(figure, innerX, top + 128);
   const figureW = ctx.measureText(figure).width;
 
   setFont(ctx, 500, 24);
   ctx.fillStyle = palette.muted;
   ctx.fillText(
-    `kcal of ${model.calorieTarget.toLocaleString()}`,
+    `kcal of ${formatGrouped(model.calorieTarget)}`,
     innerX + figureW + 14,
     top + 128,
   );
@@ -436,7 +437,7 @@ function drawMacros(
 
     setFont(ctx, 600, 20);
     ctx.fillStyle = palette.foreground;
-    ctx.fillText(`${row.calories.toLocaleString()} kcal`, innerX, top + 222);
+    ctx.fillText(`${formatGrouped(row.calories)} kcal`, innerX, top + 222);
 
     setFont(ctx, 500, 20);
     ctx.fillStyle = palette.muted;
@@ -465,7 +466,7 @@ function drawDistribution(
   ctx.fillStyle = palette.muted;
   ctx.textAlign = "right";
   ctx.fillText(
-    `${model.totalMacroCalories.toLocaleString()} kcal from macros`,
+    `${formatGrouped(model.totalMacroCalories)} kcal from macros`,
     innerX + innerW,
     top + 42,
   );

--- a/frontend/src/features/reporting/components/MealTimeBreakdown.tsx
+++ b/frontend/src/features/reporting/components/MealTimeBreakdown.tsx
@@ -11,6 +11,7 @@ import {
 import AnimatedNumber from "@/components/animation/AnimatedNumber";
 import ChartCard from "@/components/chart/ChartCard";
 import TabBar from "@/components/ui/TabBar";
+import { formatGrouped } from "@/lib/formatNumber";
 import { getUnitForStat, MEAL_COLORS } from "@/utils/chartColors";
 
 import {
@@ -56,7 +57,7 @@ const CustomDonutTooltip = ({
         <div className="mt-2 flex flex-col gap-1">
           <p className="text-sm text-muted">
             <span className="font-medium text-foreground">
-              {Math.round(value)}
+              {formatGrouped(value)}
             </span>
             {unit}
           </p>

--- a/frontend/src/features/reporting/utils/insightsCalculations.ts
+++ b/frontend/src/features/reporting/utils/insightsCalculations.ts
@@ -1,3 +1,4 @@
+import { formatGrouped } from "@/lib/formatNumber";
 import type { MacroTargetSettings } from "@/types/macro";
 
 import {
@@ -252,7 +253,7 @@ export function generateOverallTrendSummary(
       ? "Calories remain steady"
       : `Calories are trending ${caloriesTrend.direction === "up" ? "upward" : "downward"} (${
           caloriesTrend.delta && caloriesTrend.delta > 0 ? "+" : ""
-        }${caloriesTrend.delta} kcal/day)`;
+        }${formatGrouped(caloriesTrend.delta ?? 0)} kcal/day)`;
 
   const macroDrivers: string[] = [];
   if (proteinTrend.direction !== "stable") {

--- a/frontend/src/features/settings/components/DataImporter.tsx
+++ b/frontend/src/features/settings/components/DataImporter.tsx
@@ -19,6 +19,7 @@ import {
 import Heading from "@/components/ui/Heading";
 import Panel from "@/components/ui/Panel";
 import { useImportMacros } from "@/hooks/queries/useMacroQueries";
+import { formatGrouped } from "@/lib/formatNumber";
 import { useProductAnalytics } from "@/lib/productAnalytics";
 import { useStore } from "@/store/store";
 
@@ -395,7 +396,10 @@ export default function DataImporter() {
                   </span>
                   <span className="text-xs text-muted">
                     Total calories:{" "}
-                    {parsedData.summary.macroSummary.totalCalories} kcal
+                    {formatGrouped(
+                      parsedData.summary.macroSummary.totalCalories,
+                    )}{" "}
+                    kcal
                   </span>
                 </div>
                 <div className="overflow-x-auto rounded-card border border-border bg-surface-2">

--- a/frontend/src/lib/formatNumber.test.ts
+++ b/frontend/src/lib/formatNumber.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { formatGrouped } from "./formatNumber";
+
+describe("formatGrouped", () => {
+  it("groups thousands, which is the house standard", () => {
+    expect(formatGrouped(2000)).toBe("2,000");
+    expect(formatGrouped(12_345)).toBe("12,345");
+  });
+
+  it("leaves figures under a thousand alone", () => {
+    expect(formatGrouped(950)).toBe("950");
+  });
+
+  it("holds the decimals it is given", () => {
+    expect(formatGrouped(1234.56, 1)).toBe("1,234.6");
+    expect(formatGrouped(80.64, 1)).toBe("80.6");
+  });
+
+  it("prints zero rather than NaN for a figure that is not one", () => {
+    expect(formatGrouped(Number.NaN)).toBe("0");
+    expect(formatGrouped(Number.POSITIVE_INFINITY)).toBe("0");
+  });
+});

--- a/frontend/src/lib/formatNumber.ts
+++ b/frontend/src/lib/formatNumber.ts
@@ -1,0 +1,27 @@
+/**
+ * One spelling for every figure the product prints.
+ *
+ * The app shipped a daily target as both "2000 kcal" and "2,000 kcal", and the
+ * split ran straight through the primitive that exists to prevent exactly that:
+ * `Value` formatted with `toLocaleString` and grouped, while the
+ * `AnimatedNumber` it delegates to formatted with `toFixed` and did not. The
+ * same call site changed spelling when someone added `animate`.
+ *
+ * Grouped is the house standard. It is what `Value` already did, and the type
+ * scale was chosen partly to carry it: Archivo's width axis exists here so a
+ * condensed "2,140 kcal" fits a 390px column, which is an argument about the
+ * grouped form. Every separator in the product comes from this function, so
+ * changing the standard is a one-line change here rather than a sweep.
+ *
+ * Locale-aware by design: `undefined` follows the reader's locale, so a German
+ * reader gets "2.140". Do not pass "en-US" to force a comma — the figures are
+ * read, not parsed.
+ */
+export function formatGrouped(value: number, decimals = 0): string {
+  const safeValue = Number.isFinite(value) ? value : 0;
+
+  return safeValue.toLocaleString(undefined, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}

--- a/frontend/ui-budgets.json
+++ b/frontend/ui-budgets.json
@@ -16,6 +16,8 @@
     "shadows": 0,
     "hexLiterals": 21,
     "emoji": 0,
+    "adHocNumberFormat": 0,
+    "rawCalorieFigures": 0,
     "boldOutsideScale": 63
   },
   "history": {


### PR DESCRIPTION
Follow-ups on #159, from three things spotted in the running app.

## Goal step: the target weight came back empty

Switching direction cleared the target. That stopped Gain inheriting Lose's number, but it also meant *looking* at Gain to see what it did cost you the 80 kg you'd typed for Lose. The target is stored per direction now, so each pill reads its own and neither can show the other's — `handleGoalChange` has nothing left to clear. Two new tests cover the round trip including a detour via Maintain; both fail against the previous component.

## Goal step: Time to target now animates

It's the one figure on that card that actually moves — the calorie target and weekly rate are fixed per direction, while this tracks every keystroke in the target weight. So it's the one that animates, which is what "at most one per screen" is for.

Wiring it up showed `Value` hardcoding `duration={0.8}` and `AnimatedNumber` defaulting to `0.6`, while `DURATIONS.value` (0.45) exists for exactly them. Both read the token now, which also keeps the count up with typing.

## The number standard: grouped, "2,000 kcal"

The app printed a daily target both ways, and the split ran through the primitive meant to prevent it: `Value` grouped via `toLocaleString`, the `AnimatedNumber` it delegates to used `toFixed` and didn't. **The same call site changed spelling the moment someone added `animate`.**

Grouped on the evidence rather than a coin flip: `Value` always did it, and the design doc's argument for Archivo's width axis is that a condensed "2,140 kcal" fits a 390px column — an argument about the grouped form. Every separator now comes from `formatGrouped` (`src/lib/formatNumber.ts`), locale-aware, so a German reader gets "2.140" and changing the standard is one line.

**77 call sites across 27 files.** My first sweep searched for figures sitting directly beside `kcal`, which missed every case where the unit is a separate JSX expression or sits on the next line — where most survivors hid: `WeightGoalForm`'s intake slider, `WeightLossCalculator`'s safety floor and daily adjustment, `MealTimeBreakdown`'s tooltip, `MacroComponents`' grams, `insightsCalculations`' trend delta, the protein reference table.

Verified as *not* needing it: `ResultHeadline` (all four public calculators), `ChartTooltip` and `WeightGoalStatus` all render through `AnimatedNumber` and were fixed by the primitive change. Percentages and kg weights can't reach four digits. `Number(x.toFixed(1))` calls are rounding for state, not display.

### Two things fell out of the sweep

- `insightsCalculations` would have printed "**undefined** kcal/day" into user-facing insight text — `delta` is optional and was interpolated bare. Typecheck caught it the moment the value passed through a typed function.
- The protein table stored `cals` as strings, which is why it couldn't be formatted. They're figures, so they're numbers now — which lets the budget pin at 0 rather than 1-with-an-exception.

### Two budgets, because there are two ways to get this wrong

`adHocNumberFormat` catches a call site reaching for `toLocaleString`; `rawCalorieFigures` catches one that formats by *not* formatting. The second is what actually shipped, in eleven places. It counts by matching then filtering rather than subtracting two patterns — JSX's `{" "}` space token sits directly before the unit when the value is on the line above, and a subtracting version scored that as raw (3 false positives). Confirmed it fires by reintroducing a raw `{bmr * level.multiplier} kcal`: `!! 1`, then `ok 0` on revert.

## Verification

- `bun run lint` — 0 errors, all 18 budgets `ok`
- `bun run typecheck` — clean
- `bun run test` — 879 passed / 150 files
- `bun run build` — succeeds
- Checked every file's diff is proportionate to its edit, after last round's `--fix` churn

## Note

`MacroComponents`' gram figures are included for uniformity, though grams realistically never reach four digits — grouping is a no-op below 1000, and deciding "is this number big enough" per call site is the drift the rule exists to stop.