### PR TITLE
fix(e2e): run the auth suite against Clerk, and make it assert something

### DIFF
--- a/frontend/e2e/auth.test.ts
+++ b/frontend/e2e/auth.test.ts
@@ -1,6 +1,8 @@
+import { setupClerkTestingToken } from '@clerk/testing/playwright'
 import { test, expect } from '@playwright/test'
 import type { Page } from '@playwright/test'
 import { navigateToSignUp, navigateToSignIn, loginWithTestUser, signUpViaUI } from './helpers/auth'
+import { generateRandomEmail, generateRandomPassword } from './helpers'
 
 test.describe('Authentication E2E Tests', () => {
   test.describe('Sign Up Flow', () => {
@@ -41,6 +43,8 @@ test.describe('Authentication E2E Tests', () => {
       const emailInput = page.locator('input[type="email"], input[name="email"]').first()
       await expect(emailInput).toBeVisible()
 
+      // The password field is revealed once there is an email to go with it.
+      await emailInput.fill('someone@example.com')
       const passwordInput = page.locator('input[type="password"], input[name="password"]').first()
       await expect(passwordInput).toBeVisible()
     })
@@ -50,20 +54,24 @@ test.describe('Authentication E2E Tests', () => {
     test('should complete registration flow', async ({ page }: { page: Page }) => {
       test.setTimeout(60000)
 
-      const email = `test_${Date.now()}@example.com`
-      const password = 'TestPassword123!'
+      // The dev instance has bot protection on, which blocks a headless
+      // sign-up outright. Without this the flow never reaches the code screen.
+      await setupClerkTestingToken({ page })
+
+      const email = generateRandomEmail()
+      // A fixed password fails HIBP on the dev instance (form_password_pwned).
+      const password = generateRandomPassword()
 
       await signUpViaUI(page, email, password)
 
-      // After sign up, should be redirected to home, verification page, or still on register if verification needed
-      const url = page.url()
-      const isSuccess = url.includes('home') || 
-                       url.includes('verify') || 
-                       url.includes('dashboard') ||
-                       url.includes('register') ||
-                       url.includes('confirm') ||
-                       url.includes('auth')
-      expect(isSuccess).toBe(true)
+      // "still on /register" used to count as success here, so this passed
+      // while the account was never created. Landing on profile setup or the
+      // app is the only outcome that means the sign-up actually completed.
+      // /auth-ready is a staging post: it exchanges the Clerk token and syncs
+      // the account before routing on, so give it room.
+      await expect(page).toHaveURL(/\/profile-setup|\/home|\/dashboard/, {
+        timeout: 30000,
+      })
     })
   })
 
@@ -76,6 +84,7 @@ test.describe('Authentication E2E Tests', () => {
         test.skip()
       }
 
+      await setupClerkTestingToken({ page })
       await loginWithTestUser(page)
 
       // Verify we're on an authenticated page

--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -1,20 +1,40 @@
 import type { Page } from '@playwright/test'
-import { waitForAnyVisible, waitForPageReady } from './index'
+import { TEST_VERIFICATION_CODE, waitForAnyVisible, waitForPageReady } from './index'
 
 export interface TestUser {
   email: string
   password: string
 }
 
+/**
+ * Both auth screens open on the social providers. The email fields are behind
+ * "Continue with email", so every helper that wants them has to ask first.
+ */
+async function revealEmailForm(page: Page): Promise<void> {
+  const emailField = page.locator('input[name="email"]').first()
+  if (await emailField.isVisible().catch(() => false)) {
+    return
+  }
+
+  const continueWithEmail = page
+    .locator('button:has-text("Continue with email")')
+    .first()
+  if (await continueWithEmail.isVisible().catch(() => false)) {
+    await continueWithEmail.click()
+  }
+}
+
 export async function navigateToSignUp(page: Page): Promise<void> {
   await page.goto('/register')
   await waitForPageReady(page)
+  await revealEmailForm(page)
   await waitForAnyVisible(page, ['input[type="email"]', 'input[name="email"]'])
 }
 
 export async function navigateToSignIn(page: Page): Promise<void> {
   await page.goto('/login')
   await waitForPageReady(page)
+  await revealEmailForm(page)
   await waitForAnyVisible(page, ['input[type="email"]', 'input[name="email"]'])
 }
 
@@ -87,12 +107,32 @@ export async function signUpViaUI(page: Page, email: string, password: string): 
   const submitButton = page.locator('button[type="submit"], button:has-text("Create Account")').first()
   await submitButton.click()
 
-  await Promise.race([
-    page.waitForURL(/\/home|\/dashboard|verify|register|confirm|auth/, { timeout: 15000 }),
-    waitForAnyVisible(page, ['[role="alert"]', 'text=verify', 'text=Check your email'], 15000),
-  ])
+  await completeEmailVerification(page)
 
   await waitForPageReady(page)
+}
+
+/**
+ * Clerk puts any address containing +clerk_test into test mode: no mail is
+ * sent and TEST_VERIFICATION_CODE is accepted. Without this step the sign-up
+ * stops at the verify screen and never becomes an account, which is how the
+ * registration test came to assert nothing.
+ */
+export async function completeEmailVerification(page: Page): Promise<void> {
+  const codeInput = page.locator('input[name="verificationCode"]').first()
+
+  try {
+    await codeInput.waitFor({ state: 'visible', timeout: 15000 })
+  } catch {
+    // Sign-up completed without a verification step.
+    return
+  }
+
+  await codeInput.fill(TEST_VERIFICATION_CODE)
+  await page.locator('button:has-text("Verify Email")').first().click()
+  await page.waitForURL(/\/profile-setup|\/home|\/dashboard|\/auth-ready/, {
+    timeout: 20000,
+  })
 }
 
 export async function isAuthenticated(page: Page): Promise<boolean> {

--- a/frontend/e2e/helpers/index.ts
+++ b/frontend/e2e/helpers/index.ts
@@ -67,9 +67,14 @@ export async function waitForAnyVisible(
   throw new Error(`None of the expected selectors became visible: ${selectors.join(', ')}`)
 }
 
+/**
+ * The +clerk_test marker puts Clerk into test mode for this address: no real
+ * email is sent and TEST_VERIFICATION_CODE is accepted. Without it a sign-up
+ * test waits on a delivery that never arrives.
+ */
 export function generateRandomEmail(): string {
   const timestamp = Date.now()
-  return `test_${timestamp}@example.com`
+  return `test_${timestamp}+clerk_test@example.com`
 }
 
 export function generateRandomPassword(): string {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -25,13 +25,40 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: 'list',
+
+  // Must be the config option, not a setup project. As a project, Playwright
+  // looks for test() calls in the file and never invokes its default export,
+  // so clerkSetup() did not run and setupClerkTestingToken had no Frontend API
+  // URL to work with. globalSetup also runs before workers fork, which is what
+  // lets the env it sets reach them.
+  globalSetup: './e2e/global.setup.ts',
   
-  webServer: {
-    command: 'bun run dev',
-    url: baseURL,
-    reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
-  },
+  // Both halves have to run in Clerk mode or the suite tests the wrong app.
+  // AUTH_MODE is unset in .env.development, so the default ("local") renders
+  // LocalSignUpForm and the backend rejects Clerk tokens with a 401. Every
+  // Clerk auth path went untested that way, which is how a production-only
+  // sign-up break reached users.
+  webServer: [
+    {
+      command: 'bun run dev',
+      url: baseURL,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120 * 1000,
+      env: { VITE_AUTH_MODE: 'clerk' },
+    },
+    {
+      command: 'bun run dev',
+      cwd: resolve(__dirname, '..', 'backend'),
+      url: process.env.BACKEND_URL || 'http://localhost:3000',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120 * 1000,
+      env: {
+        AUTH_MODE: 'clerk',
+        APP_MODE: 'managed',
+        BILLING_MODE: 'managed',
+      },
+    },
+  ],
 
   use: {
     baseURL,
@@ -40,16 +67,11 @@ export default defineConfig({
   
   projects: [
     {
-      name: 'setup',
-      testMatch: /global\.setup\.ts/,
-    },
-    {
       name: 'tests',
       testMatch: /.*\.test\.ts/,
       use: {
         ...devices['Desktop Chrome'],
       },
-      dependencies: ['setup'],
     },
   ],
 })


### PR DESCRIPTION
Follow-up to #167. While verifying that fix I found the e2e suite could not have caught it, and still could not.

## The suite was testing the wrong app

`AUTH_MODE` is unset in `frontend/.env.development` and `backend/.env.development`, and both default to `local`. So the suite rendered `LocalSignUpForm`, and the backend rejected Clerk tokens with a 401. **Every Clerk sign-in and sign-up path was unexercised.** That is how a production-only sign-up break shipped with a green suite behind it.

Playwright now starts both halves in clerk mode, backend included, so the app under test matches production.

## `clerkSetup()` never ran

It was registered as a setup *project*, but a project looks for `test()` calls and never invokes a default export. So `setupClerkTestingToken` had no Frontend API URL and bot protection blocked every headless sign-up. It is the `globalSetup` config option now, matching `growth-canary.config.ts`, which also runs before workers fork so the env it sets reaches them.

## The registration test asserted nothing

```js
url.includes('register') || ... // "still on the sign-up page" counted as success
```

It passed while no account was ever created. I confirmed that against the dev instance: zero users after a green run. It now completes verification with Clerk's test code and asserts the app routes on, and I confirmed a real `email_code` user with a verified email is created.

Three things had to be fixed before that was even reachable:

| Blocker | Symptom |
| --- | --- |
| Address had no `+clerk_test` | Clerk waits on a real email delivery that never arrives |
| Fixed `TestPassword123!` | `form_password_pwned`, the dev instance has HIBP on |
| Email fields behind "Continue with email" | Both auth screens open on the social providers |

Also corrects the sign-in field assertion: the password input is revealed once an email is present, the same progressive disclosure sign-up uses.

## Result

| | Failed | Passed |
| --- | --- | --- |
| master | 20 | 11 |
| this branch | **11** | **20** |

The eleven that remain were already failing on master and are untouched here: `basic`, `debug`, `goals`, `macro-tracking` and `full-flow`. They need an authenticated session with seeded data, which is a separate piece of work.

## Notes for the reviewer

CI does not run e2e, so nothing here affects the quality gate. `typecheck` clean, `lint` 0 errors / 81 warnings (unchanged), 893 unit tests pass.

Running it locally now needs nothing extra: `bun run test:e2e` from `frontend/` starts both servers itself.

One gap this does **not** close: the dev Clerk instance has `legal_consent_enabled: false` while production has it `true`. Until that matches, this suite still cannot catch the #167 regression specifically. It is a dashboard-only setting, absent from the Backend API, so it needs a manual flip at Configure > Legal.
