### PR TITLE
docs(legal): state an 18+ age requirement and strengthen the health disclaimer

### DIFF
--- a/frontend/src/features/landing/pages/PrivacyPolicyPage.tsx
+++ b/frontend/src/features/landing/pages/PrivacyPolicyPage.tsx
@@ -94,6 +94,19 @@ const PrivacyPolicyPage: React.FC = () => {
                   </ul>
                 </section>
 
+                <section className="mb-8">
+                  <h2 className="mb-3 text-2xl font-semibold text-foreground">
+                    Children's Privacy
+                  </h2>
+                  <p>
+                    MacroTrackr is intended for people aged 18 and over. We do
+                    not knowingly collect personal information from children. If
+                    you believe a child has provided us with personal
+                    information, contact us and we will delete the account and
+                    its data.
+                  </p>
+                </section>
+
                 <section className="mb-2">
                   <h2 className="mb-3 text-2xl font-semibold text-foreground">
                     Contact Us

--- a/frontend/src/features/landing/pages/TermsAndConditionsPage.tsx
+++ b/frontend/src/features/landing/pages/TermsAndConditionsPage.tsx
@@ -60,6 +60,13 @@ const TermsAndConditionsPage: React.FC = () => {
                   account. You are responsible for account security and accurate
                   information.
                 </p>
+                <p className="mb-4 leading-relaxed text-muted">
+                  <strong>You must be 18 or older to create an account.</strong>{" "}
+                  MacroTrackr is not intended for children, and we do not
+                  knowingly collect information from anyone under 18. If you
+                  believe a minor has created an account, contact us and we will
+                  remove it.
+                </p>
                 <ul className="mb-4 list-inside list-disc space-y-2 text-muted">
                   <li>Maintain credential confidentiality</li>
                   <li>All activities under your account</li>
@@ -111,8 +118,27 @@ const TermsAndConditionsPage: React.FC = () => {
                   7. Health Disclaimer
                 </h2>
                 <p className="mb-4 leading-relaxed text-muted">
-                  MacroTrackr is not a medical service; consult professionals
-                  before significant dietary or exercise changes.
+                  <strong>
+                    MacroTrackr does not provide medical advice.
+                  </strong>{" "}
+                  It is a tracking tool, not a medical service, and nothing in
+                  it is a diagnosis, treatment, or a substitute for professional
+                  care. Consult a qualified healthcare professional before
+                  making significant dietary or exercise changes, and
+                  particularly before pursuing a calorie deficit.
+                </p>
+                <p className="mb-4 leading-relaxed text-muted">
+                  Calorie and macro targets, along with BMR and TDEE figures,
+                  are <strong>estimates</strong> produced by standard formulae
+                  from the details you enter. They are not measurements, they
+                  are not personalised to your medical history, and they can be
+                  wrong for you.
+                </p>
+                <p className="mb-4 leading-relaxed text-muted">
+                  Do not use MacroTrackr if tracking food intake is harmful to
+                  you. If you are experiencing disordered eating, or tracking
+                  makes your relationship with food worse, please stop and speak
+                  to a doctor or a qualified support service.
                 </p>
               </section>
 


### PR DESCRIPTION
Two gaps found while filling in Play Console's **Target audience and content** section. Play cross-checks these declarations against the app, and the terms were silent on age entirely.

## Terms

**User Accounts** now states plainly that you must be **18 or older**, that the app isn't intended for children, and that accounts believed to belong to minors will be removed.

This has to match the 18+ target age declared in Play Console. Declaring 18+ there while the terms say nothing about age is the kind of mismatch a reviewer picks up — and 18+ is the right call regardless, because ticking any under-18 bracket pulls the app into Play's Families programme (COPPA/GDPR-K obligations, SDK restrictions, extra review) for an audience we don't want.

**Health Disclaimer** was one sentence: *"MacroTrackr is not a medical service; consult professionals before significant dietary or exercise changes."* It now also says three things it didn't:

1. Nothing here is a diagnosis, treatment, or substitute for professional care.
2. Calorie, macro, BMR and TDEE figures are **estimates** from standard formulae — not measurements, and not personalised to anyone's medical history.
3. If tracking food is harmful to you, stop and seek support.

The third point is deliberate. A calorie tracker with a deficit goal carries a real risk of reinforcing disordered eating. Saying so plainly is both the responsible position and what platforms expect of this category.

## Privacy

Adds a **Children's Privacy** section: intended for 18+, no knowing collection from children, deletion on request.

## Notes

- Placed the age requirement inside the existing *User Accounts* section rather than adding a new numbered one, so the nine sections that follow don't all get renumbered for a two-sentence addition.
- Both pages are pre-rendered for SEO, so this ships in the static HTML too.

**Not legal advice.** This is reasonable-practice wording and should get a lawyer's review before launch — flagging that explicitly rather than burying it.

## Verification

- `tsc` clean
- lint **0 errors**
- frontend **879 tests** pass (150 files)