### PR TITLE
fix(settings): slim the delete panel, drop em-dashes, fix a full-width button

### DIFF
--- a/frontend/src/features/landing/pages/DeleteAccountPage.tsx
+++ b/frontend/src/features/landing/pages/DeleteAccountPage.tsx
@@ -86,7 +86,10 @@ const DeleteAccountPage: React.FC = () => {
             </p>
             <ul className="list-inside list-disc space-y-2 text-muted">
               <li>Your account, name and email address</li>
-              <li>Your profile details — date of birth, height, weight, gender, activity level</li>
+              <li>
+                Your profile details: date of birth, height, weight, gender and
+                activity level
+              </li>
               <li>Every logged meal and its macros</li>
               <li>Your weight history, weight goals and macro targets</li>
               <li>Your habits and saved meals</li>
@@ -99,8 +102,8 @@ const DeleteAccountPage: React.FC = () => {
               What we keep, and for how long
             </h2>
             <p className="mb-4 leading-relaxed text-muted">
-              We keep records of completed payments where the law requires it —
-              tax and accounting rules oblige us to retain transaction records,
+              We keep records of completed payments where the law requires it.
+              Tax and accounting rules oblige us to retain transaction records,
               typically for several years depending on jurisdiction. Those
               records are held by our payment providers (Google Play or Stripe)
               and are not linked back to a deleted account beyond what those

--- a/frontend/src/features/settings/components/DeleteAccountForm.tsx
+++ b/frontend/src/features/settings/components/DeleteAccountForm.tsx
@@ -8,7 +8,6 @@ import Heading from "@/components/ui/Heading";
 import Panel from "@/components/ui/Panel";
 import { downloadHistoryCsv } from "@/features/macroTracking/utils/historyExport";
 import { useLogout } from "@/hooks/auth/useAuthQueries";
-import { cn } from "@/lib/classnameUtilities";
 import type { MacroEntry } from "@/types/macro";
 
 /** Typed exactly, or the button stays disabled. */
@@ -54,7 +53,7 @@ const DeleteAccountForm: React.FC = () => {
     setError(null);
     try {
       await userApi.deleteAccount();
-      // The account is gone, so the session is meaningless — clear it rather
+      // The account is gone, so the session is meaningless. Clear it rather
       // than leaving the app holding a token for a user that no longer exists.
       logout.mutate();
     } catch (deleteError) {
@@ -74,60 +73,58 @@ const DeleteAccountForm: React.FC = () => {
       </Heading>
 
       <p className="mb-4 text-sm leading-relaxed text-muted">
-        This permanently deletes your account and everything in it — every
-        logged meal, your weight history, goals, macro targets, habits and saved
-        meals. It cannot be undone, and we cannot recover it for you.
-      </p>
-      <p className="mb-4 text-sm leading-relaxed text-muted">
-        If you want a copy of your data, download it first. Once the account is
-        gone we cannot recover it for you.
+        Deletes your account and all your data: meals, weight history, goals,
+        targets, habits and saved meals. This cannot be undone.
       </p>
 
-      <button
-        type="button"
-        onClick={handleExport}
-        disabled={isExporting || isDeleting}
-        aria-label="Download my history as CSV before deleting"
-        className={cn(
-          getButtonClasses("secondary", "md", isExporting || isDeleting),
-          "mb-6",
-        )}
-      >
-        {isExporting ? "Preparing download…" : "Download my data (CSV)"}
-      </button>
+      {/* One row: take a copy, confirm, delete. Previously five stacked blocks,
+          which made a routine settings panel look like a wizard. */}
+      <div className="flex flex-wrap items-end gap-3">
+        <button
+          type="button"
+          onClick={handleExport}
+          disabled={isExporting || isDeleting}
+          aria-label="Download my data as CSV before deleting"
+          className={getButtonClasses("secondary", "md", false)}
+        >
+          {isExporting ? "Preparing…" : "Download a copy (CSV)"}
+        </button>
 
-      <label
-        htmlFor="delete-confirm"
-        className="mb-2 block text-sm font-medium text-foreground"
-      >
-        Type <span className="font-semibold text-error">{CONFIRM_WORD}</span> to
-        confirm
-      </label>
-      <input
-        id="delete-confirm"
-        type="text"
-        value={confirmText}
-        onChange={(event) => setConfirmText(event.target.value)}
-        autoComplete="off"
-        aria-describedby={error ? "delete-error" : undefined}
-        className="mb-4 w-full max-w-xs rounded-control border border-border bg-surface-2 px-3 py-2 text-foreground"
-      />
+        <div>
+          <label
+            htmlFor="delete-confirm"
+            className="mb-1 block text-xs text-muted"
+          >
+            Type <span className="font-semibold text-error">{CONFIRM_WORD}</span>{" "}
+            to confirm
+          </label>
+          <input
+            id="delete-confirm"
+            type="text"
+            value={confirmText}
+            onChange={(event) => setConfirmText(event.target.value)}
+            autoComplete="off"
+            aria-describedby={error ? "delete-error" : undefined}
+            className="w-32 rounded-control border border-border bg-surface-2 px-3 py-2 text-foreground"
+          />
+        </div>
+
+        <button
+          type="button"
+          onClick={handleDelete}
+          disabled={!canDelete}
+          aria-label="Permanently delete my account"
+          className={getButtonClasses("danger", "md", false)}
+        >
+          {isDeleting ? "Deleting…" : "Delete my account"}
+        </button>
+      </div>
 
       {error ? (
-        <p id="delete-error" role="alert" className="mb-4 text-sm text-error">
+        <p id="delete-error" role="alert" className="mt-3 text-sm text-error">
           {error}
         </p>
       ) : null}
-
-      <button
-        type="button"
-        onClick={handleDelete}
-        disabled={!canDelete}
-        aria-label="Permanently delete my account"
-        className={getButtonClasses("danger", "md", !canDelete)}
-      >
-        {isDeleting ? "Deleting…" : "Delete my account"}
-      </button>
     </Panel>
   );
 };


### PR DESCRIPTION
Three fixes, all of them mine from #162 and #163.

## Copy said the same thing twice

Before:
> This permanently deletes your account and everything in it (…) **It cannot be undone, and we cannot recover it for you.**
> If you want a copy of your data, download it first. **Once the account is gone we cannot recover it for you.**

After:
> Deletes your account and all your data: meals, weight history, goals, targets, habits and saved meals. This cannot be undone.

One sentence, names what goes, no duplicate reassurance. Em-dashes removed here and in the public page body copy.

## Layout was five stacked blocks

Two paragraphs, a button, a label, an input, another button, each on its own line. A routine settings panel read like a wizard.

Now one row: **Download a copy (CSV)** → confirm field → **Delete my account**. Roughly half the height, and it wraps on narrow screens.

## The delete button was full width

`getButtonClasses(variant, size, fullWidth, className)` and I was passing `!canDelete` into the **fullWidth** slot, so the button stretched across the panel whenever it was disabled. Now passing `false`; the disabled state comes from the `disabled` attribute, as it always did.

## Left alone deliberately

The page title `Delete your account — MacroTrackr` follows the site-wide convention. There are **101** em-dashes in `frontend/src` and 20 more in `prerender.mjs`, including 10 page titles, so purging them repo-wide is a separate change with SEO-visible effects. Happy to do it as its own PR.

## Verification

- frontend **879 tests** pass (150 files)
- typecheck clean, lint **0 errors**
- UI budgets unchanged at 63