### PR TITLE
feat(account): self-serve account deletion and a public deletion page

### DIFF
--- a/backend/src/modules/user/routes.ts
+++ b/backend/src/modules/user/routes.ts
@@ -13,6 +13,7 @@ import {
   NotFoundError,
   ConflictError,
   BadRequestError,
+  AuthIntegrationError,
 } from "../../lib/http/errors";
 import { handleError } from "../../lib/http/responses";
 import { loggerHelpers, logger } from "../../lib/observability/logger";
@@ -26,7 +27,12 @@ import {
 
 type UserRouteContext = AuthenticatedRouteContextWithUser<
   Record<string, unknown>
->;
+> & {
+  /** Present in clerk auth mode; absent when self-hosted with local auth. */
+  clerkClient?: {
+    users?: { deleteUser?: (clerkUserId: string) => Promise<unknown> };
+  };
+};
 
 const ErrorResponseSchema = t.Object({
   code: t.String(),
@@ -468,6 +474,99 @@ export const userRoutes = (app: Elysia) =>
           detail: {
             summary:
               "Add or update specific user details (e.g., during onboarding)",
+            tags: ["User"],
+          },
+        },
+      )
+      /**
+       * DELETE /me — irreversibly delete the caller's account.
+       *
+       * Every user-owned table carries ON DELETE CASCADE on its user_id
+       * foreign key (12 of them), so removing the users row takes the food
+       * log, weight history, goals, macro targets, habits, saved meals,
+       * subscriptions and sessions with it. That is deliberately relied on
+       * here rather than deleting each table by hand, which would rot the
+       * moment a new table is added.
+       *
+       * Refuses while a subscription is active: Play subscriptions cannot be
+       * cancelled server-side by us, so deleting the account would leave
+       * someone being billed with no account behind it.
+       */
+      .delete(
+        "/me",
+        async (rawContext: unknown) => {
+          const context = rawContext as UserRouteContext;
+          try {
+            const { db, clerkClient } = context;
+            const { userId: internalUserId, providerUserId } =
+              context.authenticatedUser;
+
+            if (internalUserId === null) {
+              throw new AccountNotSyncedError(
+                "Unable to resolve internal user ID.",
+              );
+            }
+
+            const existing = safeQuery<{
+              id: number;
+              subscription_status: string | null;
+            }>(
+              db,
+              "SELECT id, subscription_status FROM users WHERE id = ? LIMIT 1",
+              [internalUserId],
+            );
+            if (!existing) {
+              throw new NotFoundError("Account not found");
+            }
+
+            if (existing.subscription_status === "pro") {
+              throw new ConflictError(
+                "Cancel your subscription before deleting your account. " +
+                  "Manage it in Google Play if you subscribed on Android, " +
+                  "or in the billing portal if you subscribed on the web.",
+              );
+            }
+
+            // Clerk first: if it fails we still have a local row to retry
+            // with. Doing it the other way round can orphan a Clerk identity
+            // whose local account is already gone.
+            if (providerUserId && clerkClient?.users?.deleteUser) {
+              try {
+                await clerkClient.users.deleteUser(providerUserId);
+              } catch (clerkError) {
+                logger.error(
+                  { internalUserId, error: clerkError },
+                  "[/api/user/me] Failed to delete Clerk user; aborting",
+                );
+                throw new AuthIntegrationError(
+                  "Could not delete your sign-in identity. Please try again.",
+                );
+              }
+            }
+
+            const result = safeExecute(db, "DELETE FROM users WHERE id = ?", [
+              internalUserId,
+            ]);
+
+            logger.info(
+              { internalUserId, rowsDeleted: result.changes },
+              "[/api/user/me] Account deleted",
+            );
+
+            return {
+              success: true,
+              message: "Your account and all associated data have been deleted.",
+            };
+          } catch (error) {
+            return handleError(error, context.set);
+          }
+        },
+        {
+          response: {
+            200: t.Object({ success: t.Boolean(), message: t.String() }),
+          },
+          detail: {
+            summary: "Permanently delete the current account and all its data",
             tags: ["User"],
           },
         },

--- a/backend/tests/modules/user/routes.delete-account.test.ts
+++ b/backend/tests/modules/user/routes.delete-account.test.ts
@@ -1,0 +1,114 @@
+import { Elysia } from "elysia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const safeQueryMock = vi.fn();
+const safeExecuteMock = vi.fn();
+const withTransactionAsyncMock = vi.fn();
+
+vi.mock("../../../src/lib/data/database", () => ({
+  safeQuery: (...arguments_: unknown[]) => safeQueryMock(...arguments_),
+  safeExecute: (...arguments_: unknown[]) => safeExecuteMock(...arguments_),
+  withTransactionAsync: (...arguments_: unknown[]) =>
+    withTransactionAsyncMock(...arguments_),
+}));
+
+import { resetConfigCache } from "../../../src/config";
+import { userRoutes } from "../../../src/modules/user/routes";
+
+const deleteClerkUserMock = vi.fn();
+
+function createApp(options: { withClerk?: boolean } = {}) {
+  const app = new Elysia().decorate("db", { kind: "test-db" });
+  if (options.withClerk) {
+    app.decorate("clerkClient", {
+      users: { deleteUser: deleteClerkUserMock },
+    });
+  }
+  return app
+    .derive({ as: "global" }, () => ({
+      authenticatedUser: {
+        userId: 7,
+        providerUserId: "clerk_abc",
+        authProvider: "clerk" as const,
+        email: "test@example.com",
+        firstName: "Test",
+        lastName: "User",
+      },
+      correlationId: "test-correlation-id",
+    }))
+    .use(userRoutes);
+}
+
+const del = (app: Elysia) =>
+  app.handle(new Request("http://localhost/api/user/me", { method: "DELETE" }));
+
+describe("DELETE /api/user/me", () => {
+  beforeEach(() => {
+    process.env.APP_MODE = "managed";
+    process.env.AUTH_MODE = "clerk";
+    process.env.BILLING_MODE = "managed";
+    resetConfigCache();
+    safeQueryMock.mockReset();
+    safeExecuteMock.mockReset();
+    withTransactionAsyncMock.mockReset();
+    deleteClerkUserMock.mockReset();
+  });
+
+  it("deletes the users row, relying on cascades for owned data", async () => {
+    safeQueryMock.mockReturnValue({ id: 7, subscription_status: "free" });
+    safeExecuteMock.mockReturnValue({ changes: 1 });
+
+    const response = await del(createApp());
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ success: true });
+
+    // One DELETE against users; every other table cascades.
+    expect(safeExecuteMock).toHaveBeenCalledTimes(1);
+    const [, sql, parameters] = safeExecuteMock.mock.calls[0] as [
+      unknown,
+      string,
+      unknown[],
+    ];
+    expect(sql).toContain("DELETE FROM users");
+    expect(parameters).toEqual([7]);
+  });
+
+  it("refuses while a subscription is active, and deletes nothing", async () => {
+    safeQueryMock.mockReturnValue({ id: 7, subscription_status: "pro" });
+
+    const response = await del(createApp());
+    expect(response.status).toBe(409);
+    // The guard exists so nobody keeps being billed for an account that is
+    // gone — so it must not have deleted anything.
+    expect(safeExecuteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the account no longer exists", async () => {
+    safeQueryMock.mockReturnValue(undefined);
+
+    const response = await del(createApp());
+    expect(response.status).toBe(404);
+    expect(safeExecuteMock).not.toHaveBeenCalled();
+  });
+
+  it("removes the Clerk identity before the local row", async () => {
+    safeQueryMock.mockReturnValue({ id: 7, subscription_status: "free" });
+    safeExecuteMock.mockReturnValue({ changes: 1 });
+    deleteClerkUserMock.mockResolvedValue(undefined);
+
+    const response = await del(createApp({ withClerk: true }));
+    expect(response.status).toBe(200);
+    expect(deleteClerkUserMock).toHaveBeenCalledWith("clerk_abc");
+  });
+
+  it("keeps the local row when Clerk deletion fails", async () => {
+    safeQueryMock.mockReturnValue({ id: 7, subscription_status: "free" });
+    deleteClerkUserMock.mockRejectedValue(new Error("clerk is down"));
+
+    const response = await del(createApp({ withClerk: true }));
+    expect(response.status).toBe(500);
+    // Deleting locally anyway would orphan a Clerk identity whose account is
+    // gone, leaving the user unable to sign in or retry.
+    expect(safeExecuteMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -127,6 +127,12 @@
     <priority>0.2</priority>
   </url>
   <url>
+    <loc>https://macrotrackr.com/delete-account</loc>
+    <lastmod>2026-08-24</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.2</priority>
+  </url>
+  <url>
     <loc>https://macrotrackr.com/blog/v3-1-0</loc>
     <lastmod>2026-08-24</lastmod>
     <changefreq>weekly</changefreq>

--- a/frontend/scripts/generate-sitemap.js
+++ b/frontend/scripts/generate-sitemap.js
@@ -51,6 +51,7 @@ const routes = [
   { path: "/pricing", changefreq: "monthly", priority: 0.6 },
   { path: "/privacy", changefreq: "yearly", priority: 0.2 },
   { path: "/terms", changefreq: "yearly", priority: 0.2 },
+  { path: "/delete-account", changefreq: "yearly", priority: 0.2 },
 ];
 
 function buildSitemap(hostname) {

--- a/frontend/scripts/prerender.mjs
+++ b/frontend/scripts/prerender.mjs
@@ -260,6 +260,19 @@ const pages = [
     `,
   },
   {
+    route: "delete-account",
+    title: `Delete your account — ${APP_NAME}`,
+    description: `How to permanently delete your ${APP_NAME} account and all associated data.`,
+    canonical: `${APP_URL}/delete-account`,
+    type: "website",
+    bodyHtml: `
+      <main style="padding:2rem 1rem;max-width:800px;margin:0 auto;">
+        <h1>Delete your account</h1>
+        <p>Delete your account and all associated data from Settings inside the app, or email support to request deletion.</p>
+      </main>
+    `,
+  },
+  {
     route: "terms",
     title: `Terms of Service — ${APP_NAME}`,
     description: `Terms and conditions for using ${APP_NAME}.`,

--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -176,6 +176,16 @@ export const userApi = {
   /**
    * @throws {ApiError}
    */
+  /**
+   * Permanently delete the current account and everything owned by it.
+   * Irreversible. Rejects with 409 while a subscription is active.
+   *
+   * @throws {ApiError}
+   */
+  deleteAccount: async (): Promise<{ success: boolean; message: string }> => {
+    return apiClient.del<{ success: boolean; message: string }>("/api/user/me");
+  },
+
   completeProfile: async (
     profileData: Partial<
       Pick<

--- a/frontend/src/features/landing/pages/DeleteAccountPage.tsx
+++ b/frontend/src/features/landing/pages/DeleteAccountPage.tsx
@@ -1,0 +1,147 @@
+import React from "react";
+
+import AppHeader from "@/components/layout/AppHeader";
+import PageShell from "@/components/layout/PageShell";
+import Heading from "@/components/ui/Heading";
+import BackToTopButton from "@/features/landing/components/BackToTopButton";
+import Footer from "@/features/landing/components/Footer";
+import { usePageMetadata } from "@/hooks";
+import {
+  APP_NAME,
+  buildCanonicalUrl,
+  SUPPORT_EMAIL,
+  SUPPORT_EMAIL_MAILTO,
+} from "@/utils/appConstants";
+
+/**
+ * Public account-deletion page.
+ *
+ * Google Play requires a URL where users can request deletion of their account
+ * and data, reachable **without installing the app**. That is why this is a
+ * public marketing route rather than a screen inside Settings: a reviewer, or
+ * someone who has already uninstalled, has to be able to read it.
+ *
+ * The in-app route (Settings → Delete account) does the deletion itself; this
+ * page documents it and gives an email fallback for people who can no longer
+ * sign in.
+ */
+const DeleteAccountPage: React.FC = () => {
+  usePageMetadata({
+    title: `Delete your account — ${APP_NAME}`,
+    description: `How to permanently delete your ${APP_NAME} account and all associated data, what is removed, and what is kept.`,
+    canonical: buildCanonicalUrl("/delete-account"),
+  });
+
+  return (
+    <div className="min-h-screen bg-background">
+      <AppHeader mode="minimal" />
+      <PageShell>
+        <div className="mx-auto max-w-3xl px-4 py-16">
+          <Heading level="display" as="h1" className="mb-3">
+            Delete your account
+          </Heading>
+          <p className="mb-10 text-lg text-muted">
+            You can delete your {APP_NAME} account and everything in it at any
+            time. Deletion is immediate and cannot be undone.
+          </p>
+
+          <section className="mb-10">
+            <h2 className="mb-3 text-2xl font-semibold text-foreground">
+              From inside the app
+            </h2>
+            <ol className="list-inside list-decimal space-y-2 text-muted">
+              <li>Open {APP_NAME} and sign in.</li>
+              <li>
+                Go to <strong>Settings</strong>.
+              </li>
+              <li>
+                Choose <strong>Delete account</strong> and confirm.
+              </li>
+            </ol>
+          </section>
+
+          <section className="mb-10">
+            <h2 className="mb-3 text-2xl font-semibold text-foreground">
+              If you can&apos;t sign in
+            </h2>
+            <p className="mb-4 leading-relaxed text-muted">
+              Email{" "}
+              <a
+                href={SUPPORT_EMAIL_MAILTO}
+                className="text-primary underline underline-offset-4"
+              >
+                {SUPPORT_EMAIL}
+              </a>{" "}
+              from the address on the account and ask us to delete it. We will
+              confirm and complete the deletion within 30 days.
+            </p>
+          </section>
+
+          <section className="mb-10">
+            <h2 className="mb-3 text-2xl font-semibold text-foreground">
+              What gets deleted
+            </h2>
+            <p className="mb-4 leading-relaxed text-muted">
+              Everything tied to your account is removed:
+            </p>
+            <ul className="list-inside list-disc space-y-2 text-muted">
+              <li>Your account, name and email address</li>
+              <li>Your profile details — date of birth, height, weight, gender, activity level</li>
+              <li>Every logged meal and its macros</li>
+              <li>Your weight history, weight goals and macro targets</li>
+              <li>Your habits and saved meals</li>
+              <li>Your sign-in sessions and saved credentials</li>
+            </ul>
+          </section>
+
+          <section className="mb-10">
+            <h2 className="mb-3 text-2xl font-semibold text-foreground">
+              What we keep, and for how long
+            </h2>
+            <p className="mb-4 leading-relaxed text-muted">
+              We keep records of completed payments where the law requires it —
+              tax and accounting rules oblige us to retain transaction records,
+              typically for several years depending on jurisdiction. Those
+              records are held by our payment providers (Google Play or Stripe)
+              and are not linked back to a deleted account beyond what those
+              obligations require.
+            </p>
+            <p className="mb-4 leading-relaxed text-muted">
+              Server logs may contain technical entries such as IP addresses for
+              a short period for security and abuse prevention. These expire on
+              a rolling basis and are not used to reconstruct a deleted account.
+            </p>
+          </section>
+
+          <section className="mb-10">
+            <h2 className="mb-3 text-2xl font-semibold text-foreground">
+              If you have an active subscription
+            </h2>
+            <p className="mb-4 leading-relaxed text-muted">
+              Cancel it before deleting your account, otherwise you may continue
+              to be billed for a subscription with no account attached. Cancel
+              in <strong>Google Play</strong> if you subscribed on Android, or
+              through the billing portal in Settings if you subscribed on the
+              web. Deletion is blocked while a subscription is active.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-2xl font-semibold text-foreground">
+              Prefer to export first?
+            </h2>
+            <p className="leading-relaxed text-muted">
+              You can export your data as CSV from the app before deleting.
+              Once the account is gone we cannot recover it for you.
+            </p>
+          </section>
+        </div>
+      </PageShell>
+
+      <Footer />
+      <BackToTopButton label="Back to top" className="bottom-32 sm:bottom-28" />
+    </div>
+  );
+};
+
+export default DeleteAccountPage;

--- a/frontend/src/features/landing/pages/PrivacyPolicyPage.tsx
+++ b/frontend/src/features/landing/pages/PrivacyPolicyPage.tsx
@@ -89,7 +89,14 @@ const PrivacyPolicyPage: React.FC = () => {
                   <ul className="ml-4 list-inside list-disc space-y-2">
                     <li>Access your personal data</li>
                     <li>Correct inaccurate data</li>
-                    <li>Delete your account and data</li>
+                    <li>
+                      <a
+                        href="/delete-account"
+                        className="text-primary underline underline-offset-4"
+                      >
+                        Delete your account and data
+                      </a>
+                    </li>
                     <li>Export your data</li>
                   </ul>
                 </section>

--- a/frontend/src/features/settings/components/DeleteAccountForm.tsx
+++ b/frontend/src/features/settings/components/DeleteAccountForm.tsx
@@ -1,0 +1,101 @@
+import React, { useCallback, useState } from "react";
+
+import { ApiError } from "@/api/core";
+import { userApi } from "@/api/user";
+import { getButtonClasses } from "@/components/ui/Button";
+import Heading from "@/components/ui/Heading";
+import Panel from "@/components/ui/Panel";
+import { useLogout } from "@/hooks/auth/useAuthQueries";
+
+/** Typed exactly, or the button stays disabled. */
+const CONFIRM_WORD = "DELETE";
+
+/**
+ * Irreversible account deletion.
+ *
+ * Two deliberate choices:
+ *  - Confirmation is a typed word rather than an "Are you sure?" dialog. This
+ *    destroys every meal, weight entry and goal the person has, and a
+ *    misplaced tap should not be able to do that.
+ *  - A 409 from the server (active subscription) is surfaced verbatim, because
+ *    the server's message names where to go and cancel.
+ */
+const DeleteAccountForm: React.FC = () => {
+  const [confirmText, setConfirmText] = useState("");
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const logout = useLogout();
+
+  const canDelete = confirmText.trim() === CONFIRM_WORD && !isDeleting;
+
+  const handleDelete = useCallback(async () => {
+    if (!canDelete) return;
+    setIsDeleting(true);
+    setError(null);
+    try {
+      await userApi.deleteAccount();
+      // The account is gone, so the session is meaningless — clear it rather
+      // than leaving the app holding a token for a user that no longer exists.
+      logout.mutate();
+    } catch (deleteError) {
+      setError(
+        deleteError instanceof ApiError
+          ? deleteError.message
+          : "Could not delete your account. Please try again.",
+      );
+      setIsDeleting(false);
+    }
+  }, [canDelete, logout]);
+
+  return (
+    <Panel className="border-error/40">
+      <Heading level="panel" className="mb-2 text-error">
+        Delete account
+      </Heading>
+
+      <p className="mb-4 text-sm leading-relaxed text-muted">
+        This permanently deletes your account and everything in it — every
+        logged meal, your weight history, goals, macro targets, habits and saved
+        meals. It cannot be undone, and we cannot recover it for you.
+      </p>
+      <p className="mb-4 text-sm leading-relaxed text-muted">
+        If you want a copy of your data, export it as CSV before you continue.
+      </p>
+
+      <label
+        htmlFor="delete-confirm"
+        className="mb-2 block text-sm font-medium text-foreground"
+      >
+        Type <span className="font-semibold text-error">{CONFIRM_WORD}</span> to
+        confirm
+      </label>
+      <input
+        id="delete-confirm"
+        type="text"
+        value={confirmText}
+        onChange={(event) => setConfirmText(event.target.value)}
+        autoComplete="off"
+        aria-describedby={error ? "delete-error" : undefined}
+        className="mb-4 w-full max-w-xs rounded-control border border-border bg-surface-2 px-3 py-2 text-foreground"
+      />
+
+      {error ? (
+        <p id="delete-error" role="alert" className="mb-4 text-sm text-error">
+          {error}
+        </p>
+      ) : null}
+
+      <button
+        type="button"
+        onClick={handleDelete}
+        disabled={!canDelete}
+        aria-label="Permanently delete my account"
+        className={getButtonClasses("danger", "md", !canDelete)}
+      >
+        {isDeleting ? "Deleting…" : "Delete my account"}
+      </button>
+    </Panel>
+  );
+};
+
+export default DeleteAccountForm;

--- a/frontend/src/features/settings/pages/SettingsPage.tsx
+++ b/frontend/src/features/settings/pages/SettingsPage.tsx
@@ -25,6 +25,7 @@ import {
   ProfileForm,
   SettingsLoadingSkeleton,
 } from "@/features/settings/components";
+import DeleteAccountForm from "@/features/settings/components/DeleteAccountForm";
 import { useBeforeUnload, useMutationErrorHandler } from "@/hooks";
 import { useLogout } from "@/hooks/auth/useAuthQueries";
 import { useSaveSettings, useSettings } from "@/hooks/queries/useSettings";
@@ -312,7 +313,10 @@ export default function SettingsPage() {
             )}
             {activeTab === "data" && (
               <PageTransition key="data">
-                <DataImporter />
+                <div className="space-y-6">
+                  <DataImporter />
+                  <DeleteAccountForm />
+                </div>
               </PageTransition>
             )}
             {BILLING_TAB_ENABLED && activeTab === "billing" && (

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as PricingRouteImport } from './routes/pricing'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as HomeRouteImport } from './routes/home'
 import { Route as GoalsRouteImport } from './routes/goals'
+import { Route as DeleteAccountRouteImport } from './routes/delete-account'
 import { Route as AuthReadyRouteImport } from './routes/auth-ready'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ToolsIndexRouteImport } from './routes/tools/index'
@@ -94,6 +95,11 @@ const HomeRoute = HomeRouteImport.update({
 const GoalsRoute = GoalsRouteImport.update({
   id: '/goals',
   path: '/goals',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DeleteAccountRoute = DeleteAccountRouteImport.update({
+  id: '/delete-account',
+  path: '/delete-account',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthReadyRoute = AuthReadyRouteImport.update({
@@ -171,6 +177,7 @@ const BlogSlugRoute = BlogSlugRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/auth-ready': typeof AuthReadyRoute
+  '/delete-account': typeof DeleteAccountRoute
   '/goals': typeof GoalsRoute
   '/home': typeof HomeRoute
   '/login': typeof LoginRoute
@@ -199,6 +206,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/auth-ready': typeof AuthReadyRoute
+  '/delete-account': typeof DeleteAccountRoute
   '/goals': typeof GoalsRoute
   '/home': typeof HomeRoute
   '/login': typeof LoginRoute
@@ -228,6 +236,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/auth-ready': typeof AuthReadyRoute
+  '/delete-account': typeof DeleteAccountRoute
   '/goals': typeof GoalsRoute
   '/home': typeof HomeRoute
   '/login': typeof LoginRoute
@@ -258,6 +267,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/auth-ready'
+    | '/delete-account'
     | '/goals'
     | '/home'
     | '/login'
@@ -286,6 +296,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/auth-ready'
+    | '/delete-account'
     | '/goals'
     | '/home'
     | '/login'
@@ -314,6 +325,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/auth-ready'
+    | '/delete-account'
     | '/goals'
     | '/home'
     | '/login'
@@ -343,6 +355,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AuthReadyRoute: typeof AuthReadyRoute
+  DeleteAccountRoute: typeof DeleteAccountRoute
   GoalsRoute: typeof GoalsRoute
   HomeRoute: typeof HomeRoute
   LoginRoute: typeof LoginRoute
@@ -455,6 +468,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof GoalsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/delete-account': {
+      id: '/delete-account'
+      path: '/delete-account'
+      fullPath: '/delete-account'
+      preLoaderRoute: typeof DeleteAccountRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/auth-ready': {
       id: '/auth-ready'
       path: '/auth-ready'
@@ -559,6 +579,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthReadyRoute: AuthReadyRoute,
+  DeleteAccountRoute: DeleteAccountRoute,
   GoalsRoute: GoalsRoute,
   HomeRoute: HomeRoute,
   LoginRoute: LoginRoute,

--- a/frontend/src/routes/delete-account.tsx
+++ b/frontend/src/routes/delete-account.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { createFileRoute } from "@tanstack/react-router";
+
+import { PublicSelfHostedGate } from "@/routes/-PublicSelfHostedGate";
+
+const DeleteAccountPage = React.lazy(
+  () => import("@/features/landing/pages/DeleteAccountPage"),
+);
+
+export const Route = createFileRoute("/delete-account")({
+  component: () => (
+    <PublicSelfHostedGate>
+      <DeleteAccountPage />
+    </PublicSelfHostedGate>
+  ),
+});


### PR DESCRIPTION
## Why

Google Play requires a **URL where users can request deletion** of their account and data, reachable *without installing the app*. We had neither that URL nor any deletion mechanism — while `PrivacyPolicyPage` already promised *"Delete your account and data"* under Your Rights. This closes both the Play requirement and the gap between what we promise and what exists.

## Backend

`DELETE /api/user/me` deletes the caller's account.

- **Relies on cascades.** All 12 user-owned tables carry `ON DELETE CASCADE` on `user_id`, so removing the `users` row takes the food log, weight history, goals, macro targets, habits, saved meals, subscriptions and sessions with it. Deliberate: enumerating tables by hand rots the moment someone adds one.
- **Refuses with 409 while `subscription_status = 'pro'`.** Play subscriptions can't be cancelled server-side by us, so deleting the account would leave someone billed with no account behind it. The error names where to go and cancel.
- **Deletes the Clerk identity first, aborts if that fails.** The other order orphans a Clerk user whose local account is already gone — leaving the person unable to sign in *or* retry.

## Frontend

**Settings → Data** gains a Delete account panel. Confirmation is a typed word rather than an "Are you sure?" dialog, because this destroys every meal and weight entry someone has and a mis-tap shouldn't be able to.

**New public `/delete-account` page** — the URL for Play. Documents the in-app route, an email fallback for people who can no longer sign in, exactly what's deleted, and what's retained (payment records where tax law requires, short-lived server logs). Pre-rendered and in the sitemap so it resolves without JS for a reviewer or crawler.

The privacy policy's existing bullet now links to it, so the promise points at the mechanism.

## Tests

5 new backend tests, covering the parts worth pinning:

| Case | Asserts |
|---|---|
| Happy path | exactly one `DELETE FROM users`, cascades do the rest |
| Active subscription | 409 **and nothing deleted** |
| Missing account | 404, nothing deleted |
| Clerk ordering | Clerk identity removed before the local row |
| Clerk failure | local row **survives**, so the user can retry |

## Verification

- backend **458 tests** (46 files)
- frontend **879 tests** (150 files)
- typecheck clean, lint **0 errors**
- UI budgets unchanged — `boldOutsideScale` back at 63 after routing the new `h1` through `Heading` instead of a raw `font-bold`
- `bun run build` pre-renders 36 pages (was 34) including `/delete-account`

## Follow-up worth considering

Deletion is immediate and total. If you'd rather have a grace period (soft-delete, purge after 30 days), that's a different design and worth deciding deliberately — Play accepts either.