### PR TITLE
fix(auth): tie the consent checkbox to the buttons it gates

### DIFF
--- a/frontend/src/features/auth/components/ClerkSignUpForm.tsx
+++ b/frontend/src/features/auth/components/ClerkSignUpForm.tsx
@@ -788,6 +788,7 @@ export function ClerkSignUpForm({
               <LegalConsentCheckbox
                 checked={legalAccepted}
                 onChange={setLegalAccepted}
+                showRequiredHint={!legalAccepted}
               />
 
               <Button
@@ -809,10 +810,11 @@ export function ClerkSignUpForm({
             exit={{ opacity: 0, y: -8 }}
             transition={{ duration: 0.22, ease: "easeOut" }}
           >
-            <div className="mb-5">
+            <div className="mb-3">
               <LegalConsentCheckbox
                 checked={legalAccepted}
                 onChange={setLegalAccepted}
+                showRequiredHint={!legalAccepted}
               />
             </div>
 

--- a/frontend/src/features/auth/components/LegalConsentCheckbox.tsx
+++ b/frontend/src/features/auth/components/LegalConsentCheckbox.tsx
@@ -1,32 +1,61 @@
+import { useId } from "react";
+
 import { LegalLink } from "@/features/auth/components/LegalLink";
+import { cn } from "@/lib/classnameUtilities";
 
 interface LegalConsentCheckboxProps {
   checked: boolean;
   onChange: (checked: boolean) => void;
+  /**
+   * Says why the buttons below are inert. A disabled control cannot explain
+   * itself: it swallows the click without firing anything.
+   */
+  showRequiredHint?: boolean;
 }
 
 /**
  * Consent is a required sign-up field on the Clerk instance, so the account
- * cannot be created without it.
+ * cannot be created without it. It sits above the actions it gates.
  */
 export function LegalConsentCheckbox({
   checked,
   onChange,
+  showRequiredHint = false,
 }: LegalConsentCheckboxProps) {
+  const hintId = useId();
+
   return (
-    <label className="flex min-h-11 items-start gap-3 py-2 text-sm text-muted">
-      <input
-        type="checkbox"
-        checked={checked}
-        onChange={(event) => onChange(event.target.checked)}
-        className="mt-0.5 h-4 w-4 rounded border-border accent-primary"
-        name="legalAccepted"
-        required
-      />
-      <span>
-        I agree to the <LegalLink to="/terms">Terms of Service</LegalLink> and{" "}
-        <LegalLink to="/privacy">Privacy Policy</LegalLink>.
-      </span>
-    </label>
+    <div>
+      <label className="flex min-h-11 items-start gap-3 py-2 text-sm text-muted">
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(event) => onChange(event.target.checked)}
+          className="mt-0.5 h-4 w-4 rounded border-border accent-primary"
+          name="legalAccepted"
+          required
+          aria-describedby={showRequiredHint ? hintId : undefined}
+        />
+        <span>
+          I agree to the <LegalLink to="/terms">Terms of Service</LegalLink> and{" "}
+          <LegalLink to="/privacy">Privacy Policy</LegalLink>.
+        </span>
+      </label>
+      {/*
+        Held in place rather than unmounted: dropping it on tick pulls the
+        buttons up under the pointer. `invisible` keeps the row's height and
+        takes it out of the accessibility tree at the same time.
+        pl-7 clears the box and its gap so the hint lines up with the label.
+      */}
+      <p
+        id={hintId}
+        className={cn(
+          "pl-7 text-xs text-muted",
+          !showRequiredHint && "invisible",
+        )}
+      >
+        Accept these to continue.
+      </p>
+    </div>
   );
 }


### PR DESCRIPTION
Follow-up to #167 on how the consent control reads.

## The problem

The checkbox was the first thing in the card, spaced the same as everything else, so it looked like a stray line of text rather than the control holding sign-up shut. The Google button below it was dim with nothing saying why.

## Why it did not move down

A disabled button cannot explain itself. It swallows the click and fires no event, so consent placed *below* it would be a silent dead end: press, nothing happens, no clue. Keeping the buttons disabled means the consent has to precede them.

So this binds it to the buttons rather than moving it.

## Changes

- Consent now hugs the provider buttons instead of floating above them at full card rhythm.
- An "Accept these to continue" line sits under the checkbox and explains the dim buttons. Wired to the input via `aria-describedby`.
- That line holds its space when ticked. Unmounting it pulled the buttons up **28px under the pointer**; measured 0px shift now.
- The email form gets the same line above its disabled submit.

## Verification

`typecheck` clean, `lint` 0 errors / 81 warnings (unchanged), UI budgets pass, 893 unit tests and 10 auth e2e pass against a dev instance now configured like production.

Shift measured directly rather than eyeballed: Google button `y` is 330.55 both ticked and unticked.
