### PR TITLE
fix(settings): move account deletion to Security, and name the tab

### DIFF
--- a/frontend/src/features/landing/pages/DeleteAccountPage.tsx
+++ b/frontend/src/features/landing/pages/DeleteAccountPage.tsx
@@ -52,7 +52,7 @@ const DeleteAccountPage: React.FC = () => {
             <ol className="list-inside list-decimal space-y-2 text-muted">
               <li>Open {APP_NAME} and sign in.</li>
               <li>
-                Go to <strong>Settings</strong>.
+                Go to <strong>Settings → Security</strong>.
               </li>
               <li>
                 Choose <strong>Delete account</strong> and confirm.

--- a/frontend/src/features/settings/pages/SettingsPage.tsx
+++ b/frontend/src/features/settings/pages/SettingsPage.tsx
@@ -313,10 +313,7 @@ export default function SettingsPage() {
             )}
             {activeTab === "data" && (
               <PageTransition key="data">
-                <div className="space-y-6">
-                  <DataImporter />
-                  <DeleteAccountForm />
-                </div>
+                <DataImporter />
               </PageTransition>
             )}
             {BILLING_TAB_ENABLED && activeTab === "billing" && (
@@ -331,7 +328,10 @@ export default function SettingsPage() {
             )}
             {activeTab === "security" && (
               <PageTransition key="security">
-                <ChangePasswordForm />
+                <div className="space-y-6">
+                  <ChangePasswordForm />
+                  <DeleteAccountForm />
+                </div>
               </PageTransition>
             )}
           </AnimatePresence>


### PR DESCRIPTION
## Problem

In #162 I put the delete-account panel in the tab labelled **"Import Data"**. That's the last place anyone would look for it — the user couldn't find the button, and a Play reviewer following our own `/delete-account` page ("Go to Settings") would have hit the same wall.

## Fix

Moved to **Security**, beside the password form. That's where people expect destructive account actions, and it groups the two account-level concerns: credentials and account existence.

Also names the exact tab on the public page — **"Settings → Security"** instead of just "Settings", since that vagueness is what caused the hunt.

## Why not rename the tab to "Data"

The other option was renaming "Import Data" → "Data" and leaving deletion there, on the grounds it'd cover import, export and deletion. But **export isn't in that tab** — CSV export lives on Home (Entry History) and Analytics. The rename would have implied a capability that isn't there, fixing one naming problem by creating a smaller one.

## Reach unchanged

`profile`, `data` and `security` are always present; only `billing` (managed billing mode) and `accounts` (Clerk auth mode) are conditional. So this doesn't change who can get to deletion.

## Verification

- frontend **879 tests** pass (150 files)
- typecheck clean, lint **0 errors**
- UI budgets unchanged at 63