### PR TITLE
fix(auth): send legal consent, and stop calling correct codes wrong

### DIFF
--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -76,6 +76,13 @@ export async function signUpViaUI(page: Page, email: string, password: string): 
   const passwordInput = page.locator('input[type="password"], input[name="password"]').first()
   await passwordInput.fill(password)
 
+  // Legal consent is a required sign-up field on the Clerk instance, so the
+  // submit stays disabled until it is ticked.
+  const consentCheckbox = page.locator('input[name="legalAccepted"]').first()
+  if (await consentCheckbox.isVisible().catch(() => false)) {
+    await consentCheckbox.check()
+  }
+
   // Submit form
   const submitButton = page.locator('button[type="submit"], button:has-text("Create Account")').first()
   await submitButton.click()

--- a/frontend/src/features/auth/components/ClerkSignInForm.tsx
+++ b/frontend/src/features/auth/components/ClerkSignInForm.tsx
@@ -9,12 +9,14 @@ import TextField from "@/components/form/TextField";
 import Button from "@/components/ui/Button";
 import { BiometricOptInCheckbox } from "@/features/auth/components/BiometricOptInCheckbox";
 import { BiometricSignInButton } from "@/features/auth/components/BiometricSignInButton";
+import { LegalLink } from "@/features/auth/components/LegalLink";
 import { SecondFactorChallenge } from "@/features/auth/components/SecondFactorChallenge";
 import {
   SocialAuthOptions,
   type SocialAuthStrategy,
 } from "@/features/auth/components/SocialAuthOptions";
 import { AUTH_NOT_READY_MESSAGE } from "@/features/auth/constants";
+import { rememberLegalConsent } from "@/features/auth/utils/legalConsent";
 import { getAuthLinkIntent } from "@/features/auth/utils/linkIntent";
 import {
   buildSocialAuthRedirectUrls,
@@ -315,6 +317,10 @@ export function ClerkSignInForm({
       return;
     }
 
+    // These buttons fall through to sign-up for anyone without an account, and
+    // consent is presented beneath them. The redirect cannot carry the flag, so
+    // record it for /sso-callback.
+    rememberLegalConsent();
     setLoadingStrategy(strategy);
 
     try {
@@ -391,6 +397,7 @@ export function ClerkSignInForm({
               strategy,
               redirectUrl,
               actionCompleteRedirectUrl: redirectUrlComplete,
+              legalAccepted: true,
             });
 
             externalUrl =
@@ -733,6 +740,13 @@ export function ClerkSignInForm({
               onContinueWithEmail={() => setIsEmailMode(true)}
               loadingStrategy={loadingStrategy}
             />
+
+            <p className="mt-4 text-center text-xs text-muted">
+              A provider creates an account if you do not have one, which means
+              you agree to our{" "}
+              <LegalLink to="/terms">Terms of Service</LegalLink> and{" "}
+              <LegalLink to="/privacy">Privacy Policy</LegalLink>.
+            </p>
           </motion.div>
         )}
       </AnimatePresence>

--- a/frontend/src/features/auth/components/ClerkSignUpForm.legalConsent.test.tsx
+++ b/frontend/src/features/auth/components/ClerkSignUpForm.legalConsent.test.tsx
@@ -1,0 +1,378 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ClerkSignUpForm } from "@/features/auth/components/ClerkSignUpForm";
+
+// Hoisted so the vi.mock factories below can reference them; vi.mock is
+// lifted above module-level consts.
+const {
+  signUpCreate,
+  signUpUpdate,
+  prepareEmailAddressVerification,
+  attemptEmailAddressVerification,
+  setActive,
+  navigate,
+  showNotification,
+  signUpState,
+} = vi.hoisted(() => ({
+  signUpCreate: vi.fn(),
+  signUpUpdate: vi.fn(),
+  prepareEmailAddressVerification: vi.fn(),
+  attemptEmailAddressVerification: vi.fn(),
+  setActive: vi.fn(),
+  navigate: vi.fn(),
+  showNotification: vi.fn(),
+  signUpState: {
+    status: null as string | null,
+    emailAddress: null as string | null,
+    unverifiedFields: [] as string[],
+    missingFields: [] as string[],
+    abandonAt: null as number | null,
+    createdSessionId: null as string | null,
+  },
+}));
+
+// AnimatePresence mode="wait" defers mounting the next child until the exit
+// animation resolves, which never happens under jsdom. Render children
+// directly so the flow can be driven synchronously.
+vi.mock("motion/react", () => {
+  const components = new Map<string, React.FC<Record<string, unknown>>>();
+
+  return {
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+    motion: new Proxy({} as Record<string, React.FC>, {
+      get: (_target, tag: string) => {
+        const cached = components.get(tag);
+        if (cached) {
+          return cached;
+        }
+
+        const Component = ({
+          children,
+          ...properties
+        }: React.PropsWithChildren<Record<string, unknown>>) => {
+          const {
+            initial: _initial,
+            animate: _animate,
+            exit: _exit,
+            transition: _transition,
+            ...domProps
+          } = properties;
+
+          return <div {...domProps}>{children}</div>;
+        };
+        Component.displayName = `motion.${tag}`;
+        components.set(tag, Component);
+
+        return Component;
+      },
+    }),
+  };
+});
+
+vi.mock("@clerk/react", () => ({
+  useClerk: () => ({}),
+}));
+
+vi.mock("@clerk/react/legacy", () => ({
+  useSignUp: () => ({
+    isLoaded: true,
+    setActive,
+    signUp: {
+      get status() {
+        return signUpState.status;
+      },
+      get emailAddress() {
+        return signUpState.emailAddress;
+      },
+      get unverifiedFields() {
+        return signUpState.unverifiedFields;
+      },
+      get missingFields() {
+        return signUpState.missingFields;
+      },
+      get abandonAt() {
+        return signUpState.abandonAt;
+      },
+      get createdSessionId() {
+        return signUpState.createdSessionId;
+      },
+      create: signUpCreate,
+      update: signUpUpdate,
+      prepareEmailAddressVerification,
+      attemptEmailAddressVerification,
+    },
+  }),
+  useSignIn: () => ({ isLoaded: true, setActive, signIn: { create: vi.fn() } }),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigate,
+}));
+
+vi.mock("@/store/store", () => ({
+  useStore: () => ({ showNotification }),
+}));
+
+vi.mock("@/lib/productAnalytics", () => ({
+  useProductAnalytics: () => ({ capture: vi.fn() }),
+}));
+
+vi.mock("@/services/native/googleAuth", () => ({
+  exchangeNativeGoogleTokenWithClerk: vi.fn(),
+  nativeGoogleSignIn: vi.fn(),
+}));
+
+vi.mock("@/services/native/platform", () => ({
+  isNativePlatform: () => false,
+}));
+
+function renderForm() {
+  render(<ClerkSignUpForm onSwitchToSignIn={vi.fn()} redirectTo="/home" />);
+}
+
+async function fillSignUpForm(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(
+    screen.getByRole("button", { name: /continue with email/i }),
+  );
+  await user.type(screen.getByLabelText(/first name/i), "Ada");
+  await user.type(screen.getByLabelText(/last name/i), "Lovelace");
+  await user.type(screen.getByLabelText(/^email$/i), "ada@example.com");
+  await user.type(screen.getByLabelText(/^password$/i), "correct-horse");
+}
+
+async function acceptTerms(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("checkbox", { name: /i agree to the/i }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sessionStorage.clear();
+  signUpState.status = null;
+  signUpState.emailAddress = null;
+  signUpState.unverifiedFields = [];
+  signUpState.missingFields = [];
+  signUpState.abandonAt = null;
+  signUpState.createdSessionId = null;
+});
+
+describe("ClerkSignUpForm legal consent", () => {
+  it("sends legalAccepted so the attempt is not left short a required field", async () => {
+    const user = userEvent.setup();
+    signUpCreate.mockResolvedValue({ status: "missing_requirements" });
+    prepareEmailAddressVerification.mockResolvedValue({});
+
+    renderForm();
+    await fillSignUpForm(user);
+    await acceptTerms(user);
+    await user.click(screen.getByRole("button", { name: /create account/i }));
+
+    await waitFor(() => expect(signUpCreate).toHaveBeenCalledTimes(1));
+    expect(signUpCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAddress: "ada@example.com",
+        legalAccepted: true,
+      }),
+    );
+  });
+
+  it("holds the submit until the terms are accepted", async () => {
+    const user = userEvent.setup();
+
+    renderForm();
+    await fillSignUpForm(user);
+
+    expect(
+      screen.getByRole("button", { name: /create account/i }),
+    ).toBeDisabled();
+  });
+
+  it("does not blame the code when a correct one leaves another field missing", async () => {
+    const user = userEvent.setup();
+    signUpCreate.mockResolvedValue({ status: "missing_requirements" });
+    prepareEmailAddressVerification.mockResolvedValue({});
+    // Clerk accepted the code: a wrong one throws. The attempt is still short
+    // of legal consent, which is what stranded the user on this screen.
+    attemptEmailAddressVerification.mockResolvedValue({
+      status: "missing_requirements",
+      missingFields: ["legal_accepted"],
+      unverifiedFields: [],
+      update: signUpUpdate,
+    });
+    signUpUpdate.mockResolvedValue({
+      status: "complete",
+      createdSessionId: "sess_1",
+      missingFields: [],
+      unverifiedFields: [],
+    });
+
+    renderForm();
+    await fillSignUpForm(user);
+    await acceptTerms(user);
+    await user.click(screen.getByRole("button", { name: /create account/i }));
+
+    await screen.findByRole("heading", { name: /verify your email/i });
+    await user.type(screen.getByLabelText(/verification code/i), "123456");
+    await user.click(screen.getByRole("button", { name: /verify email/i }));
+
+    await waitFor(() =>
+      expect(signUpUpdate).toHaveBeenCalledWith({ legalAccepted: true }),
+    );
+    expect(showNotification).not.toHaveBeenCalledWith(
+      expect.stringMatching(/invalid verification code/i),
+      "error",
+    );
+    await waitFor(() =>
+      expect(setActive).toHaveBeenCalledWith({ session: "sess_1" }),
+    );
+  });
+
+  it("keeps the digits when a pasted code brings whitespace with it", async () => {
+    const user = userEvent.setup();
+    signUpCreate.mockResolvedValue({ status: "missing_requirements" });
+    prepareEmailAddressVerification.mockResolvedValue({});
+    attemptEmailAddressVerification.mockResolvedValue({
+      status: "complete",
+      createdSessionId: "sess_2",
+      missingFields: [],
+      unverifiedFields: [],
+    });
+
+    renderForm();
+    await fillSignUpForm(user);
+    await acceptTerms(user);
+    await user.click(screen.getByRole("button", { name: /create account/i }));
+
+    await screen.findByRole("heading", { name: /verify your email/i });
+    await user.type(screen.getByLabelText(/verification code/i), " 123 456 ");
+    await user.click(screen.getByRole("button", { name: /verify email/i }));
+
+    await waitFor(() =>
+      expect(attemptEmailAddressVerification).toHaveBeenCalledWith({
+        code: "123456",
+      }),
+    );
+  });
+
+  it("carries on when the code already landed on an earlier submit", async () => {
+    const user = userEvent.setup();
+    signUpCreate.mockResolvedValue({ status: "missing_requirements" });
+    prepareEmailAddressVerification.mockResolvedValue({});
+    attemptEmailAddressVerification.mockRejectedValue({
+      errors: [{ code: "verification_already_verified" }],
+    });
+    signUpState.status = "complete";
+
+    renderForm();
+    await fillSignUpForm(user);
+    await acceptTerms(user);
+    await user.click(screen.getByRole("button", { name: /create account/i }));
+
+    await screen.findByRole("heading", { name: /verify your email/i });
+    signUpState.createdSessionId = "sess_3";
+    await user.type(screen.getByLabelText(/verification code/i), "123456");
+    await user.click(screen.getByRole("button", { name: /verify email/i }));
+
+    await waitFor(() =>
+      expect(setActive).toHaveBeenCalledWith({ session: "sess_3" }),
+    );
+  });
+
+  it("names an expired code instead of calling it wrong", async () => {
+    const user = userEvent.setup();
+    signUpCreate.mockResolvedValue({ status: "missing_requirements" });
+    prepareEmailAddressVerification.mockResolvedValue({});
+    attemptEmailAddressVerification.mockRejectedValue({
+      errors: [{ code: "verification_expired" }],
+    });
+
+    renderForm();
+    await fillSignUpForm(user);
+    await acceptTerms(user);
+    await user.click(screen.getByRole("button", { name: /create account/i }));
+
+    await screen.findByRole("heading", { name: /verify your email/i });
+    await user.type(screen.getByLabelText(/verification code/i), "123456");
+    await user.click(screen.getByRole("button", { name: /verify email/i }));
+
+    await waitFor(() =>
+      expect(showNotification).toHaveBeenCalledWith(
+        expect.stringMatching(/expired/i),
+        "error",
+      ),
+    );
+  });
+});
+
+describe("ClerkSignUpForm pending verification", () => {
+  it("reopens the verify screen for an attempt left unverified", async () => {
+    signUpState.status = "missing_requirements";
+    signUpState.emailAddress = "ada@example.com";
+    signUpState.unverifiedFields = ["email_address"];
+
+    renderForm();
+
+    await screen.findByRole("heading", { name: /verify your email/i });
+    expect(screen.getByText(/ada@example\.com/)).toBeInTheDocument();
+  });
+
+  it("leaves an abandoned attempt alone", async () => {
+    signUpState.status = "missing_requirements";
+    signUpState.emailAddress = "ada@example.com";
+    signUpState.unverifiedFields = ["email_address"];
+    signUpState.abandonAt = Date.now() - 1000;
+
+    renderForm();
+
+    expect(
+      screen.queryByRole("heading", { name: /verify your email/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("asks for consent an older attempt never captured", async () => {
+    const user = userEvent.setup();
+    signUpState.status = "missing_requirements";
+    signUpState.emailAddress = "ada@example.com";
+    signUpState.unverifiedFields = ["email_address"];
+    signUpState.missingFields = ["legal_accepted"];
+
+    renderForm();
+
+    await screen.findByRole("heading", { name: /verify your email/i });
+    expect(
+      screen.getByRole("button", { name: /verify email/i }),
+    ).toBeDisabled();
+
+    await user.click(screen.getByRole("checkbox", { name: /i agree to the/i }));
+
+    expect(
+      screen.getByRole("button", { name: /verify email/i }),
+    ).not.toBeDisabled();
+    // The box stays put once ticked; removing it would move the layout under
+    // the pointer and leave no record of what was agreed to.
+    expect(
+      screen.getByRole("checkbox", { name: /i agree to the/i }),
+    ).toBeChecked();
+  });
+
+  it("offers a fresh code, because the old one expires", async () => {
+    const user = userEvent.setup();
+    signUpState.status = "missing_requirements";
+    signUpState.emailAddress = "ada@example.com";
+    signUpState.unverifiedFields = ["email_address"];
+    prepareEmailAddressVerification.mockResolvedValue({});
+
+    renderForm();
+
+    await user.click(
+      await screen.findByRole("button", { name: /resend code/i }),
+    );
+
+    await waitFor(() =>
+      expect(prepareEmailAddressVerification).toHaveBeenCalledWith({
+        strategy: "email_code",
+      }),
+    );
+  });
+});

--- a/frontend/src/features/auth/components/ClerkSignUpForm.tsx
+++ b/frontend/src/features/auth/components/ClerkSignUpForm.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Browser } from "@capacitor/browser";
 import { useClerk } from "@clerk/react";
 import { useSignIn, useSignUp } from "@clerk/react/legacy";
@@ -9,18 +9,27 @@ import { AnimatePresence, motion } from "motion/react";
 import TextField from "@/components/form/TextField";
 import Button from "@/components/ui/Button";
 import { CalorieIcon } from "@/components/ui/Icons";
+import { LegalConsentCheckbox } from "@/features/auth/components/LegalConsentCheckbox";
 import {
   SocialAuthOptions,
   type SocialAuthStrategy,
 } from "@/features/auth/components/SocialAuthOptions";
 import { AUTH_NOT_READY_MESSAGE } from "@/features/auth/constants";
 import {
+  forgetLegalConsent,
+  isMissingLegalConsent,
+  rememberLegalConsent,
+} from "@/features/auth/utils/legalConsent";
+import {
   buildSocialAuthRedirectUrls,
   encodeAuthRedirect,
   normalizeAuthRedirect,
   shouldBypassSyncForRedirect,
 } from "@/features/auth/utils/redirect";
-import { resolveSocialAuthError } from "@/features/auth/utils/socialAuth";
+import {
+  extractClerkError,
+  resolveSocialAuthError,
+} from "@/features/auth/utils/socialAuth";
 import { logger } from "@/lib/logger";
 import { useProductAnalytics } from "@/lib/productAnalytics";
 import {
@@ -29,6 +38,37 @@ import {
 } from "@/services/native/googleAuth";
 import { isNativePlatform } from "@/services/native/platform";
 import { useStore } from "@/store/store";
+
+const RESEND_COOLDOWN_SECONDS = 30;
+
+const VERIFICATION_CODE_LENGTH = 6;
+
+// Pasting a code out of an email routinely brings whitespace with it, and the
+// autofill for one-time-code can bring a non-breaking space. Keep the digits.
+function sanitizeVerificationCode(value: string): string {
+  return value.replaceAll(/\D/gu, "").slice(0, VERIFICATION_CODE_LENGTH);
+}
+
+const CONSENT_REQUIRED_MESSAGE =
+  "Please accept the Terms of Service and Privacy Policy to create an account.";
+
+function resolveVerificationErrorMessage(
+  errorCode: string | undefined,
+  message: string | undefined,
+): string {
+  switch (errorCode) {
+    case "form_code_incorrect":
+    case "verification_failed": {
+      return "That code doesn't match. Check the email and try again, or resend a new code.";
+    }
+    case "verification_expired": {
+      return "That code has expired. Send a new one and try again.";
+    }
+    default: {
+      return message ?? "Verification failed. Please try again.";
+    }
+  }
+}
 
 interface ClerkSignUpFormProps {
   onSwitchToSignIn: () => void;
@@ -60,9 +100,118 @@ export function ClerkSignUpForm({
   const [verifying, setVerifying] = useState(false);
   const [code, setCode] = useState("");
   const [isEmailMode, setIsEmailMode] = useState(false);
+  const [legalAccepted, setLegalAccepted] = useState(false);
+  const [isResending, setIsResending] = useState(false);
+  const [resendCooldown, setResendCooldown] = useState(0);
+  const [consentRequiredOnVerify, setConsentRequiredOnVerify] = useState(false);
+  const hasCheckedPendingSignUp = useRef(false);
 
   const showPasswordField = useMemo(() => email.trim().length > 0, [email]);
   const normalizedRedirect = normalizeAuthRedirect(redirectTo);
+  const pendingEmail = signUp?.emailAddress ?? email;
+
+  // Latched at restore rather than read live, so ticking the box does not make
+  // the box disappear out from under the pointer.
+  const consentOutstanding = consentRequiredOnVerify && !legalAccepted;
+
+  const afterSignUpRedirect = shouldBypassSyncForRedirect(normalizedRedirect)
+    ? normalizedRedirect
+    : `/profile-setup?redirectTo=${encodeAuthRedirect(normalizedRedirect)}`;
+
+  // A sign-up attempt lives on the Clerk client, not in this component, so an
+  // unverified one survives a reload, a tab close, or the app being killed.
+  // Without this the user came back to an empty form and no way to reach the
+  // code they had already been sent.
+  useEffect(() => {
+    if (!isLoaded || hasCheckedPendingSignUp.current) {
+      return;
+    }
+    hasCheckedPendingSignUp.current = true;
+
+    // Clerk abandons a stale attempt server-side. Restoring one puts the user
+    // on a screen where the code, the resend and the submit all fail.
+    const isAbandoned =
+      signUp.abandonAt !== null && signUp.abandonAt <= Date.now();
+
+    if (
+      !isAbandoned &&
+      signUp.status === "missing_requirements" &&
+      signUp.unverifiedFields.includes("email_address") &&
+      signUp.emailAddress
+    ) {
+      setEmail(signUp.emailAddress);
+      setIsEmailMode(true);
+      setVerifying(true);
+      // An attempt created before consent was collected still owes it. Ask on
+      // the verify screen rather than accepting on the user's behalf when the
+      // code lands.
+      setConsentRequiredOnVerify(isMissingLegalConsent(signUp));
+    }
+  }, [isLoaded, signUp]);
+
+  useEffect(() => {
+    if (resendCooldown <= 0) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setResendCooldown((seconds) => Math.max(0, seconds - 1));
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [resendCooldown]);
+
+  const goToAuthReady = useCallback(
+    async (sessionId: string) => {
+      forgetLegalConsent();
+      await setActive?.({ session: sessionId });
+      navigate({
+        to: "/auth-ready",
+        search: { redirectTo: afterSignUpRedirect },
+      });
+    },
+    [afterSignUpRedirect, navigate, setActive],
+  );
+
+  type SignUpAttempt = NonNullable<typeof signUp>;
+
+  /**
+   * Settles whatever the attempt still owes. "outstanding" means something is
+   * genuinely unmet, so the caller can say what rather than reaching for the
+   * nearest error message.
+   */
+  const finishSignUpAttempt = useCallback(
+    async (
+      attempt: SignUpAttempt,
+    ): Promise<"signed-in" | "needs-sign-in" | "outstanding"> => {
+      let settled = attempt;
+
+      if (isMissingLegalConsent(settled)) {
+        settled = await settled.update({ legalAccepted: true });
+      }
+
+      if (settled.status !== "complete") {
+        return "outstanding";
+      }
+
+      if (!settled.createdSessionId) {
+        // Complete with no session is not something the user can act on here.
+        logger.error("Sign-up completed without a session");
+        showNotification(
+          "Your account was created, but we couldn't sign you in. Please sign in to continue.",
+          "warning",
+        );
+        onSwitchToSignIn();
+
+        return "needs-sign-in";
+      }
+
+      await goToAuthReady(settled.createdSessionId);
+
+      return "signed-in";
+    },
+    [goToAuthReady, onSwitchToSignIn, showNotification],
+  );
 
   // Handle social sign-up
   const handleSocialSignUp = async (strategy: SocialAuthStrategy) => {
@@ -71,6 +220,16 @@ export function ClerkSignUpForm({
 
       return;
     }
+
+    if (!legalAccepted) {
+      showNotification(CONSENT_REQUIRED_MESSAGE, "warning");
+
+      return;
+    }
+
+    // The redirect paths cannot carry the consent flag, so record it here and
+    // let /sso-callback apply it to the attempt Clerk hands back.
+    rememberLegalConsent();
 
     productAnalytics.capture({
       event: "signup_started",
@@ -150,6 +309,7 @@ export function ClerkSignUpForm({
             strategy,
             redirectUrl,
             actionCompleteRedirectUrl: redirectUrlComplete,
+            legalAccepted: true,
           });
 
           externalUrl =
@@ -249,6 +409,12 @@ export function ClerkSignUpForm({
       return;
     }
 
+    if (!legalAccepted) {
+      showNotification(CONSENT_REQUIRED_MESSAGE, "warning");
+
+      return;
+    }
+
     productAnalytics.capture({
       event: "signup_started",
       properties: {
@@ -259,31 +425,28 @@ export function ClerkSignUpForm({
     setIsLoading(true);
 
     try {
+      // legalAccepted is required by the instance. Omitting it leaves the
+      // attempt at missing_requirements even after the email code verifies.
       const result = await signUp.create({
         emailAddress: email,
         password,
         firstName,
         lastName,
+        legalAccepted: true,
       });
 
       if (result.status === "complete") {
         // Sign-up complete, set session and redirect to auth-ready
         // AuthReadyPage will set the token and then redirect to the intended destination
-        await setActive({ session: result.createdSessionId });
-        navigate({
-          to: "/auth-ready",
-          search: {
-            redirectTo: shouldBypassSyncForRedirect(normalizedRedirect)
-              ? normalizedRedirect
-              : `/profile-setup?redirectTo=${encodeAuthRedirect(normalizedRedirect)}`,
-          },
-        });
+        await finishSignUpAttempt(result);
       } else if (result.status === "missing_requirements") {
         // Email verification required
         await signUp.prepareEmailAddressVerification({
           strategy: "email_code",
         });
         setVerifying(true);
+        setCode("");
+        setResendCooldown(RESEND_COOLDOWN_SECONDS);
         showNotification(
           "Please check your email for the verification code",
           "success",
@@ -357,43 +520,102 @@ export function ClerkSignUpForm({
   const handleVerify = async (event: React.FormEvent) => {
     event.preventDefault();
 
-    if (!isLoaded) return;
+    // The submit button is disabled while loading, but Enter in the code field
+    // is not, and a second attempt on an accepted code fails.
+    if (!isLoaded || isLoading) return;
+
+    if (consentOutstanding) {
+      showNotification(CONSENT_REQUIRED_MESSAGE, "warning");
+
+      return;
+    }
 
     setIsLoading(true);
 
     try {
       const result = await signUp.attemptEmailAddressVerification({
-        code,
+        code: sanitizeVerificationCode(code),
       });
 
-      if (result.status === "complete") {
-        // Verification complete, set session and redirect to auth-ready
-        // AuthReadyPage will set the token and then redirect to the intended destination
-        await setActive({ session: result.createdSessionId });
-        showNotification("Email verified successfully!", "success");
-        navigate({
-          to: "/auth-ready",
-          search: {
-            redirectTo: shouldBypassSyncForRedirect(normalizedRedirect)
-              ? normalizedRedirect
-              : `/profile-setup?redirectTo=${encodeAuthRedirect(normalizedRedirect)}`,
-          },
-        });
-      } else {
-        showNotification(
-          "Invalid verification code. Please try again.",
-          "error",
-        );
+      // Reaching here means the code was accepted: a wrong one throws. Anything
+      // still outstanding is a different requirement, and blaming the code for
+      // it strands the user on a screen whose only input is already correct.
+      const outcome = await finishSignUpAttempt(result);
+
+      if (outcome === "signed-in") {
+        showNotification("Email verified", "success");
+
+        return;
       }
+
+      if (outcome === "needs-sign-in") {
+        return;
+      }
+
+      logger.error("Sign-up still incomplete after verification", {
+        status: result.status,
+        missingFields: result.missingFields,
+        unverifiedFields: result.unverifiedFields,
+      });
+      showNotification(
+        "Your email is verified, but we couldn't finish creating the account. Please try again.",
+        "error",
+      );
     } catch (error) {
       logger.error("Verification error:", error);
+
+      const { code: errorCode, message } = extractClerkError(error);
+
+      // The code landed on an earlier submit. Carry on from where that got to
+      // rather than reporting a failure for something that already worked.
+      if (
+        errorCode === "verification_already_verified" &&
+        (await finishSignUpAttempt(signUp)) !== "outstanding"
+      ) {
+        return;
+      }
+
       showNotification(
-        error instanceof Error ? error.message : "Verification failed",
+        resolveVerificationErrorMessage(errorCode, message),
         "error",
       );
     } finally {
       setIsLoading(false);
     }
+  };
+
+  // Codes expire, and a user coming back to a half-finished sign-up needs a
+  // fresh one rather than a dead end.
+  const handleResendCode = async () => {
+    if (!isLoaded || isResending || resendCooldown > 0) return;
+
+    setIsResending(true);
+
+    try {
+      await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
+      setCode("");
+      setResendCooldown(RESEND_COOLDOWN_SECONDS);
+      showNotification(`New code sent to ${pendingEmail}`, "success");
+    } catch (error) {
+      logger.error("Resend verification code error:", error);
+      showNotification(
+        extractClerkError(error).message ??
+          "Couldn't send a new code. Please try again.",
+        "error",
+      );
+    } finally {
+      setIsResending(false);
+    }
+  };
+
+  const handleUseDifferentEmail = () => {
+    setVerifying(false);
+    setCode("");
+    setResendCooldown(0);
+    // A restored attempt prefills the old address; leaving it there makes the
+    // button a lie and re-submits the same sign-up.
+    setEmail("");
+    setPassword("");
   };
 
   // Show verification form
@@ -408,7 +630,7 @@ export function ClerkSignUpForm({
             Verify Your Email
           </h1>
           <p className="mt-2 text-muted">
-            We&apos;ve sent a verification code to {email}
+            We&apos;ve sent a verification code to {pendingEmail}
           </p>
         </div>
 
@@ -416,32 +638,51 @@ export function ClerkSignUpForm({
           <TextField
             label="Verification Code"
             value={code}
-            onChange={setCode}
+            onChange={(value) => setCode(sanitizeVerificationCode(value))}
             type="text"
             required
             placeholder="123456"
-            maxLength={6}
             name="verificationCode"
             autoComplete="one-time-code"
           />
+
+          {consentRequiredOnVerify ? (
+            <LegalConsentCheckbox
+              checked={legalAccepted}
+              onChange={setLegalAccepted}
+            />
+          ) : null}
 
           <Button
             type="submit"
             fullWidth
             isLoading={isLoading}
             loadingText="Verifying..."
+            disabled={consentOutstanding}
           >
             Verify Email
           </Button>
         </form>
 
-        <div className="mt-6 text-center">
+        <div className="mt-6 flex flex-col items-center gap-1 text-center">
           <button
             type="button"
-            onClick={() => setVerifying(false)}
-            className="inline-flex min-h-11 items-center rounded-control px-3 py-2 text-sm text-primary transition-colors duration-200 hover:underline focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface focus-visible:outline-none"
+            onClick={handleResendCode}
+            disabled={isResending || resendCooldown > 0}
+            className="inline-flex min-h-11 items-center rounded-control px-3 py-2 text-sm text-primary transition-colors duration-200 hover:underline focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface focus-visible:outline-none disabled:text-muted disabled:hover:no-underline"
           >
-            Back to sign up
+            {resendCooldown > 0
+              ? `Resend code in ${resendCooldown}s`
+              : isResending
+                ? "Sending..."
+                : "Resend code"}
+          </button>
+          <button
+            type="button"
+            onClick={handleUseDifferentEmail}
+            className="inline-flex min-h-11 items-center rounded-control px-3 py-2 text-sm text-muted transition-colors duration-200 hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface focus-visible:outline-none"
+          >
+            Use a different email
           </button>
         </div>
       </div>
@@ -544,11 +785,17 @@ export function ClerkSignUpForm({
                 ) : null}
               </AnimatePresence>
 
+              <LegalConsentCheckbox
+                checked={legalAccepted}
+                onChange={setLegalAccepted}
+              />
+
               <Button
                 type="submit"
                 fullWidth
                 isLoading={isLoading}
                 loadingText="Creating account..."
+                disabled={!legalAccepted}
               >
                 Create Account
               </Button>
@@ -562,10 +809,18 @@ export function ClerkSignUpForm({
             exit={{ opacity: 0, y: -8 }}
             transition={{ duration: 0.22, ease: "easeOut" }}
           >
+            <div className="mb-5">
+              <LegalConsentCheckbox
+                checked={legalAccepted}
+                onChange={setLegalAccepted}
+              />
+            </div>
+
             <SocialAuthOptions
               onProviderSelect={handleSocialSignUp}
               onContinueWithEmail={() => setIsEmailMode(true)}
               loadingStrategy={loadingStrategy}
+              providersDisabled={!legalAccepted}
             />
           </motion.div>
         )}

--- a/frontend/src/features/auth/components/LegalConsentCheckbox.tsx
+++ b/frontend/src/features/auth/components/LegalConsentCheckbox.tsx
@@ -1,0 +1,32 @@
+import { LegalLink } from "@/features/auth/components/LegalLink";
+
+interface LegalConsentCheckboxProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+/**
+ * Consent is a required sign-up field on the Clerk instance, so the account
+ * cannot be created without it.
+ */
+export function LegalConsentCheckbox({
+  checked,
+  onChange,
+}: LegalConsentCheckboxProps) {
+  return (
+    <label className="flex min-h-11 items-start gap-3 py-2 text-sm text-muted">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+        className="mt-0.5 h-4 w-4 rounded border-border accent-primary"
+        name="legalAccepted"
+        required
+      />
+      <span>
+        I agree to the <LegalLink to="/terms">Terms of Service</LegalLink> and{" "}
+        <LegalLink to="/privacy">Privacy Policy</LegalLink>.
+      </span>
+    </label>
+  );
+}

--- a/frontend/src/features/auth/components/LegalLink.tsx
+++ b/frontend/src/features/auth/components/LegalLink.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from "react";
+import { Browser } from "@capacitor/browser";
+
+import { isNativePlatform } from "@/services/native/platform";
+
+// The native build serves from a capacitor:// origin, so a relative link has
+// no public address to open. Matches the fallback in buildSocialAuthRedirectUrls.
+const PUBLIC_SITE_ORIGIN = "https://macrotrackr.com";
+
+const LINK_CLASS =
+  "text-primary underline underline-offset-2 hover:no-underline focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface focus-visible:outline-none";
+
+interface LegalLinkProps {
+  to: "/terms" | "/privacy";
+  children: ReactNode;
+}
+
+/**
+ * Opens a policy document without unmounting the auth form behind it. A new tab
+ * on the web, the in-app browser on native: `target="_blank"` there resolves
+ * against the capacitor:// scheme and silently opens nothing.
+ */
+export function LegalLink({ to, children }: LegalLinkProps) {
+  return (
+    <a
+      href={to}
+      target="_blank"
+      rel="noreferrer"
+      className={LINK_CLASS}
+      onClick={(event) => {
+        if (!isNativePlatform()) {
+          return;
+        }
+
+        event.preventDefault();
+        void Browser.open({ url: `${PUBLIC_SITE_ORIGIN}${to}` });
+      }}
+    >
+      {children}
+    </a>
+  );
+}

--- a/frontend/src/features/auth/components/SocialAuthOptions.tsx
+++ b/frontend/src/features/auth/components/SocialAuthOptions.tsx
@@ -3,14 +3,17 @@ import type React from "react";
 import Button from "@/components/ui/Button";
 import { AppleIcon, GoogleIcon } from "@/components/ui/Icons";
 
-export type SocialAuthStrategy =
-  | "oauth_google"
-  | "oauth_apple";
+export type SocialAuthStrategy = "oauth_google" | "oauth_apple";
 
 interface SocialAuthOptionsProps {
   onProviderSelect: (strategy: SocialAuthStrategy) => void;
   onContinueWithEmail: () => void;
   loadingStrategy?: SocialAuthStrategy | null;
+  /**
+   * Sign-up holds these until legal consent is ticked. The email button stays
+   * live: consent is only needed at submit, and the form asks again there.
+   */
+  providersDisabled?: boolean;
 }
 
 interface SocialAuthProviderConfig {
@@ -48,6 +51,7 @@ export function SocialAuthOptions({
   onProviderSelect,
   onContinueWithEmail,
   loadingStrategy,
+  providersDisabled = false,
 }: SocialAuthOptionsProps) {
   return (
     <>
@@ -69,12 +73,14 @@ export function SocialAuthOptions({
               isLoading={isLoading}
               loadingText={`Connecting to ${label}...`}
               onClick={() => {
-                if (enabled && !loadingStrategy) {
+                if (enabled && !loadingStrategy && !providersDisabled) {
                   onProviderSelect(strategy);
                 }
               }}
               leftIcon={<Icon className="h-5 w-5" />}
-              disabled={!enabled || Boolean(loadingStrategy)}
+              disabled={
+                !enabled || Boolean(loadingStrategy) || providersDisabled
+              }
             >
               {buttonLabel}
             </Button>

--- a/frontend/src/features/auth/pages/SsoCallbackPage.test.tsx
+++ b/frontend/src/features/auth/pages/SsoCallbackPage.test.tsx
@@ -1,16 +1,33 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import SSOCallbackPage from "@/features/auth/pages/SsoCallbackPage";
 
-const { handleRedirectCallback, signOut, navigate } = vi.hoisted(() => ({
+const {
+  handleRedirectCallback,
+  signOut,
+  navigate,
+  setActive,
+  signUpUpdate,
+  clientState,
+} = vi.hoisted(() => ({
   handleRedirectCallback: vi.fn(),
   signOut: vi.fn(),
   navigate: vi.fn(),
+  setActive: vi.fn(),
+  signUpUpdate: vi.fn(),
+  clientState: {
+    signUp: undefined as Record<string, unknown> | undefined,
+  },
 }));
 
 vi.mock("@clerk/react", () => ({
-  useClerk: () => ({ handleRedirectCallback, signOut }),
+  useClerk: () => ({
+    client: clientState,
+    handleRedirectCallback,
+    setActive,
+    signOut,
+  }),
   useAuth: () => ({ isLoaded: true, isSignedIn: false }),
   useUser: () => ({ user: null, isLoaded: true }),
 }));
@@ -29,6 +46,8 @@ vi.mock("@/components/ui/LoadingSpinner", () => ({ default: () => null }));
 describe("SSOCallbackPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sessionStorage.clear();
+    clientState.signUp = undefined;
     handleRedirectCallback.mockResolvedValue(undefined);
   });
 
@@ -68,5 +87,85 @@ describe("SSOCallbackPage", () => {
     await waitFor(() => {
       expect(handleRedirectCallback).toHaveBeenCalledOnce();
     });
+  });
+
+  /**
+   * Legal consent is a required sign-up field and an OAuth redirect cannot
+   * carry it, so Clerk hands the attempt back at missing_requirements: no
+   * session, no error, and this page spun until the user gave up.
+   */
+  it("finishes a sign-up that came back short of legal consent", async () => {
+    sessionStorage.setItem("macrotrackr.signup.legalAccepted", "true");
+    clientState.signUp = {
+      status: "missing_requirements",
+      missingFields: ["legal_accepted"],
+      verifications: { externalAccount: { status: "verified" } },
+      update: signUpUpdate,
+    };
+    signUpUpdate.mockResolvedValue({
+      status: "complete",
+      createdSessionId: "sess_1",
+      missingFields: [],
+    });
+
+    render(<SSOCallbackPage />);
+
+    await waitFor(() => {
+      expect(signUpUpdate).toHaveBeenCalledWith({ legalAccepted: true });
+    });
+    await waitFor(() => {
+      expect(setActive).toHaveBeenCalledWith({ session: "sess_1" });
+    });
+  });
+
+  it("says so rather than spinning when consent was never given", async () => {
+    clientState.signUp = {
+      status: "missing_requirements",
+      missingFields: ["legal_accepted"],
+      verifications: { externalAccount: { status: "verified" } },
+      update: signUpUpdate,
+    };
+
+    render(<SSOCallbackPage />);
+
+    expect(
+      await screen.findByText(/accept the terms and privacy policy/i),
+    ).toBeInTheDocument();
+    expect(signUpUpdate).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The client hangs on to the last sign-up attempt, so an abandoned one from
+   * earlier in the session is indistinguishable from the one this callback is
+   * for. Completing it would activate a session the user never asked for.
+   */
+  it("leaves an attempt alone when it did not come from this callback", async () => {
+    sessionStorage.setItem("macrotrackr.signup.legalAccepted", "true");
+    clientState.signUp = {
+      status: "missing_requirements",
+      missingFields: ["legal_accepted"],
+      verifications: { externalAccount: { status: null } },
+      update: signUpUpdate,
+    };
+
+    render(<SSOCallbackPage />);
+
+    await waitFor(() => {
+      expect(handleRedirectCallback).toHaveBeenCalledOnce();
+    });
+    expect(signUpUpdate).not.toHaveBeenCalled();
+    expect(setActive).not.toHaveBeenCalled();
+  });
+
+  it("keeps Clerk off its hosted continue page", async () => {
+    render(<SSOCallbackPage />);
+
+    await waitFor(() => {
+      expect(handleRedirectCallback).toHaveBeenCalledOnce();
+    });
+
+    expect(handleRedirectCallback.mock.calls[0]?.[0].continueSignUpUrl).toBe(
+      globalThis.location.href,
+    );
   });
 });

--- a/frontend/src/features/auth/pages/SsoCallbackPage.tsx
+++ b/frontend/src/features/auth/pages/SsoCallbackPage.tsx
@@ -9,6 +9,11 @@ import LoadingSpinner from "@/components/ui/LoadingSpinner";
 import { isClerkAuthMode } from "@/config/runtime";
 import { handleAccountCollision } from "@/features/auth/utils/handleAuthCollision";
 import {
+  forgetLegalConsent,
+  hasRememberedLegalConsent,
+  isMissingLegalConsent,
+} from "@/features/auth/utils/legalConsent";
+import {
   normalizeAuthRedirect,
   resolveAuthReturnTo,
 } from "@/features/auth/utils/redirect";
@@ -43,7 +48,7 @@ export default function SSOCallbackPage() {
 }
 
 function ClerkSsoCallbackPage() {
-  const { handleRedirectCallback, signOut } = useClerk();
+  const { client, handleRedirectCallback, setActive, signOut } = useClerk();
   const { isLoaded: authLoaded, isSignedIn } = useAuth();
   const { user, isLoaded: userLoaded } = useUser();
   const navigate = useNavigate();
@@ -76,21 +81,82 @@ function ClerkSsoCallbackPage() {
       // the fallback variants, but those props had force semantics.
       signInForceRedirectUrl: globalThis.location.href,
       signUpForceRedirectUrl: globalThis.location.href,
-    }).catch((error_) => {
-      // Clerk may throw if the callback was already handled (e.g. page refresh)
-      // This is safe to ignore if the user is already signed in
-      const resolution = resolveSocialAuthError(
-        error_,
-        isSignUpFlow ? "signup" : "signin",
-      );
+      // An OAuth sign-up that still owes a field sends Clerk to its continue
+      // URL, which defaults to the hosted Account Portal on another origin.
+      // Keep it here so the block below can finish the attempt in the app.
+      continueSignUpUrl: globalThis.location.href,
+    })
+      .then(() => completePendingLegalConsent())
+      .catch((error_) => {
+        // Clerk may throw if the callback was already handled (e.g. page refresh)
+        // This is safe to ignore if the user is already signed in
+        const resolution = resolveSocialAuthError(
+          error_,
+          isSignUpFlow ? "signup" : "signin",
+        );
 
-      logger.warn(
-        "[SSOCallback] handleRedirectCallback error (may be safe to ignore):",
-        error_,
-      );
-      setCallbackResolution(resolution);
-    });
-  }, [handleRedirectCallback, isSignUpFlow]);
+        logger.warn(
+          "[SSOCallback] handleRedirectCallback error (may be safe to ignore):",
+          error_,
+        );
+        setCallbackResolution(resolution);
+      });
+
+    // Legal consent is a required sign-up field, and an OAuth redirect has no
+    // way to carry it. Clerk hands the attempt back at missing_requirements,
+    // which is neither a session nor an error, so step 2 returned early and the
+    // spinner never stopped. The forms record consent before leaving; apply it.
+    async function completePendingLegalConsent() {
+      const pendingSignUp = client?.signUp;
+
+      if (!pendingSignUp || !isMissingLegalConsent(pendingSignUp)) {
+        return;
+      }
+
+      // The client keeps the last sign-up attempt around, so an abandoned one
+      // from earlier in the session looks identical to the one we just came
+      // back with. Only the latter has a verified external account on it, and
+      // completing the wrong attempt would activate a session nobody asked for.
+      if (pendingSignUp.verifications?.externalAccount?.status !== "verified") {
+        return;
+      }
+
+      if (!hasRememberedLegalConsent()) {
+        setError(
+          "To finish creating your account, accept the Terms and Privacy Policy on the sign-up page.",
+        );
+
+        return;
+      }
+
+      try {
+        const updated = await pendingSignUp.update({ legalAccepted: true });
+
+        if (updated.status === "complete" && updated.createdSessionId) {
+          forgetLegalConsent();
+          await setActive({ session: updated.createdSessionId });
+
+          return;
+        }
+
+        logger.error("[SSOCallback] Sign-up incomplete after legal consent", {
+          status: updated.status,
+          missingFields: updated.missingFields,
+        });
+        setError(
+          "We couldn't finish creating your account. Please try signing up again.",
+        );
+      } catch (consentError) {
+        logger.error(
+          "[SSOCallback] Failed to record legal consent:",
+          consentError,
+        );
+        setError(
+          "We couldn't finish creating your account. Please try signing up again.",
+        );
+      }
+    }
+  }, [client, handleRedirectCallback, isSignUpFlow, setActive]);
 
   // Step 2: Once Clerk is loaded and user is signed in, handle routing
   useEffect(() => {
@@ -111,6 +177,8 @@ function ClerkSsoCallbackPage() {
     async function routeUser() {
       try {
         const safeRedirectTo = redirectTo;
+
+        forgetLegalConsent();
 
         // For sign-in flows, go straight to auth-ready
         if (!isSignUpFlow) {

--- a/frontend/src/features/auth/utils/legalConsent.ts
+++ b/frontend/src/features/auth/utils/legalConsent.ts
@@ -1,0 +1,60 @@
+/**
+ * The Clerk instance has legal consent enabled, which makes `legal_accepted` a
+ * required sign-up field. A custom sign-up form has to send it itself.
+ *
+ * Getting this wrong is invisible until the last step: `signUp.create()` still
+ * succeeds (the instance runs progressive sign-up), the email code still sends,
+ * and the code still verifies — but the attempt stays at `missing_requirements`
+ * because consent is outstanding. The form read that as a failed verification
+ * and told the user their code was wrong.
+ */
+
+const CONSENT_KEY = "macrotrackr.signup.legalAccepted";
+
+export const LEGAL_ACCEPTED_FIELD = "legal_accepted";
+
+export function rememberLegalConsent(): void {
+  try {
+    globalThis.sessionStorage?.setItem(CONSENT_KEY, "true");
+  } catch {
+    // Storage can be unavailable (private mode, embedded webviews). The OAuth
+    // repair in SsoCallbackPage degrades to asking the user to sign up again.
+  }
+}
+
+export function hasRememberedLegalConsent(): boolean {
+  try {
+    return globalThis.sessionStorage?.getItem(CONSENT_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function forgetLegalConsent(): void {
+  try {
+    globalThis.sessionStorage?.removeItem(CONSENT_KEY);
+  } catch {
+    // See rememberLegalConsent.
+  }
+}
+
+interface LegalConsentSignUp {
+  status: string | null;
+  // Read defensively: this runs on the OAuth return path, where a throw would
+  // put the callback page back to spinning with nothing on screen.
+  missingFields?: readonly string[];
+}
+
+/**
+ * True when the only thing standing between this attempt and an account is the
+ * consent flag — the OAuth redirect paths cannot pass it up front, so it has to
+ * be repaired on the way back.
+ */
+export function isMissingLegalConsent(
+  signUp: LegalConsentSignUp | null | undefined,
+): boolean {
+  return (
+    signUp?.status === "missing_requirements" &&
+    (signUp.missingFields ?? []).includes(LEGAL_ACCEPTED_FIELD)
+  );
+}

--- a/frontend/src/features/auth/utils/socialAuth.ts
+++ b/frontend/src/features/auth/utils/socialAuth.ts
@@ -25,7 +25,7 @@ interface ClerkLikeError {
   errors?: ClerkErrorEntry[];
 }
 
-function extractClerkError(error: unknown): {
+export function extractClerkError(error: unknown): {
   code?: string;
   message?: string;
 } {


### PR DESCRIPTION
## The bug

Signing up with email reported **"Invalid verification code"** for a code that was correct, and there was no way back to the verification screen once you left it.

Production Clerk has `legal_consent_enabled: true` (read from `clerk.macrotrackr.com/v1/environment`); `ClerkSignUpForm` never sent `legalAccepted`. Because the instance runs progressive sign-up, nothing failed early: `create()` succeeded, the code sent, the code verified. The attempt just stayed at `missing_requirements`, and the old `else` branch printed our own "Invalid verification code" string. Retrying the same code then fails for real, so the user was stuck with no route back.

The dev instance has `legal_consent_enabled: false`, which is why this never reproduced locally or in tests.

## What changed

**Verification** &mdash; `signUp.create()` sends `legalAccepted: true` behind a required checkbox linking to `/terms` and `/privacy`. A non-complete status after verification is no longer blamed on the code: a wrong one *throws* and is handled with Clerk's own error, a surviving `legal_accepted` is repaired via `update()`, and anything else logs the real `missingFields`/`unverifiedFields`.

**Getting back in** &mdash; the attempt lives on the Clerk client, not in the component, so a pending unverified one reopens the verify screen after a reload, a closed tab, or the app being killed. Adds **Resend code** with a 30s cooldown; the dead-end "Back to sign up" becomes "Use a different email".

**OAuth, same root cause, not reported** &mdash; an attempt returned at `missing_requirements` is neither a session nor an error, so `/sso-callback` returned early and spun for ever. A new Google sign-up would have hit this. Consent is recorded before the redirect and applied on return, `continueSignUpUrl` keeps Clerk off its hosted Account Portal, and an attempt that did not come from this callback is left alone. The sign-in screen's provider buttons fall through to sign-up for new users, so they carry consent too, with an inline notice.

## Edge cases

| Edge | Before |
| --- | --- |
| Pasted code with whitespace | `maxLength={6}` truncated `" 123456 "` to `" 12345"`; now sanitised to digits |
| Abandoned attempt (`abandonAt`) | Restored a screen where every action failed |
| Attempt stranded by this bug | Would have had consent accepted on its behalf; now asks on the verify screen |
| Stale attempt during a sign-in | Could activate a session nobody asked for; now requires a verified external account |
| Double submit via Enter | Bypassed the disabled button and failed the second attempt |
| `verification_already_verified` | Reported a failure for something that worked; now finishes from the live resource |
| `verification_expired` | Reported as "that code doesn't match" |
| Complete with no session | Navigated to `/auth-ready` unauthenticated |
| Terms links on mobile | `target="_blank"` on a relative path opens nothing in the Capacitor webview |

## Testing

`typecheck` clean, `lint` 0 errors (81 warnings, unchanged baseline), UI budgets pass, prettier clean on every touched file. **893 frontend + 458 backend tests pass**, 14 added. One reproduces the reported bug and was confirmed to fail against the old logic.

**Not run:** the Playwright e2e suite (needs real Clerk credentials). `signUpViaUI` was updated to tick the new checkbox but is unexecuted.

## Reviewer note

The alternative is turning `legal_consent_enabled` off in the Clerk dashboard, which fixes the bug with zero code but records no terms acceptance. This PR assumes the consent is wanted.
