### PR TITLE
fix(ui): judge a UI budget against the base of the change, not a stale count

### DIFF
--- a/.github/design-system.md
+++ b/.github/design-system.md
@@ -163,6 +163,25 @@ it as a queue of work rather than as headroom.
 The numbers may fall freely. Raising one is a design decision and belongs in the
 same commit as the change that needs it, so the trade-off appears in the diff.
 
+A budget is enforced against what the change in front of it actually added.
+`src` is counted twice, once as it stands and once out of the base the change
+started from: the base branch tip for a pull request, because the checkout is
+the merge commit and its counts already include whatever landed while the
+branch was open, and the fork point when you run it by hand. A count over
+budget that the base already holds prints `~~`, says so, and does not fail,
+because this change is not what moved it. That cannot let a regression in:
+absolution requires the base to already hold the count, so the edit is owed by
+whatever put it there, and a count higher than the base still fails. If the
+base cannot be read the check falls back to the budget alone, which is the
+stricter answer, so a shallow clone loses the nuance and not the gate.
+
+This is what `legacyViewportHeight` ran into on arrival. It was pinned at 29,
+the count on a branch that had forked 20 commits earlier. `master` reached 34
+while the branch was open, the branch's own four conversions to `min-h-dvh`
+came off that, and the merge measured 30. The check failed a change that had
+just removed four call sites, against a number describing a tree nobody was
+merging.
+
 **A counter that cannot rise is worse than no counter.** `surfaces` read 2
 against a budget of 4 for its whole life, and printed `ratchet this down` the
 entire time. Its alternation listed `surface` ahead of `surface-2`, and `-` is a

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -39,6 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+      with:
+        # Depth 1 fetches the merge commit and none of its parents, and the UI
+        # budget check needs the base.
+        fetch-depth: 0
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
@@ -55,6 +59,10 @@ jobs:
 
     - name: Lint
       working-directory: ./frontend
+      env:
+        # Base branch tip for a pull request, previous head for a push. Empty
+        # otherwise, and the check falls back to the budget alone.
+        UI_BUDGET_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
       run: bun run lint
 
     # Five releases' worth of drift went unnoticed because this only ever ran

--- a/frontend/scripts/check-ui-budgets.mjs
+++ b/frontend/scripts/check-ui-budgets.mjs
@@ -11,6 +11,7 @@
  * ui-budgets.json in the same change, which makes the decision visible in
  * review rather than invisible in a diff.
  */
+import { spawnSync } from "node:child_process";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 
@@ -34,133 +35,231 @@ const listFiles = (directory) => {
   return files;
 };
 
+// Takes a file list rather than reading the working tree, so the base tree can
+// be counted by this same implementation.
+const measure = (files, sources) => {
+  const all = sources.join("\n");
+
+  /**
+   * Comments stripped, so a budget measures colour the browser paints rather than
+   * prose about colour. Several of these files explain in a doc comment which hex
+   * they used to hold and why it was wrong, which is worth keeping and is not
+   * drift. Block comments go first, then whole-line `//` comments — a trailing
+   * comment after code is left alone rather than risk eating a `https://` URL.
+   */
+  const code = sources
+    .map((source) =>
+      source
+        .replaceAll(/\/\*[\s\S]*?\*\//g, "")
+        .replaceAll(/^\s*\/\/.*$/gm, ""),
+    )
+    .join("\n");
+
+  const countMatches = (pattern) => (all.match(pattern) ?? []).length;
+  const countCode = (pattern) => (code.match(pattern) ?? []).length;
+  const countDistinct = (pattern) => new Set(all.match(pattern) ?? []).size;
+  const countFiles = (needle) =>
+    sources.filter((source) => source.includes(needle)).length;
+
+  return {
+    // Three radii: controls, cards, pills. Nothing else.
+    radii: countDistinct(/\brounded-(?:control|card|full)\b/g),
+    // Only class strings: `rounded="card"` is the Skeleton prop, not a utility.
+    legacyRadii: countMatches(/\brounded-(?:sm|md|lg|xl|2xl|3xl)\b/g),
+    // Four opaque surface steps, no alpha.
+    //
+    // Longest alternative first, and the reason is not style. `-` is a word
+    // boundary, so with `surface` listed ahead of `surface-2` the engine matches
+    // `bg-surface-2` as `bg-surface` and stops. Three of the four steps collapsed
+    // into one, the distinct count could not exceed 2 against a budget of 4, and
+    // the line printed `ratchet this down` for a counter measuring nothing — a
+    // `bg-surface-4` would have entered the codebase silently. Any alternation
+    // here whose branches share a prefix has to run longest-first.
+    surfaces: countDistinct(
+      /\bbg-(?:background|surface-2|surface-3|surface)\b/g,
+    ),
+    surfaceAlpha: countMatches(/\bbg-(?:surface|surface-2|surface-3)\/\d+\b/g),
+    // Two hairlines.
+    hairlineAlpha: countMatches(/\bborder-(?:border|border-2|white)\/\d+\b/g),
+    // Motion. The first version of this budget counted files importing
+    // motion/react and asked for 20. That measured the wrong thing: it is
+    // satisfied by deleting motion that was doing its job, and violated by a
+    // system with perfect motion spread across many components. Every other
+    // budget here counts *distinct values*, because inventing a value at a call
+    // site is the drift. Motion gets measured the same way.
+    //
+    // Seconds-scale only — `duration: 8000` is a toast timer, not an animation.
+    motionDurations: countDistinct(/\bduration: (?:[0-4](?:\.\d+)?)\b/g),
+    motionEasings: countDistinct(/\bease: (?:"[a-zA-Z]+"|\[[\d.,\s]+\])/g),
+    // A call site declaring its own initial/animate is how 23 durations happened.
+    // Intent belongs in <Reveal>; numbers belong in DURATIONS/EASINGS.
+    motionCallSites: countFiles("initial={{"),
+    // `layout`/`layoutId` re-measure on every render and reflow the content being
+    // read. Never inside a virtualized list, which measures rows itself.
+    layoutProjection: countMatches(/\blayoutId=|^\s+layout$/gm),
+    // Loose backstop only. Not the headline.
+    motionFiles: countFiles("motion/react"),
+    // One breakpoint was doing all the work; this should keep falling as density
+    // moves into the primitives.
+    smOverrides: countMatches(/\bsm:/g),
+    // Blur costs a compositing layer per element and samples an opaque page
+    // everywhere except a genuine overlay.
+    backdropBlur: countMatches(/\bbackdrop-blur-/g),
+    // Shadows cannot render on #000; only the modal keeps one. The arbitrary form
+    // is counted too: 95 hex literals of Clerk theming hid a drop shadow behind
+    // `shadow-[0_25px_50px_...]`, which the keyword-only pattern missed.
+    shadows: countMatches(/\bshadow-(?:sm|md|lg|xl|2xl)\b|\bshadow-\[/g),
+    // A colour written as a literal cannot follow a token change. Two files
+    // transcribed the whole palette by hand and both were still on the
+    // pre-Phase-9 values: the snapshot PNG drew rose fats against the app's
+    // yellow, and Clerk themed the auth screens in the old green over cool greys.
+    // What remains is the floor: the 15-value fallback in designTokens.ts, which
+    // a test holds equal to style.css, and Google's six brand colours, which are
+    // theirs and not ours to tokenise. Comments are stripped before counting, so
+    // a doc comment naming the hex a file used to hold does not count against it.
+    hexLiterals: countCode(/#[\dA-Fa-f]{6}\b/g),
+    // Emoji are not part of the UI vocabulary. Badges shipped with 🔥, 🎯 and ⚡.
+    emoji: countMatches(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/gu),
+    // One spelling for a figure. A daily target shipped as both "2000 kcal" and
+    // "2,000 kcal", and the split ran through the primitive meant to prevent it:
+    // `Value` grouped via toLocaleString, the `AnimatedNumber` it delegates to
+    // did not, so adding `animate` changed the spelling. Every separator comes
+    // from `formatGrouped` now; a call site formatting for itself is the drift.
+    // The no-argument form only: `date.toLocaleString("en-US", {...})` in the
+    // reporting queries formats a month label, which is not a figure and not
+    // this counter's business. formatNumber.ts is excluded as the implementation.
+    adHocNumberFormat: files.reduce(
+      (total, file, index) =>
+        /lib[/\\]formatNumber\.ts$/.test(file)
+          ? total
+          : total +
+            (sources[index].match(/\.toLocaleString\(\)/g) ?? []).length,
+      0,
+    ),
+    // The other half of the same rule. `adHocNumberFormat` catches a call site
+    // reaching for `toLocaleString`; this catches one that formats by not
+    // formatting — `{tdee} kcal`, which prints "2841 kcal" beside a "2,841 kcal"
+    // two components away. Both JSX and template-literal forms, because the
+    // sweep found the split in both. Anything printing a figure next to a
+    // calorie unit goes through `formatGrouped`.
+    //
+    // Counted by matching then filtering rather than by subtracting two patterns:
+    // `{" "}` is JSX's explicit space, so `{formatGrouped(tdee)}{" "}\nkcal` puts
+    // a bare `{" "}` directly before the unit and a subtracting pattern scores it
+    // as raw. The expression itself has to be inspected.
+    rawCalorieFigures: (() => {
+      const figureBeforeUnit =
+        /\{[^{}\n]{1,70}\}\s*(?:\{" "\})?\s*(?:kcal|calories|cal\/)|\$\{[^}\n]{1,70}\}\s*(?:kcal|calories)/g;
+
+      return (code.match(figureBeforeUnit) ?? []).filter(
+        (match) =>
+          !match.includes("formatGrouped") && !/^\{"\s*"\}/.test(match),
+      ).length;
+    })(),
+    // TYPE_SCALE stops at font-semibold except for its two display steps, so
+    // font-bold outside Heading/Value is a call site inventing a weight. Heading
+    // and Value are excluded because they define the scale.
+    boldOutsideScale: files.reduce(
+      (total, file, index) =>
+        /components[/\\]ui[/\\](?:Heading|Value)\.tsx$/.test(file)
+          ? total
+          : total + (sources[index].match(/\bfont-bold\b/g) ?? []).length,
+      0,
+    ),
+  };
+};
+
 const files = listFiles(SOURCE);
-const sources = files.map((file) => readFileSync(file, "utf8"));
-const all = sources.join("\n");
+const measurements = measure(
+  files,
+  files.map((file) => readFileSync(file, "utf8")),
+);
 
-/**
- * Comments stripped, so a budget measures colour the browser paints rather than
- * prose about colour. Several of these files explain in a doc comment which hex
- * they used to hold and why it was wrong, which is worth keeping and is not
- * drift. Block comments go first, then whole-line `//` comments — a trailing
- * comment after code is left alone rather than risk eating a `https://` URL.
- */
-const code = sources
-  .map((source) =>
-    source.replaceAll(/\/\*[\s\S]*?\*\//g, "").replaceAll(/^\s*\/\/.*$/gm, ""),
-  )
-  .join("\n");
+const git = (arguments_) => {
+  const result = spawnSync("git", arguments_, {
+    cwd: ROOT,
+    maxBuffer: 256 * 1024 * 1024,
+  });
 
-const countMatches = (pattern) => (all.match(pattern) ?? []).length;
-const countCode = (pattern) => (code.match(pattern) ?? []).length;
-const countDistinct = (pattern) => new Set(all.match(pattern) ?? []).size;
-const countFiles = (needle) =>
-  sources.filter((source) => source.includes(needle)).length;
+  return result.status === 0 ? result.stdout.toString("utf8") : null;
+};
 
-const measurements = {
-  // Three radii: controls, cards, pills. Nothing else.
-  radii: countDistinct(/\brounded-(?:control|card|full)\b/g),
-  // Only class strings: `rounded="card"` is the Skeleton prop, not a utility.
-  legacyRadii: countMatches(/\brounded-(?:sm|md|lg|xl|2xl|3xl)\b/g),
-  // Four opaque surface steps, no alpha.
-  //
-  // Longest alternative first, and the reason is not style. `-` is a word
-  // boundary, so with `surface` listed ahead of `surface-2` the engine matches
-  // `bg-surface-2` as `bg-surface` and stops. Three of the four steps collapsed
-  // into one, the distinct count could not exceed 2 against a budget of 4, and
-  // the line printed `ratchet this down` for a counter measuring nothing — a
-  // `bg-surface-4` would have entered the codebase silently. Any alternation
-  // here whose branches share a prefix has to run longest-first.
-  surfaces: countDistinct(/\bbg-(?:background|surface-2|surface-3|surface)\b/g),
-  surfaceAlpha: countMatches(/\bbg-(?:surface|surface-2|surface-3)\/\d+\b/g),
-  // Two hairlines.
-  hairlineAlpha: countMatches(/\bborder-(?:border|border-2|white)\/\d+\b/g),
-  // Motion. The first version of this budget counted files importing
-  // motion/react and asked for 20. That measured the wrong thing: it is
-  // satisfied by deleting motion that was doing its job, and violated by a
-  // system with perfect motion spread across many components. Every other
-  // budget here counts *distinct values*, because inventing a value at a call
-  // site is the drift. Motion gets measured the same way.
-  //
-  // Seconds-scale only — `duration: 8000` is a toast timer, not an animation.
-  motionDurations: countDistinct(/\bduration: (?:[0-4](?:\.\d+)?)\b/g),
-  motionEasings: countDistinct(/\bease: (?:"[a-zA-Z]+"|\[[\d.,\s]+\])/g),
-  // A call site declaring its own initial/animate is how 23 durations happened.
-  // Intent belongs in <Reveal>; numbers belong in DURATIONS/EASINGS.
-  motionCallSites: countFiles("initial={{"),
-  // `layout`/`layoutId` re-measure on every render and reflow the content being
-  // read. Never inside a virtualized list, which measures rows itself.
-  layoutProjection: countMatches(/\blayoutId=|^\s+layout$/gm),
-  // Loose backstop only. Not the headline.
-  motionFiles: countFiles("motion/react"),
-  // One breakpoint was doing all the work; this should keep falling as density
-  // moves into the primitives.
-  smOverrides: countMatches(/\bsm:/g),
-  // Blur costs a compositing layer per element and samples an opaque page
-  // everywhere except a genuine overlay.
-  backdropBlur: countMatches(/\bbackdrop-blur-/g),
-  // Shadows cannot render on #000; only the modal keeps one. The arbitrary form
-  // is counted too: 95 hex literals of Clerk theming hid a drop shadow behind
-  // `shadow-[0_25px_50px_...]`, which the keyword-only pattern missed.
-  shadows: countMatches(/\bshadow-(?:sm|md|lg|xl|2xl)\b|\bshadow-\[/g),
-  // A colour written as a literal cannot follow a token change. Two files
-  // transcribed the whole palette by hand and both were still on the
-  // pre-Phase-9 values: the snapshot PNG drew rose fats against the app's
-  // yellow, and Clerk themed the auth screens in the old green over cool greys.
-  // What remains is the floor: the 15-value fallback in designTokens.ts, which
-  // a test holds equal to style.css, and Google's six brand colours, which are
-  // theirs and not ours to tokenise. Comments are stripped before counting, so
-  // a doc comment naming the hex a file used to hold does not count against it.
-  hexLiterals: countCode(/#[\dA-Fa-f]{6}\b/g),
-  // Emoji are not part of the UI vocabulary. Badges shipped with 🔥, 🎯 and ⚡.
-  emoji: countMatches(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/gu),
-  // One spelling for a figure. A daily target shipped as both "2000 kcal" and
-  // "2,000 kcal", and the split ran through the primitive meant to prevent it:
-  // `Value` grouped via toLocaleString, the `AnimatedNumber` it delegates to
-  // did not, so adding `animate` changed the spelling. Every separator comes
-  // from `formatGrouped` now; a call site formatting for itself is the drift.
-  // The no-argument form only: `date.toLocaleString("en-US", {...})` in the
-  // reporting queries formats a month label, which is not a figure and not
-  // this counter's business. formatNumber.ts is excluded as the implementation.
-  adHocNumberFormat: files.reduce(
-    (total, file, index) =>
-      /lib[/\\]formatNumber\.ts$/.test(file)
-        ? total
-        : total + (sources[index].match(/\.toLocaleString\(\)/g) ?? []).length,
-    0,
-  ),
-  // The other half of the same rule. `adHocNumberFormat` catches a call site
-  // reaching for `toLocaleString`; this catches one that formats by not
-  // formatting — `{tdee} kcal`, which prints "2841 kcal" beside a "2,841 kcal"
-  // two components away. Both JSX and template-literal forms, because the
-  // sweep found the split in both. Anything printing a figure next to a
-  // calorie unit goes through `formatGrouped`.
-  //
-  // Counted by matching then filtering rather than by subtracting two patterns:
-  // `{" "}` is JSX's explicit space, so `{formatGrouped(tdee)}{" "}\nkcal` puts
-  // a bare `{" "}` directly before the unit and a subtracting pattern scores it
-  // as raw. The expression itself has to be inspected.
-  rawCalorieFigures: (() => {
-    const figureBeforeUnit =
-      /\{[^{}\n]{1,70}\}\s*(?:\{" "\})?\s*(?:kcal|calories|cal\/)|\$\{[^}\n]{1,70}\}\s*(?:kcal|calories)/g;
+// The workflow passes the base branch tip; locally the fork point stands in.
+const resolveBase = () => {
+  const explicit = process.env.UI_BUDGET_BASE_SHA?.trim();
+  const candidate = explicit || git(["merge-base", "HEAD", "origin/master"]);
+  const base = git(["rev-parse", "--verify", `${candidate?.trim()}^{commit}`]);
+  if (base === null) return null;
 
-    return (code.match(figureBeforeUnit) ?? []).filter(
-      (match) => !match.includes("formatGrouped") && !/^\{"\s*"\}/.test(match),
-    ).length;
-  })(),
-  // TYPE_SCALE stops at font-semibold except for its two display steps, so
-  // font-bold outside Heading/Value is a call site inventing a weight. Heading
-  // and Value are excluded because they define the scale.
-  boldOutsideScale: files.reduce(
-    (total, file, index) =>
-      /components[/\\]ui[/\\](?:Heading|Value)\.tsx$/.test(file)
-        ? total
-        : total + (sources[index].match(/\bfont-bold\b/g) ?? []).length,
-    0,
-  ),
+  // On master the fork point is HEAD, and a tree compared against itself
+  // forgives everything. Falling back to the budget alone is stricter.
+  const head = git(["rev-parse", "HEAD"]);
+
+  return base.trim() === head?.trim() ? null : base.trim();
+};
+
+// Reads src out of a git tree without checking it out. --batch so this is two
+// processes and not one per file: `<oid> <type> <size>`, then that many bytes.
+const measureTree = (revision) => {
+  const toplevel = git(["rev-parse", "--show-toplevel"]);
+  if (toplevel === null) return null;
+
+  const sourceInRepo = path.relative(toplevel.trim(), SOURCE);
+  // --full-tree: pathspec and results relative to the repo root, not to this
+  // script's directory, which is what `<revision>:<path>` wants below.
+  const listing = git([
+    "ls-tree",
+    "-r",
+    "-z",
+    "--full-tree",
+    "--name-only",
+    revision,
+    "--",
+    sourceInRepo,
+  ]);
+  if (listing === null) return null;
+
+  const paths = listing
+    .split("\0")
+    .filter((entry) => /\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry));
+  if (paths.length === 0) return null;
+
+  const batch = spawnSync("git", ["cat-file", "--batch"], {
+    cwd: ROOT,
+    input: paths.map((entry) => `${revision}:${entry}`).join("\n") + "\n",
+    maxBuffer: 256 * 1024 * 1024,
+  });
+  if (batch.status !== 0) return null;
+
+  const out = batch.stdout;
+  const sources = [];
+  let offset = 0;
+  for (let index = 0; index < paths.length; index++) {
+    const newline = out.indexOf(0x0a, offset);
+    if (newline === -1) return null;
+    const size = Number(out.toString("utf8", offset, newline).split(" ")[2]);
+    if (!Number.isFinite(size)) return null;
+    sources.push(out.toString("utf8", newline + 1, newline + 1 + size));
+    offset = newline + 1 + size + 1;
+  }
+
+  // Repo-relative paths, absolute in the working-tree call. Only
+  // boldOutsideScale reads a path, and it matches on a suffix.
+  return measure(paths, sources);
+};
+
+let baseMeasurements;
+const baseCountFor = (key) => {
+  if (baseMeasurements === undefined) {
+    const base = resolveBase();
+    baseMeasurements = base === null ? null : measureTree(base);
+  }
+
+  return baseMeasurements?.[key];
 };
 
 let failed = false;
+let inherited = false;
 const rows = [];
 
 for (const [key, budget] of Object.entries(BUDGETS.budgets)) {
@@ -170,22 +269,50 @@ for (const [key, budget] of Object.entries(BUDGETS.budgets)) {
     continue;
   }
 
-  const ok = actual <= budget;
-  if (!ok) failed = true;
+  if (actual <= budget) {
+    rows.push(
+      `  ok ${key}: ${actual} (budget ${budget})${
+        actual < budget ? " — ratchet this down" : ""
+      }`,
+    );
+    continue;
+  }
+
+  // Over budget: only fail if this change is what raised it. Absolving a count
+  // the base already holds cannot let a rise through, since a rise exceeds it.
+  const baseCount = baseCountFor(key);
+
+  if (baseCount !== undefined && actual <= baseCount) {
+    inherited = true;
+    rows.push(
+      `  ~~ ${key}: ${actual} (budget ${budget}, already ${baseCount} on the base)`,
+    );
+    continue;
+  }
+
+  failed = true;
   rows.push(
-    `  ${ok ? "ok" : "!!"} ${key}: ${actual} (budget ${budget})${
-      actual < budget ? " — ratchet this down" : ""
-    }`,
+    `  !! ${key}: ${actual} (budget ${budget}${
+      baseCount === undefined ? "" : `, ${baseCount} on the base`
+    })`,
   );
 }
 
 console.log("UI budgets");
 console.log(rows.join("\n"));
 
+if (inherited) {
+  console.log(
+    "\n~~ is over budget but no higher than the base, so this change did not " +
+      "move it. Refresh the number in ui-budgets.json when you next touch it.",
+  );
+}
+
 if (failed) {
   console.error(
-    "\nA budget went up. Either put it back, or raise the number in " +
-      "ui-budgets.json in this same change so the trade-off is reviewable.",
+    "\nA budget went up, and this change is what raised it. Either put it back, " +
+      "or raise the number in ui-budgets.json in this same change so the " +
+      "trade-off is reviewable.",
   );
   process.exit(1);
 }


### PR DESCRIPTION
## The problem

A UI budget is an absolute number, measured on whatever tree was checked out when someone wrote it down. CI enforces it against a different tree: GitHub runs `pull_request` checks on the **merge commit**, so the count it compares is the branch plus everything that landed on `master` while the branch was open.

Those two trees drift apart the moment a branch falls behind, and the branch gets failed for call sites it has never seen.

`legacyViewportHeight` hit this on the day it was added, in #171:

| tree | `min-h-screen` |
| --- | --- |
| branch, on its own | 29 (budget written here) |
| `master` | 34 |
| the merge CI actually measured | 30 |

The branch converted four shells to `min-h-dvh`. On the tree being merged it took the count from 34 to 30, a net **-4**, and the check failed it, because the number it had recorded described its own pre-merge tree. The only repair available was to raise the budget for somebody else's landing page.

## The rule now

`src` is counted twice by one implementation, and a breach asks who put it there.

- **over budget, no higher than the base** → prints `~~`, says so, passes. This change did not move it.
- **higher than the base** → fails, exactly as before.
- **under budget** → unchanged, and no git call is made at all.

```
  ~~ legacyViewportHeight: 30 (budget 29, already 34 on the base)

~~ is over budget but no higher than the base, so this change did not move it.
Refresh the number in ui-budgets.json when you next touch it.
```

The base is the base branch tip for a pull request (the merge commit's counts already include what landed while the branch was open) and the fork point when you run it by hand. Both ask the same question of the same diff.

## Why this cannot let a regression in

Absolution requires the base to **already hold** the count. So it never forgives something the change added, only something the change inherited, and the number owed belongs to whatever put it there. By induction a rise can only enter `master` through a change that was blamed for it.

Two holes worth naming, both closed:

- A base that resolves to `HEAD` compares a tree against itself and would forgive everything. Treated as no base at all.
- If the base cannot be read (shallow clone, no git), the check falls back to the budget alone, which is the **stricter** answer. A shallow clone loses the nuance, not the gate.

## Reviewing this

`check-ui-budgets.mjs` reads as +274/-127, but the substance is +159/-12. The rest is a function wrapper around the existing counting block and the indentation it forced, plus a few lines prettier re-wrapped at 80 columns.

**Read it with `git diff -w`.**

Counting had to stop being a function of the working tree so the base tree could be measured without checking it out: `git ls-tree` plus a single `git cat-file --batch`, so two processes rather than one per file, and neither runs unless a budget is already breached.

## Verification

| case | expected | result |
| --- | --- | --- |
| happy path | output identical to the old script | byte-identical |
| count the base already holds | `~~`, exit 0 | pass |
| count above the base | `!!`, exit 1 | pass |
| rise on top of a base itself over budget | `!!`, exit 1 | pass |
| base unreadable | `!!`, exit 1 | pass |
| base equal to `HEAD` | `!!`, exit 1 | pass |
| #171's failure replayed on the real merge tree | `~~`, exit 0 | pass |

The last one is the point of the change: the merge tree that failed CI now reports `legacyViewportHeight: 30 (budget 29, already 34 on the base)` and passes.

`.github/design-system.md` gets the rule, since that is where the budget contract is written down.
