### PR TITLE
feat(auth): consent by notice for providers, by checkbox for email

### DIFF
--- a/frontend/src/features/auth/components/ClerkSignInForm.tsx
+++ b/frontend/src/features/auth/components/ClerkSignInForm.tsx
@@ -9,7 +9,7 @@ import TextField from "@/components/form/TextField";
 import Button from "@/components/ui/Button";
 import { BiometricOptInCheckbox } from "@/features/auth/components/BiometricOptInCheckbox";
 import { BiometricSignInButton } from "@/features/auth/components/BiometricSignInButton";
-import { LegalLink } from "@/features/auth/components/LegalLink";
+import { LegalConsentNotice } from "@/features/auth/components/LegalConsentNotice";
 import { SecondFactorChallenge } from "@/features/auth/components/SecondFactorChallenge";
 import {
   SocialAuthOptions,
@@ -741,12 +741,7 @@ export function ClerkSignInForm({
               loadingStrategy={loadingStrategy}
             />
 
-            <p className="mt-4 text-center text-xs text-muted">
-              A provider creates an account if you do not have one, which means
-              you agree to our{" "}
-              <LegalLink to="/terms">Terms of Service</LegalLink> and{" "}
-              <LegalLink to="/privacy">Privacy Policy</LegalLink>.
-            </p>
+            <LegalConsentNotice lead="A provider creates an account if you do not have one." />
           </motion.div>
         )}
       </AnimatePresence>

--- a/frontend/src/features/auth/components/ClerkSignUpForm.tsx
+++ b/frontend/src/features/auth/components/ClerkSignUpForm.tsx
@@ -10,6 +10,7 @@ import TextField from "@/components/form/TextField";
 import Button from "@/components/ui/Button";
 import { CalorieIcon } from "@/components/ui/Icons";
 import { LegalConsentCheckbox } from "@/features/auth/components/LegalConsentCheckbox";
+import { LegalConsentNotice } from "@/features/auth/components/LegalConsentNotice";
 import {
   SocialAuthOptions,
   type SocialAuthStrategy,
@@ -221,14 +222,8 @@ export function ClerkSignUpForm({
       return;
     }
 
-    if (!legalAccepted) {
-      showNotification(CONSENT_REQUIRED_MESSAGE, "warning");
-
-      return;
-    }
-
-    // The redirect paths cannot carry the consent flag, so record it here and
-    // let /sso-callback apply it to the attempt Clerk hands back.
+    // Pressing the button is the agreement: the terms sit under it. The
+    // redirect paths cannot carry the flag, so record it for /sso-callback.
     rememberLegalConsent();
 
     productAnalytics.capture({
@@ -788,7 +783,6 @@ export function ClerkSignUpForm({
               <LegalConsentCheckbox
                 checked={legalAccepted}
                 onChange={setLegalAccepted}
-                showRequiredHint={!legalAccepted}
               />
 
               <Button
@@ -810,20 +804,13 @@ export function ClerkSignUpForm({
             exit={{ opacity: 0, y: -8 }}
             transition={{ duration: 0.22, ease: "easeOut" }}
           >
-            <div className="mb-3">
-              <LegalConsentCheckbox
-                checked={legalAccepted}
-                onChange={setLegalAccepted}
-                showRequiredHint={!legalAccepted}
-              />
-            </div>
-
             <SocialAuthOptions
               onProviderSelect={handleSocialSignUp}
               onContinueWithEmail={() => setIsEmailMode(true)}
               loadingStrategy={loadingStrategy}
-              providersDisabled={!legalAccepted}
             />
+
+            <LegalConsentNotice />
           </motion.div>
         )}
       </AnimatePresence>

--- a/frontend/src/features/auth/components/LegalConsentCheckbox.tsx
+++ b/frontend/src/features/auth/components/LegalConsentCheckbox.tsx
@@ -1,61 +1,33 @@
-import { useId } from "react";
-
 import { LegalLink } from "@/features/auth/components/LegalLink";
-import { cn } from "@/lib/classnameUtilities";
 
 interface LegalConsentCheckboxProps {
   checked: boolean;
   onChange: (checked: boolean) => void;
-  /**
-   * Says why the buttons below are inert. A disabled control cannot explain
-   * itself: it swallows the click without firing anything.
-   */
-  showRequiredHint?: boolean;
 }
 
 /**
- * Consent is a required sign-up field on the Clerk instance, so the account
- * cannot be created without it. It sits above the actions it gates.
+ * Consent for the email form, where there is a form to submit and a checkbox
+ * is the honest control for it. Provider buttons use LegalConsentNotice: a
+ * tickbox in front of a one-click button is friction for no added clarity.
  */
 export function LegalConsentCheckbox({
   checked,
   onChange,
-  showRequiredHint = false,
 }: LegalConsentCheckboxProps) {
-  const hintId = useId();
-
   return (
-    <div>
-      <label className="flex min-h-11 items-start gap-3 py-2 text-sm text-muted">
-        <input
-          type="checkbox"
-          checked={checked}
-          onChange={(event) => onChange(event.target.checked)}
-          className="mt-0.5 h-4 w-4 rounded border-border accent-primary"
-          name="legalAccepted"
-          required
-          aria-describedby={showRequiredHint ? hintId : undefined}
-        />
-        <span>
-          I agree to the <LegalLink to="/terms">Terms of Service</LegalLink> and{" "}
-          <LegalLink to="/privacy">Privacy Policy</LegalLink>.
-        </span>
-      </label>
-      {/*
-        Held in place rather than unmounted: dropping it on tick pulls the
-        buttons up under the pointer. `invisible` keeps the row's height and
-        takes it out of the accessibility tree at the same time.
-        pl-7 clears the box and its gap so the hint lines up with the label.
-      */}
-      <p
-        id={hintId}
-        className={cn(
-          "pl-7 text-xs text-muted",
-          !showRequiredHint && "invisible",
-        )}
-      >
-        Accept these to continue.
-      </p>
-    </div>
+    <label className="flex min-h-11 items-start gap-3 py-2 text-sm text-muted">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+        className="mt-0.5 h-4 w-4 rounded border-border accent-primary"
+        name="legalAccepted"
+        required
+      />
+      <span>
+        I agree to the <LegalLink to="/terms">Terms of Service</LegalLink> and{" "}
+        <LegalLink to="/privacy">Privacy Policy</LegalLink>.
+      </span>
+    </label>
   );
 }

--- a/frontend/src/features/auth/components/LegalConsentNotice.tsx
+++ b/frontend/src/features/auth/components/LegalConsentNotice.tsx
@@ -1,0 +1,23 @@
+import { LegalLink } from "@/features/auth/components/LegalLink";
+
+interface LegalConsentNoticeProps {
+  /** Context sentence placed before the agreement, where the flow needs one. */
+  lead?: string;
+}
+
+/**
+ * Consent for one-click provider sign-in, where a checkbox would be friction
+ * on a button that is itself the whole interaction. Pressing the button is the
+ * agreement, so the terms have to be visible beside it: sending the flag
+ * without showing them records consent to something never presented.
+ */
+export function LegalConsentNotice({ lead }: LegalConsentNoticeProps) {
+  return (
+    <p className="mt-4 text-center text-xs text-muted">
+      {lead ? `${lead} ` : null}
+      By continuing you agree to our{" "}
+      <LegalLink to="/terms">Terms of Service</LegalLink> and{" "}
+      <LegalLink to="/privacy">Privacy Policy</LegalLink>.
+    </p>
+  );
+}

--- a/frontend/src/features/auth/components/SocialAuthOptions.tsx
+++ b/frontend/src/features/auth/components/SocialAuthOptions.tsx
@@ -9,11 +9,6 @@ interface SocialAuthOptionsProps {
   onProviderSelect: (strategy: SocialAuthStrategy) => void;
   onContinueWithEmail: () => void;
   loadingStrategy?: SocialAuthStrategy | null;
-  /**
-   * Sign-up holds these until legal consent is ticked. The email button stays
-   * live: consent is only needed at submit, and the form asks again there.
-   */
-  providersDisabled?: boolean;
 }
 
 interface SocialAuthProviderConfig {
@@ -51,7 +46,6 @@ export function SocialAuthOptions({
   onProviderSelect,
   onContinueWithEmail,
   loadingStrategy,
-  providersDisabled = false,
 }: SocialAuthOptionsProps) {
   return (
     <>
@@ -73,14 +67,12 @@ export function SocialAuthOptions({
               isLoading={isLoading}
               loadingText={`Connecting to ${label}...`}
               onClick={() => {
-                if (enabled && !loadingStrategy && !providersDisabled) {
+                if (enabled && !loadingStrategy) {
                   onProviderSelect(strategy);
                 }
               }}
               leftIcon={<Icon className="h-5 w-5" />}
-              disabled={
-                !enabled || Boolean(loadingStrategy) || providersDisabled
-              }
+              disabled={!enabled || Boolean(loadingStrategy)}
             >
               {buttonLabel}
             </Button>


### PR DESCRIPTION
Splits how consent is captured by how the action works.

## Providers: notice, no tickbox

A checkbox in front of a one-click button is friction for no added clarity. The button is the whole interaction, so pressing it is the agreement. The terms move underneath as a notice, the buttons go live again, and `legalAccepted` is still sent.

What does not change is that the terms are **visible at the point of consent**. Sending the flag with nothing on screen would record agreement to something never put in front of the user, which is the weak form legally. This is the standard pattern instead.

## Email: checkbox, as before

There is a form to submit, so an explicit control is the honest thing in front of it. The submit stays disabled until it is ticked.

## Also

- Drops the "Accept these to continue" hint. It existed to explain dimmed provider buttons, which no longer dim; in the email form the checkbox sits directly above the button it gates.
- Sign-in shares the new `LegalConsentNotice` instead of its own copy of the markup.
- `SocialAuthOptions` loses `providersDisabled`, which has no callers left.

Net 80 lines removed, 49 added.

## Verification

`typecheck` clean, `lint` 0 errors / 81 warnings (unchanged), UI budgets pass. 893 unit tests and 10 auth e2e pass against a dev instance configured like production.

Checked both rendered states rather than assuming: providers screen with the notice, and the email form with the checkbox above a disabled submit.
