### PR TITLE
feat(account): offer a CSV download inside the delete panel

### DIFF
--- a/frontend/src/features/settings/components/DeleteAccountForm.tsx
+++ b/frontend/src/features/settings/components/DeleteAccountForm.tsx
@@ -1,11 +1,15 @@
 import React, { useCallback, useState } from "react";
 
 import { ApiError } from "@/api/core";
+import { macrosApi } from "@/api/macros";
 import { userApi } from "@/api/user";
 import { getButtonClasses } from "@/components/ui/Button";
 import Heading from "@/components/ui/Heading";
 import Panel from "@/components/ui/Panel";
+import { downloadHistoryCsv } from "@/features/macroTracking/utils/historyExport";
 import { useLogout } from "@/hooks/auth/useAuthQueries";
+import { cn } from "@/lib/classnameUtilities";
+import type { MacroEntry } from "@/types/macro";
 
 /** Typed exactly, or the button stays disabled. */
 const CONFIRM_WORD = "DELETE";
@@ -23,8 +27,24 @@ const CONFIRM_WORD = "DELETE";
 const DeleteAccountForm: React.FC = () => {
   const [confirmText, setConfirmText] = useState("");
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const logout = useLogout();
+
+  // Same call and same CSV writer the Entry History export uses, rather than a
+  // second implementation that could drift from it.
+  const handleExport = useCallback(async () => {
+    setIsExporting(true);
+    setError(null);
+    try {
+      const response = await macrosApi.getAllHistory();
+      downloadHistoryCsv(response.entries as MacroEntry[]);
+    } catch {
+      setError("Could not export your history. Try again before deleting.");
+    } finally {
+      setIsExporting(false);
+    }
+  }, []);
 
   const canDelete = confirmText.trim() === CONFIRM_WORD && !isDeleting;
 
@@ -59,8 +79,22 @@ const DeleteAccountForm: React.FC = () => {
         meals. It cannot be undone, and we cannot recover it for you.
       </p>
       <p className="mb-4 text-sm leading-relaxed text-muted">
-        If you want a copy of your data, export it as CSV before you continue.
+        If you want a copy of your data, download it first. Once the account is
+        gone we cannot recover it for you.
       </p>
+
+      <button
+        type="button"
+        onClick={handleExport}
+        disabled={isExporting || isDeleting}
+        aria-label="Download my history as CSV before deleting"
+        className={cn(
+          getButtonClasses("secondary", "md", isExporting || isDeleting),
+          "mb-6",
+        )}
+      >
+        {isExporting ? "Preparing download…" : "Download my data (CSV)"}
+      </button>
 
       <label
         htmlFor="delete-confirm"


### PR DESCRIPTION
Follow-up to #162, and the outcome of deciding **against** a 30-day grace period.

## Why not a grace period

Making deletion recoverable means the user must be able to sign back in to cancel it — so you cannot delete the Clerk identity. For those 30 days:

- the account still exists in Clerk, so their email stays taken and they can't re-register
- their health data is still on our servers *after* they asked us to delete it
- the Data safety declaration would have to say so
- `clerk-webhook.ts` `handleUserDeleted` hard-deletes on `user.deleted`, so a stray dashboard action would blow away someone mid-grace

Plus the build: a `deleted_at` column, filtering on every user-scoped query, and a purge job — and there's **no scheduler in the backend** today.

Neither Play nor GDPR requires a grace period, and immediate deletion is the stronger privacy position: we actually delete when asked.

## What this does instead

The risk worth mitigating is **regret**, not mis-taps — deletion already requires signing in, navigating to Settings → Data, and typing `DELETE` exactly. So the last thing someone sees before destroying months of logs is an offer to keep a copy:

**"Download my data (CSV)"**, right above the delete button.

Reuses `macrosApi.getAllHistory()` and `downloadHistoryCsv()` — the same call and CSV writer behind the Entry History export — rather than a second implementation that would drift from it. Export failures surface in the same error slot and don't block deletion.

## Verification

- frontend **879 tests** pass (150 files)
- typecheck clean, lint **0 errors**
- UI budgets unchanged at 63